### PR TITLE
Fix downstream lint config

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -39,6 +39,7 @@ jobs:
           python -m pip install .
           python -m pip install "hatchling>=1.21.1"
           jlpm
+          jlpm run build
 
       - name: Run integration lint check
         run: |
@@ -80,6 +81,7 @@ jobs:
         run: |
           python -m pip install .
           jlpm
+          jlpm run build
 
       - name: Run integration lint check
         run: |

--- a/eslint.downstream.config.mjs
+++ b/eslint.downstream.config.mjs
@@ -34,7 +34,9 @@ export default [
       parser: resolvedParser,
       parserOptions: {
         ecmaVersion: 'latest',
-        sourceType: 'module'
+        sourceType: 'module',
+        project: true,
+        tsconfigRootDir: __dirname
       }
     },
     linterOptions: {

--- a/eslint.downstream.config.mjs
+++ b/eslint.downstream.config.mjs
@@ -18,12 +18,13 @@ const tsPlugin = await import('@typescript-eslint/eslint-plugin');
 const resolvedTsPlugin = tsPlugin.default ?? tsPlugin;
 
 export default [
+  // JupyterLab
   {
     basePath: __dirname,
-    files: ['jupyterlab/packages/*/src/**/*.ts', "notebook/packages/*/src/**/*.ts"],
+    files: ['jupyterlab/packages/*/src/**/*.ts'],
     plugins: {
       'jupyter': resolvedPlugin,
-      '@typescript-eslint': resolvedTsPlugin  // registered but rules not enforced
+      '@typescript-eslint': resolvedTsPlugin
     },
     rules: {
       'jupyter/command-described-by': 'error',
@@ -35,8 +36,33 @@ export default [
       parserOptions: {
         ecmaVersion: 'latest',
         sourceType: 'module',
-        project: true,
-        tsconfigRootDir: __dirname
+        project: path.resolve(__dirname, 'jupyterlab/tsconfig.eslint.json')
+      }
+    },
+    linterOptions: {
+      reportUnusedDisableDirectives: 'off'
+    }
+  },
+
+  // Notebook
+  {
+    basePath: __dirname,
+    files: ['notebook/packages/*/src/**/*.ts'],
+    plugins: {
+      'jupyter': resolvedPlugin,
+      '@typescript-eslint': resolvedTsPlugin
+    },
+    rules: {
+      'jupyter/command-described-by': 'error',
+      'jupyter/plugin-activation-args': 'error',
+      'jupyter/plugin-description': 'error'
+    },
+    languageOptions: {
+      parser: resolvedParser,
+      parserOptions: {
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+        project: path.resolve(__dirname, 'notebook/tsconfig.eslint.json')
       }
     },
     linterOptions: {


### PR DESCRIPTION
Identified in #37 

### Description

Downstream linting wasn't running completely because `parserOptions.project` was not set in our downstream linting config.  
As a result, there was no type-checking, and type-aware linting rules were not running properly.

This PR fixes the issue by supplying `parserOptions.project` in the linting configs of downstream projects, enabling proper type-aware linting.