### PR TITLE
Improve error message when argument order matches but type annotation is incorrect

### DIFF
--- a/src/rules/plugin-activation-args.ts
+++ b/src/rules/plugin-activation-args.ts
@@ -155,7 +155,7 @@ const jupyterPluginActivationArgs = createRule({
       wrongArgumentCount:
         'Expected {{ expected }} activation arguments (app + {{ tokenCount }} tokens), got {{ actual }}.',
       unresolvableTokenType:
-        'Token "{{ token }}" type could not be resolved — package may be unbuilt. Build it for accurate type checking.'
+        'Token "{{ token }}" type could not be resolved. The package may be unbuilt or type checking may not be configured.'
     },
     fixable: 'code',
     schema: [
@@ -276,7 +276,13 @@ const jupyterPluginActivationArgs = createRule({
     ): [boolean, boolean] {
       // For most cases this check is sufficient
       if (paramType === token.name) return [true, false];
-      if (checker && paramNode) {
+      // Without a checker we cannot resolve namespace patterns like
+      // `IDebugger.ISidebar` ↔ `IDebuggerSidebar`, so we cannot distinguish
+      // a genuine mismatch from a valid aliasing convention.
+      // Users wanting full type-aware checks should configure
+      // `parserOptions.project`.
+      if (!checker) return [false, true];
+      if (paramNode) {
         const resolvedToken = resolveTokenInnerType(token.node);
         const tokenUnresolved =
           resolvedToken === null ||
@@ -290,13 +296,6 @@ const jupyterPluginActivationArgs = createRule({
           return [isSameType(resolvedToken, resolvedParam), false];
         }
       }
-      // Without a checker we cannot resolve namespace patterns like
-      // `IDebugger.ISidebar` ↔ `IDebuggerSidebar`, so we cannot distinguish
-      // a genuine mismatch from a valid aliasing convention. Treat as a match
-      // to avoid false positives; the exact-name check above already handles
-      // the common case. Users wanting full type-aware checks should configure
-      // `parserOptions.project`.
-      if (!checker) return [true, false];
       return [false, false];
     }
 

--- a/src/rules/plugin-activation-args.ts
+++ b/src/rules/plugin-activation-args.ts
@@ -291,7 +291,7 @@ const jupyterPluginActivationArgs = createRule({
       }
       // Without a checker we cannot resolve namespace patterns like
       // `IDebugger.ISidebar` ↔ `IDebuggerSidebar`.
-      if (!checker && paramType && paramType.includes('.')) return [true, false];
+      if (!checker) return [true, false];
       return [false, false];
     }
 
@@ -382,7 +382,7 @@ const jupyterPluginActivationArgs = createRule({
             });
           }
 
-          // Validation 3: If parameters have type annotations, validate order
+          // Validation 3: Validate remaining parameters against expected token order
           const actualParamTypes = paramTypes.slice(1); // First arg already validated above
           const actualParamNodes = paramNodes.slice(1);
 
@@ -394,13 +394,11 @@ const jupyterPluginActivationArgs = createRule({
 
             if (expectedToken === undefined) {
               // Extra argument
-              if (paramType) {
-                context.report({
-                  node: activateInfo.node,
-                  messageId: 'extraArgument',
-                  data: { arg: params[i + 1] }
-                });
-              }
+              context.report({
+                node: activateInfo.node,
+                messageId: 'extraArgument',
+                data: { arg: params[i + 1] }
+              });
             } else {
               const [matches, tokenUnresolved] = tokenMatchesParam(
                 expectedToken,
@@ -418,12 +416,12 @@ const jupyterPluginActivationArgs = createRule({
                 const matchesAnyOtherToken = expectedTokensWithoutApp.some(
                   (otherToken, j) => {
                     if (j === i) return false;
-                    const [otherMatches] = tokenMatchesParam(
+                    const [otherMatches, tokenUnresolved] = tokenMatchesParam(
                       otherToken,
                       paramType,
                       paramNode
                     );
-                    return otherMatches;
+                    return otherMatches && !tokenUnresolved;
                   }
                 );
                 if (matchesAnyOtherToken) {

--- a/src/rules/plugin-activation-args.ts
+++ b/src/rules/plugin-activation-args.ts
@@ -290,7 +290,11 @@ const jupyterPluginActivationArgs = createRule({
         }
       }
       // Without a checker we cannot resolve namespace patterns like
-      // `IDebugger.ISidebar` ↔ `IDebuggerSidebar`.
+      // `IDebugger.ISidebar` ↔ `IDebuggerSidebar`, so we cannot distinguish
+      // a genuine mismatch from a valid aliasing convention. Treat as a match
+      // to avoid false positives; the exact-name check above already handles
+      // the common case. Users wanting full type-aware checks should configure
+      // `parserOptions.project`.
       if (!checker) return [true, false];
       return [false, false];
     }

--- a/src/rules/plugin-activation-args.ts
+++ b/src/rules/plugin-activation-args.ts
@@ -16,7 +16,7 @@ import { createRule } from '../utils/create-rule';
 
 interface ActivateFunctionInfo {
   node: TSESTree.Node;
-  params: string[];
+  paramNames: string[];
   paramTypes: (string | null)[];
   paramNodes: (TSESTree.Identifier | null)[];
 }
@@ -56,19 +56,20 @@ function findActivateFunction(
       .filter(
         (param): param is TSESTree.Identifier => param.type === 'Identifier'
       )
-      .map(param => param.name);
 
-    const paramTypes = activateValue.params.map(param =>
+    const paramNames = params.map(param => param.name);
+
+    const paramTypes = params.map(param =>
       param.type === 'Identifier' ? extractParameterType(param) : null
     );
 
-    const paramNodes = activateValue.params.map(param =>
+    const paramNodes = params.map(param =>
       param.type === 'Identifier' ? param : null
     );
 
     return {
       node: activateProp,
-      params,
+      paramNames,
       paramTypes,
       paramNodes
     };
@@ -140,7 +141,7 @@ const jupyterPluginActivationArgs = createRule({
       mismatchedOrder:
         'Activation argument "{{ arg }}" does not match the order of requires/optional tokens.',
       incorrectType:
-        'Activation argument "{{ arg }}" has incorrect type annotation "{{ type }}". Expected type compatible with "{{ expected }}".',
+        'Activation argument "{{ arg }}" has incorrect type annotation "{{ type }}". Expected type "{{ expected }}".',
       missingArgument:
         'Token "{{ token }}" from requires/optional is missing in activation arguments.',
       extraArgument:
@@ -315,12 +316,12 @@ const jupyterPluginActivationArgs = createRule({
           if (!activateInfo) {
             return;
           }
-          const { params, paramTypes, paramNodes } = activateInfo;
+          const { paramNames, paramTypes, paramNodes } = activateInfo;
 
           const expectedCount = 1 + requires.length + optional.length;
           const expectedTokensWithoutApp = [...requires, ...optional];
 
-          if (expectedCount === 1 && params.length === 0) {
+          if (expectedCount === 1 && paramNames.length === 0) {
             // Special case, not invalid
             return;
           }
@@ -328,14 +329,14 @@ const jupyterPluginActivationArgs = createRule({
           if (pluginKind === 'frontend') {
             // Validation 1a: Check if first argument is one of the allowed names
             if (
-              params.length > 0 &&
-              !allowedFirstArgumentNames.includes(params[0])
+              paramNames.length > 0 &&
+              !allowedFirstArgumentNames.includes(paramNames[0])
             ) {
               context.report({
                 node: activateInfo.node,
                 messageId: 'appNotFirst',
                 data: {
-                  arg: params[0],
+                  arg: paramNames[0],
                   allowedNames: allowedFirstArgumentNames
                     .map(name => `"${name}"`)
                     .join(', ')
@@ -345,14 +346,14 @@ const jupyterPluginActivationArgs = createRule({
             }
 
             // Validation 1b: Check if first argument type is compatible with JupyterFrontEnd
-            if (params.length > 0 && paramTypes.length > 0) {
+            if (paramNames.length > 0 && paramTypes.length > 0) {
               const firstParamType = paramTypes[0];
               if (!isCompatibleWithJupyterFrontEnd(firstParamType)) {
                 context.report({
                   node: activateInfo.node,
                   messageId: 'invalidAppType',
                   data: {
-                    arg: params[0],
+                    arg: paramNames[0],
                     type: firstParamType || 'unknown'
                   }
                 });
@@ -361,7 +362,7 @@ const jupyterPluginActivationArgs = createRule({
             }
           } else if (pluginKind === 'service-manager') {
             // Validation 1: First argument must be literal null
-            if (params.length === 0 || paramTypes[0] !== null) {
+            if (paramNames.length === 0 || paramTypes[0] !== null) {
               context.report({
                 node: activateInfo.node,
                 messageId: 'serviceManagerFirstArgNotNull',
@@ -374,14 +375,14 @@ const jupyterPluginActivationArgs = createRule({
           }
 
           // Validation 2: Check if argument count matches
-          if (params.length !== expectedCount) {
+          if (paramNames.length !== expectedCount) {
             context.report({
               node: activateInfo.node,
               messageId: 'wrongArgumentCount',
               data: {
                 expected: String(expectedCount),
                 tokenCount: String(requires.length + optional.length),
-                actual: String(params.length)
+                actual: String(paramNames.length)
               }
             });
           }
@@ -401,7 +402,7 @@ const jupyterPluginActivationArgs = createRule({
               context.report({
                 node: activateInfo.node,
                 messageId: 'extraArgument',
-                data: { arg: params[i + 1] }
+                data: { arg: paramNames[i + 1] }
               });
             } else {
               const [matches, tokenUnresolved] = tokenMatchesParam(
@@ -432,14 +433,14 @@ const jupyterPluginActivationArgs = createRule({
                   context.report({
                     node: activateInfo.node,
                     messageId: 'mismatchedOrder',
-                    data: { arg: params[i + 1] }
+                    data: { arg: paramNames[i + 1] }
                   });
                 } else {
                   context.report({
                     node: activateInfo.node,
                     messageId: 'incorrectType',
                     data: {
-                      arg: params[i + 1],
+                      arg: paramNames[i + 1],
                       type: paramType,
                       expected: expectedToken.name
                     }
@@ -450,9 +451,9 @@ const jupyterPluginActivationArgs = createRule({
           }
 
           // Validation 4: Check for missing arguments (only if counts don't match)
-          if (params.length < expectedCount) {
+          if (paramNames.length < expectedCount) {
             for (
-              let i = Math.max(params.length - 1, 0);
+              let i = Math.max(paramNames.length - 1, 0);
               i < expectedTokensWithoutApp.length;
               i++
             ) {

--- a/src/rules/plugin-activation-args.ts
+++ b/src/rules/plugin-activation-args.ts
@@ -139,6 +139,8 @@ const jupyterPluginActivationArgs = createRule({
     messages: {
       mismatchedOrder:
         'Activation argument "{{ arg }}" does not match the order of requires/optional tokens.',
+      incorrectType:
+        'Activation argument "{{ arg }}" has incorrect type annotation "{{ type }}". Expected type compatible with "{{ expected }}".',
       missingArgument:
         'Token "{{ token }}" from requires/optional is missing in activation arguments.',
       extraArgument:
@@ -383,58 +385,65 @@ const jupyterPluginActivationArgs = createRule({
           // Validation 3: If parameters have type annotations, validate order
           const actualParamTypes = paramTypes.slice(1); // First arg already validated above
           const actualParamNodes = paramNodes.slice(1);
-          const hasTypeInfo = actualParamTypes.some(t => t !== null);
 
-          if (hasTypeInfo) {
-            // Validate that parameter types match expected token types in order
-            for (let i = 0; i < actualParamTypes.length; i++) {
-              const paramType = actualParamTypes[i];
-              const paramNode = actualParamNodes[i];
-              const expectedToken = expectedTokensWithoutApp[i];
+          // Validate that parameter types match expected token types in order
+          for (let i = 0; i < actualParamTypes.length; i++) {
+            const paramType = actualParamTypes[i];
+            const paramNode = actualParamNodes[i];
+            const expectedToken = expectedTokensWithoutApp[i];
 
-              if (expectedToken === undefined) {
-                // Extra argument
-                if (paramType) {
-                  context.report({
-                    node: activateInfo.node,
-                    messageId: 'extraArgument',
-                    data: { arg: params[i + 1] }
-                  });
-                }
-              } else {
-                const [matches, tokenUnresolved] = tokenMatchesParam(
-                  expectedToken,
-                  paramType,
-                  paramNode
+            if (expectedToken === undefined) {
+              // Extra argument
+              if (paramType) {
+                context.report({
+                  node: activateInfo.node,
+                  messageId: 'extraArgument',
+                  data: { arg: params[i + 1] }
+                });
+              }
+            } else {
+              const [matches, tokenUnresolved] = tokenMatchesParam(
+                expectedToken,
+                paramType,
+                paramNode
+              );
+              if (tokenUnresolved) {
+                context.report({
+                  node: activateInfo.node,
+                  messageId: 'unresolvableTokenType',
+                  data: { token: expectedToken.name }
+                });
+              } else if (!matches) {
+                // Distinguish token-order conflict vs. invalid type annotation.
+                const matchesAnyOtherToken = expectedTokensWithoutApp.some(
+                  (otherToken, j) => {
+                    if (j === i) return false;
+                    const [otherMatches] = tokenMatchesParam(
+                      otherToken,
+                      paramType,
+                      paramNode
+                    );
+                    return otherMatches;
+                  }
                 );
-                if (tokenUnresolved) {
-                  context.report({
-                    node: activateInfo.node,
-                    messageId: 'unresolvableTokenType',
-                    data: { token: expectedToken.name }
-                  });
-                } else if (!matches) {
+                if (matchesAnyOtherToken) {
                   context.report({
                     node: activateInfo.node,
                     messageId: 'mismatchedOrder',
                     data: { arg: params[i + 1] }
                   });
+                } else {
+                  context.report({
+                    node: activateInfo.node,
+                    messageId: 'incorrectType',
+                    data: {
+                      arg: params[i + 1],
+                      type: paramType,
+                      expected: expectedToken.name
+                    }
+                  });
                 }
               }
-            }
-          } else {
-            // Without type information, we only check for extra arguments
-            const actualParams = params.slice(1);
-            for (
-              let i = expectedTokensWithoutApp.length;
-              i < actualParams.length;
-              i++
-            ) {
-              context.report({
-                node: activateInfo.node,
-                messageId: 'extraArgument',
-                data: { arg: actualParams[i] }
-              });
             }
           }
 

--- a/tests/fixtures/debugger-types.d.ts
+++ b/tests/fixtures/debugger-types.d.ts
@@ -3,11 +3,9 @@
  * Distributed under the terms of the Modified BSD License.
  */
 
-// Simulates the real JupyterLab pattern where:
+// Simulates the real JupyterLab pattern and includes cases where:
 //   - The interface lives inside a namespace   (separate from the token)
 //   - The token is exported as a standalone const typed as Token<Namespace.Interface>
-//
-// This example mirrors @jupyterlab/debugger:
 
 declare class Token<T> {}
 declare class JupyterFrontEnd {}
@@ -19,4 +17,13 @@ export declare namespace IDebugger {
 export declare const IDebuggerSidebar: Token<IDebugger.ISidebar>;
 
 export declare interface INotebookTracker {}
-export declare const INotebookTrackerToken: Token<INotebookTracker>;
+export declare const INotebookTracker: Token<INotebookTracker>;
+
+export declare interface ITranslator {}
+export declare const ITranslator: Token<ITranslator>;
+
+export declare interface IRenderMimeRegistry {}
+export declare const IRenderMimeRegistry: Token<IRenderMimeRegistry>;
+
+export declare interface IToolbarWidgetRegistry {}
+export declare const IToolbarWidgetRegistry: Token<IToolbarWidgetRegistry>;

--- a/tests/jupyter-plugin-activation-args.test.ts
+++ b/tests/jupyter-plugin-activation-args.test.ts
@@ -12,7 +12,12 @@ const ruleTester = new RuleTester({
     parser: require('@typescript-eslint/parser'),
     parserOptions: {
       ecmaVersion: 2020,
-      sourceType: 'module'
+      sourceType: 'module',
+      projectService: {
+        allowDefaultProject: ['tests/*.ts'],
+        defaultProject: 'tsconfig.test.json'
+      },
+      tsconfigRootDir: path.resolve(__dirname, '..')
     }
   }
 });
@@ -20,7 +25,8 @@ const ruleTester = new RuleTester({
 ruleTester.run('plugin-activation-args', pluginActivationArgs, {
   valid: [
     {
-      // Only requires token
+      // Only requires token, not provided type_stubs as the names match
+      filename: 'tests/type-aware-fixture.ts',
       code: `
         const plugin: JupyterFrontEndPlugin<void> = {
           id: 'test-plugin',
@@ -33,6 +39,7 @@ ruleTester.run('plugin-activation-args', pluginActivationArgs, {
     },
     {
       // Both requires and optional token
+      filename: 'tests/type-aware-fixture.ts',
       code: `
         const plugin: JupyterFrontEndPlugin<void> = {
           id: 'test-plugin',
@@ -52,6 +59,7 @@ ruleTester.run('plugin-activation-args', pluginActivationArgs, {
     },
     {
       // Only optional tokens
+      filename: 'tests/type-aware-fixture.ts',
       code: `
         const plugin: JupyterFrontEndPlugin<void> = {
           id: 'test-plugin',
@@ -68,6 +76,7 @@ ruleTester.run('plugin-activation-args', pluginActivationArgs, {
     },
     {
       // No requires or optional
+      filename: 'tests/type-aware-fixture.ts',
       code: `
         const plugin: JupyterFrontEndPlugin<void> = {
           id: 'test-plugin',
@@ -79,6 +88,7 @@ ruleTester.run('plugin-activation-args', pluginActivationArgs, {
     },
     {
       // Empty requires and optional arrays
+      filename: 'tests/type-aware-fixture.ts',
       code: `
         const plugin: JupyterFrontEndPlugin<void> = {
           id: 'test-plugin',
@@ -92,6 +102,7 @@ ruleTester.run('plugin-activation-args', pluginActivationArgs, {
     },
     {
       // Multiple required and optional tokens
+      filename: 'tests/type-aware-fixture.ts',
       code: `
         const plugin: JupyterFrontEndPlugin<void> = {
           id: 'test-plugin',
@@ -113,10 +124,10 @@ ruleTester.run('plugin-activation-args', pluginActivationArgs, {
       `
     },
     {
-      // Namespace pattern without type info: qualified param types (X.Y) are
-      // allowed even when the token name differs (e.g. IDebuggerSidebar vs
-      // IDebugger.ISidebar) because we can't verify the match without a checker.
+      // Namespace pattern with type info
+      filename: 'tests/type-aware-fixture.ts',
       code: `
+       import { IDebugger, IDebuggerSidebar } from './fixtures/debugger-types';
         const plugin: JupyterFrontEndPlugin<void> = {
           id: 'test-plugin',
           requires: [IDebuggerSidebar],
@@ -130,24 +141,8 @@ ruleTester.run('plugin-activation-args', pluginActivationArgs, {
       `
     },
     {
-      // Namespace pattern without type info, mixed with a normal token.
-      code: `
-        const plugin: JupyterFrontEndPlugin<void> = {
-          id: 'test-plugin',
-          requires: [ITranslator],
-          optional: [IDefaultDrive],
-          activate: (
-            app: JupyterFrontEnd,
-            translator: ITranslator,
-            defaultDrive: Contents.IDrive | null,
-          ) => {
-            console.log('Activated');
-          }
-        };
-      `
-    },
-    {
       // Tokens with qualified names (JupyterFrontEnd.IPaths)
+      filename: 'tests/type-aware-fixture.ts',
       code: `
         const plugin: JupyterFrontEndPlugin<void> = {
           id: 'test-plugin',
@@ -170,7 +165,8 @@ ruleTester.run('plugin-activation-args', pluginActivationArgs, {
       `
     },
     {
-      // Multiple required and optional tokens
+      // No active method, should not report any issues
+      filename: 'tests/type-aware-fixture.ts',
       code: `
         const plugin: JupyterFrontEndPlugin<void> = {
           id: 'test-plugin',
@@ -185,7 +181,8 @@ ruleTester.run('plugin-activation-args', pluginActivationArgs, {
       `
     },
     {
-      // Multiple required and optional tokens
+      // activate is not a function, should not report any issues
+      filename: 'tests/type-aware-fixture.ts',
       code: `
         const plugin: JupyterFrontEndPlugin<void> = {
           id: 'test-plugin',
@@ -196,6 +193,20 @@ ruleTester.run('plugin-activation-args', pluginActivationArgs, {
       `
     },
     {
+      // Special case but valid
+      filename: 'tests/type-aware-fixture.ts',
+      code: `
+        const plugin: JupyterFrontEndPlugin<void> = {
+          id: 'test-plugin',
+          activate: () => {
+            console.log('Activated');
+          }
+        };
+      `
+    },
+    {
+      // Similar to above one but with empty requires.
+      filename: 'tests/type-aware-fixture.ts',
       code: `
         const plugin = {
           id: 'test-plugin',
@@ -207,18 +218,8 @@ ruleTester.run('plugin-activation-args', pluginActivationArgs, {
       `
     },
     {
-      // Sepcial case but valid
-      code: `
-        const plugin: JupyterFrontEndPlugin<void> = {
-          id: 'test-plugin',
-          activate: () => {
-            console.log('Activated');
-          }
-        };
-      `
-    },
-    {
       // JupyterLab and some other types are allowed
+      filename: 'tests/type-aware-fixture.ts',
       code: `
         const plugin: JupyterFrontEndPlugin<void> = {
           id: 'test-plugin',
@@ -230,6 +231,7 @@ ruleTester.run('plugin-activation-args', pluginActivationArgs, {
     },
     {
       // ServiceManagerPlugin must use null as first activate argument
+      filename: 'tests/type-aware-fixture.ts',
       code: `
         const plugin: ServiceManagerPlugin<void> = {
           id: 'test-service-manager-plugin',
@@ -242,17 +244,58 @@ ruleTester.run('plugin-activation-args', pluginActivationArgs, {
           }
         };
       `
+    },
+    {
+    // Namespace pattern with optional token
+    filename: 'tests/type-aware-fixture.ts',
+    code: `
+      import { IDebugger, IDebuggerSidebar } from './fixtures/debugger-types';
+      const plugin: JupyterFrontEndPlugin<void> = {
+        id: 'test-plugin',
+        requires: [INotebookTracker],
+        optional: [IDebuggerSidebar],
+        activate: (
+          app: JupyterFrontEnd,
+          tracker: INotebookTracker,
+          debuggerSidebar: IDebugger.ISidebar | null,
+        ) => {
+          console.log('Activated');
+        }
+      };
+    `
+    },
+    {
+      // Cross-file: token and interface declared in a separate .d.ts.
+    filename: 'tests/type-aware-fixture.ts',
+    code: `
+      import { IDebugger, IDebuggerSidebar, INotebookTracker, INotebookTracker } from './fixtures/debugger-types';
+      declare class JupyterFrontEnd {}
+      declare class JupyterFrontEndPlugin<T> {}
+      const plugin: JupyterFrontEndPlugin<void> = {
+        id: 'test-plugin',
+        requires: [INotebookTracker, IDebuggerSidebar],
+        activate: (
+          app: JupyterFrontEnd,
+          tracker: INotebookTracker,
+          debuggerSidebar: IDebugger.ISidebar,
+        ) => {
+          console.log('Activated');
+        }
+      };
+    `
     }
   ],
 
   invalid: [
     {
       // Arguments in wrong order (requires)
+      filename: 'tests/type-aware-fixture.ts',
       code: `
+        import { INotebookTracker, ITranslator } from './fixtures/debugger-types';
         const plugin: JupyterFrontEndPlugin<void> = {
           id: 'test-plugin',
-          requires: [INotebookTracker, IRenderMimeRegistry],
-          activate: (app: JupyterFrontEnd, rendermime: IRenderMimeRegistry, tracker: INotebookTracker) => {
+          requires: [INotebookTracker, ITranslator],
+          activate: (app: JupyterFrontEnd, translator: ITranslator, tracker: INotebookTracker) => {
             console.log('Activated');
           }
         };
@@ -260,7 +303,7 @@ ruleTester.run('plugin-activation-args', pluginActivationArgs, {
       errors: [
         {
           messageId: 'mismatchedOrder',
-          data: { arg: 'rendermime' }
+          data: { arg: 'translator' }
         },
         {
           messageId: 'mismatchedOrder',
@@ -270,6 +313,7 @@ ruleTester.run('plugin-activation-args', pluginActivationArgs, {
     },
     {
       // Missing argument from requires
+      filename: 'tests/type-aware-fixture.ts',
       code: `
         const plugin: JupyterFrontEndPlugin<void> = {
           id: 'test-plugin',
@@ -291,6 +335,7 @@ ruleTester.run('plugin-activation-args', pluginActivationArgs, {
     },
     {
       // Extra argument not in requires/optional
+      filename: 'tests/type-aware-fixture.ts',
       code: `
         const plugin: JupyterFrontEndPlugin<void> = {
           id: 'test-plugin',
@@ -312,6 +357,7 @@ ruleTester.run('plugin-activation-args', pluginActivationArgs, {
     },
     {
       // app is not first argument
+      filename: 'tests/type-aware-fixture.ts',
       code: `
         const plugin: JupyterFrontEndPlugin<void> = {
           id: 'test-plugin',
@@ -330,7 +376,9 @@ ruleTester.run('plugin-activation-args', pluginActivationArgs, {
     },
     {
       // Wrong order in requires and optional mix
+      filename: 'tests/type-aware-fixture.ts',
       code: `
+        import { INotebookTracker, ITranslator, IRenderMimeRegistry, IToolbarWidgetRegistry } from './fixtures/debugger-types';
         const plugin: JupyterFrontEndPlugin<void> = {
           id: 'test-plugin',
           requires: [INotebookTracker, IRenderMimeRegistry],
@@ -363,7 +411,9 @@ ruleTester.run('plugin-activation-args', pluginActivationArgs, {
     },
     {
       // Missing optional argument
+      filename: 'tests/type-aware-fixture.ts',
       code: `
+        import { INotebookTracker, ITranslator, IToolbarWidgetRegistry } from './fixtures/debugger-types';
         const plugin: JupyterFrontEndPlugin<void> = {
           id: 'test-plugin',
           requires: [INotebookTracker],
@@ -389,6 +439,7 @@ ruleTester.run('plugin-activation-args', pluginActivationArgs, {
     },
     {
       // Too many arguments
+      filename: 'tests/type-aware-fixture.ts',
       code: `
         const plugin: JupyterFrontEndPlugin<void> = {
           id: 'test-plugin',
@@ -419,6 +470,7 @@ ruleTester.run('plugin-activation-args', pluginActivationArgs, {
     },
     {
       // No requires or optional but extra token(s)
+      filename: 'tests/type-aware-fixture.ts',
       code: `
         const plugin: JupyterFrontEndPlugin<void> = {
           id: 'test-plugin',
@@ -439,6 +491,7 @@ ruleTester.run('plugin-activation-args', pluginActivationArgs, {
     },
     {
       // First argument has incompatible type
+      filename: 'tests/type-aware-fixture.ts',
       code: `
         const plugin: JupyterFrontEndPlugin<void> = {
           id: 'test-plugin',
@@ -456,6 +509,7 @@ ruleTester.run('plugin-activation-args', pluginActivationArgs, {
     },
     {
       // ServiceManagerPlugin first argument must be null literal
+      filename: 'tests/type-aware-fixture.ts',
       code: `
         const plugin: ServiceManagerPlugin<void> = {
           id: 'test-service-manager-plugin',
@@ -477,7 +531,9 @@ ruleTester.run('plugin-activation-args', pluginActivationArgs, {
     },
     {
       // Incorrect type (null)
+      filename: 'tests/type-aware-fixture.ts',
       code: `
+        import { INotebookTracker } from './fixtures/debugger-types';
         const plugin: JupyterFrontEndPlugin<void> = {
           id: 'test-plugin',
           requires: [INotebookTracker],
@@ -495,7 +551,9 @@ ruleTester.run('plugin-activation-args', pluginActivationArgs, {
     },
     {
       // Incorrect type
+      filename: 'tests/type-aware-fixture.ts',
       code: `
+        import { INotebookTracker, IRenderMimeRegistry } from './fixtures/debugger-types';
         const plugin: JupyterFrontEndPlugin<void> = {
           id: 'test-plugin',
           requires: [INotebookTracker, IRenderMimeRegistry],
@@ -511,129 +569,46 @@ ruleTester.run('plugin-activation-args', pluginActivationArgs, {
         }
       ]
     },
-  ]
-});
-
-// ─── Type-aware tests ────────────────────────────────────────────────────────
-// These use a real TypeScript program so the rule can resolve Token<T> type
-// arguments and handle namespace/interface patterns like
-// `IDebuggerSidebar: Token<IDebugger.ISidebar>`.
-
-const typeAwareRuleTester = new RuleTester({
-  languageOptions: {
-    parser: require('@typescript-eslint/parser'),
-    parserOptions: {
-      projectService: {
-        // Allow any .ts file under tests/ to use the default project so we can
-        // lint virtual (in-memory) test code with full type information.
-        allowDefaultProject: ['tests/*.ts'],
-        defaultProject: 'tsconfig.test.json'
-      },
-      tsconfigRootDir: path.resolve(__dirname, '..')
-    }
-  }
-});
-
-// Inline type stubs shared across type-aware test cases
-const TYPE_STUBS = `
-  declare class Token<T> {}
-  declare class JupyterFrontEnd {}
-  declare class JupyterFrontEndPlugin<T> {}
-  declare namespace IDebugger { interface ISidebar {} }
-  declare const IDebuggerSidebar: Token<IDebugger.ISidebar>;
-  declare interface INotebookTracker {}
-  declare const INotebookTrackerToken: Token<INotebookTracker>;
-  declare interface ITranslator {}
-  declare const ITranslatorToken: Token<ITranslator>;
-`;
-
-typeAwareRuleTester.run(
-  'plugin-activation-args (type-aware)',
-  pluginActivationArgs,
-  {
-    valid: [
-      {
-        // Namespace pattern: Token<IDebugger.ISidebar> matched by IDebugger.ISidebar param type.
-        // Type stubs are declared inline to simulate types being in a separate file.
-        filename: 'tests/type-aware-fixture.ts',
-        code: `
-        ${TYPE_STUBS}
+    {
+      // Incorrect type (without stubs results in unresolved tokens)
+      filename: 'tests/type-aware-fixture.ts',
+      code: `
         const plugin: JupyterFrontEndPlugin<void> = {
           id: 'test-plugin',
-          requires: [IDebuggerSidebar],
-          activate: (
-            app: JupyterFrontEnd,
-            debuggerSidebar: IDebugger.ISidebar,
-          ) => {
-            console.log('Activated');
-          }
-        };
-      `
-      },
-      {
-        // Namespace pattern with optional token
-        filename: 'tests/type-aware-fixture.ts',
-        code: `
-        ${TYPE_STUBS}
-        const plugin: JupyterFrontEndPlugin<void> = {
-          id: 'test-plugin',
-          requires: [INotebookTrackerToken],
-          optional: [IDebuggerSidebar],
-          activate: (
-            app: JupyterFrontEnd,
-            tracker: INotebookTracker,
-            debuggerSidebar: IDebugger.ISidebar | null,
-          ) => {
-            console.log('Activated');
-          }
-        };
-      `
-      },
-      {
-        // Cross-file: token and interface declared in a separate .d.ts.
-        filename: 'tests/type-aware-fixture.ts',
-        code: `
-        import { IDebugger, IDebuggerSidebar, INotebookTracker, INotebookTrackerToken } from './fixtures/debugger-types';
-        declare class JupyterFrontEnd {}
-        declare class JupyterFrontEndPlugin<T> {}
-        const plugin: JupyterFrontEndPlugin<void> = {
-          id: 'test-plugin',
-          requires: [INotebookTrackerToken, IDebuggerSidebar],
-          activate: (
-            app: JupyterFrontEnd,
-            tracker: INotebookTracker,
-            debuggerSidebar: IDebugger.ISidebar,
-          ) => {
-            console.log('Activated');
-          }
-        };
-      `
-      }
-    ],
-
-    invalid: [
-      {
-        // Namespace pattern but wrong order
-        filename: 'tests/type-aware-fixture.ts',
-        code: `
-        ${TYPE_STUBS}
-        const plugin: JupyterFrontEndPlugin<void> = {
-          id: 'test-plugin',
-          requires: [INotebookTrackerToken, IDebuggerSidebar],
-          activate: (
-            app: JupyterFrontEnd,
-            debuggerSidebar: IDebugger.ISidebar,
-            tracker: INotebookTracker,
-          ) => {
+          requires: [INotebookTracker, IRenderMimeRegistry],
+          activate: (app: JupyterFrontEnd, tracker: IDocumentTracker, rendermime: IRenderMimeRegistry) => {
             console.log('Activated');
           }
         };
       `,
-        errors: [
-          { messageId: 'mismatchedOrder', data: { arg: 'debuggerSidebar' } },
-          { messageId: 'mismatchedOrder', data: { arg: 'tracker' } }
-        ]
-      }
-    ]
-  }
-);
+      errors: [
+        {
+          messageId: 'unresolvableTokenType',
+          data: { token: 'INotebookTracker'}
+        }
+      ]
+    },
+    {
+    // Namespace pattern but wrong order
+    filename: 'tests/type-aware-fixture.ts',
+    code: `
+      import { IDebugger, IDebuggerSidebar, INotebookTracker } from './fixtures/debugger-types';
+      const plugin: JupyterFrontEndPlugin<void> = {
+        id: 'test-plugin',
+        requires: [INotebookTracker, IDebuggerSidebar],
+        activate: (
+          app: JupyterFrontEnd,
+          debuggerSidebar: IDebugger.ISidebar,
+          tracker: INotebookTracker,
+        ) => {
+          console.log('Activated');
+        }
+      };
+    `,
+      errors: [
+        { messageId: 'mismatchedOrder', data: { arg: 'debuggerSidebar' } },
+        { messageId: 'mismatchedOrder', data: { arg: 'tracker' } }
+      ]
+    }
+  ]
+});

--- a/tests/jupyter-plugin-activation-args.test.ts
+++ b/tests/jupyter-plugin-activation-args.test.ts
@@ -489,7 +489,7 @@ ruleTester.run('plugin-activation-args', pluginActivationArgs, {
       errors: [
         {
           messageId: 'incorrectType',
-          data: { arg: 'tracker', type: 'null', expected: 'INotebookTracker' }
+          data: { arg: 'tracker', type: null, expected: 'INotebookTracker' }
         }
       ]
     },

--- a/tests/jupyter-plugin-activation-args.test.ts
+++ b/tests/jupyter-plugin-activation-args.test.ts
@@ -7,6 +7,17 @@ import { RuleTester } from '@typescript-eslint/rule-tester';
 import * as path from 'path';
 import pluginActivationArgs from '../src/rules/plugin-activation-args';
 
+const nonTypeAwareTester = new RuleTester({
+  languageOptions: {
+    parser: require('@typescript-eslint/parser'),
+    parserOptions: {
+      ecmaVersion: 2020,
+      sourceType: 'module',
+      tsconfigRootDir: path.resolve(__dirname, '..')
+    }
+  }
+});
+
 const ruleTester = new RuleTester({
   languageOptions: {
     parser: require('@typescript-eslint/parser'),
@@ -20,6 +31,32 @@ const ruleTester = new RuleTester({
       tsconfigRootDir: path.resolve(__dirname, '..')
     }
   }
+});
+
+nonTypeAwareTester.run('plugin-activation-args (non-type-aware)', pluginActivationArgs, {
+  valid: [],
+  invalid: [
+    // This same case is in valid cases for the type-aware tester
+    {
+      filename: 'tests/type-aware-fixture.ts',
+      code: `
+        import { IDebuggerSidebar, IDebugger } from './fixtures/debugger-types';
+        const plugin: JupyterFrontEndPlugin<void> = {
+          id: 'test-plugin',
+          requires: [IDebuggerSidebar],
+          activate: (app: JupyterFrontEnd, sidebar: IDebugger.ISidebar) => {
+            console.log('Activated');
+          }
+        };
+      `,
+      errors: [
+        {
+          messageId: 'unresolvableTokenType',
+          data: { token: 'IDebuggerSidebar' }
+        }
+      ]
+    },
+  ]
 });
 
 ruleTester.run('plugin-activation-args', pluginActivationArgs, {

--- a/tests/jupyter-plugin-activation-args.test.ts
+++ b/tests/jupyter-plugin-activation-args.test.ts
@@ -268,7 +268,7 @@ ruleTester.run('plugin-activation-args', pluginActivationArgs, {
       // Cross-file: token and interface declared in a separate .d.ts.
     filename: 'tests/type-aware-fixture.ts',
     code: `
-      import { IDebugger, IDebuggerSidebar, INotebookTracker, INotebookTracker } from './fixtures/debugger-types';
+      import { IDebugger, IDebuggerSidebar, INotebookTracker } from './fixtures/debugger-types';
       declare class JupyterFrontEnd {}
       declare class JupyterFrontEndPlugin<T> {}
       const plugin: JupyterFrontEndPlugin<void> = {

--- a/tests/jupyter-plugin-activation-args.test.ts
+++ b/tests/jupyter-plugin-activation-args.test.ts
@@ -474,7 +474,43 @@ ruleTester.run('plugin-activation-args', pluginActivationArgs, {
           data: { arg: 'JupyterFrontEnd' }
         }
       ]
-    }
+    },
+    {
+      // Incorrect type (null)
+      code: `
+        const plugin: JupyterFrontEndPlugin<void> = {
+          id: 'test-plugin',
+          requires: [INotebookTracker],
+          activate: (app: JupyterFrontEnd, tracker: null) => {
+            console.log('Activated');
+          }
+        };
+      `,
+      errors: [
+        {
+          messageId: 'incorrectType',
+          data: { arg: 'tracker', type: 'null', expected: 'INotebookTracker' }
+        }
+      ]
+    },
+    {
+      // Incorrect type
+      code: `
+        const plugin: JupyterFrontEndPlugin<void> = {
+          id: 'test-plugin',
+          requires: [INotebookTracker, IRenderMimeRegistry],
+          activate: (app: JupyterFrontEnd, tracker: IDocumentTracker, rendermime: IRenderMimeRegistry) => {
+            console.log('Activated');
+          }
+        };
+      `,
+      errors: [
+        {
+          messageId: 'incorrectType',
+          data: { arg: 'tracker', type: 'IDocumentTracker', expected: 'INotebookTracker' }
+        }
+      ]
+    },
   ]
 });
 

--- a/website/docs/rules/plugin-activation-args.md
+++ b/website/docs/rules/plugin-activation-args.md
@@ -9,12 +9,16 @@ This rule enforces a consistent, predictable contract.
 
 ## Rule details
 
-For `JupyterFrontEndPlugin` objects, this rule validates:
+This rule reports the following errors:
 
-- First `activate` argument name is allowed (`app` by default)
-- First argument type is compatible (`JupyterFrontEnd`, `JupyterLab`, or `Application`)
-- Argument count equals: `1 + requires.length + optional.length`
-- Token order in `activate` matches `requires` then `optional`
+- `mismatchedOrder` — arguments are in the wrong order _(requires type-aware checking)_
+- `incorrectType` — an argument's type annotation does not match its token _(requires type-aware checking)_
+- `appNotFirst` — first argument name is not one of the allowed names (e.g. `app`)
+- `invalidAppType` — first argument type is not compatible with `JupyterFrontEnd`
+- `wrongArgumentCount` — argument count does not match `1 + requires.length + optional.length`
+- `missingArgument` — a token from `requires`/`optional` has no corresponding argument
+- `extraArgument` — an argument has no corresponding token in `requires`/`optional`
+- `serviceManagerFirstArgNotNull` — `ServiceManagerPlugin` first argument is not `null`
 
 ## Incorrect
 
@@ -45,6 +49,12 @@ const plugin: JupyterFrontEndPlugin<void> = {
   }
 };
 ```
+
+## Type-aware checking
+
+The two errors marked _(requires type-aware checking)_ above need TypeScript type information to work reliably. Without it, those checks are skipped and the errors will go unreported. You may also see `unresolvableTokenType` warnings frequently.
+
+> **Strongly recommended:** configure `parserOptions.project` or `projectService` in your ESLint setup to enable full type-aware checking.
 
 ## Options
 


### PR DESCRIPTION
## Fixes #34 

### Description
- Added a new error message:
  ```ts
  incorrectType: 'Activation argument "{{ arg }}" has incorrect type annotation "{{ type }}". Expected type compatible with "{{ expected }}".',
  ```
- Added logic to distinguish between order mismatch and incorrect type annotation.
- Removed conditional type-checking logic:
    ```ts
      const hasTypeInfo = actualParamTypes.some(t => t !== null);
      if (hasTypeInfo) {
    ```
- Previously, type validation was only performed when type information was present.
- Updated behavior to enforce that all activation parameters must have valid type annotations. If a parameter is missing a type (or null), an error is now raised.
- This change was motivated by a failing test case that was incorrectly passing:
  ```ts
    activate: (app: JupyterFrontEnd, tracker: null) => {
  ```
