### PR TITLE
Add `jupyter/token-format` to enforce plugin token naming convention

### DIFF
--- a/eslint.downstream.config.mjs
+++ b/eslint.downstream.config.mjs
@@ -29,7 +29,8 @@ export default [
     rules: {
       'jupyter/command-described-by': 'error',
       'jupyter/plugin-activation-args': 'error',
-      'jupyter/plugin-description': 'error'
+      'jupyter/plugin-description': 'error',
+      'jupyter/token-format': 'error'
     },
     languageOptions: {
       parser: resolvedParser,
@@ -55,7 +56,8 @@ export default [
     rules: {
       'jupyter/command-described-by': 'error',
       'jupyter/plugin-activation-args': 'error',
-      'jupyter/plugin-description': 'error'
+      'jupyter/plugin-description': 'error',
+      'jupyter/token-format': 'error'
     },
     languageOptions: {
       parser: resolvedParser,

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ const plugin = {
     'plugin-activation-args': pluginActivationArgs,
     'command-described-by': commandDescribedBy,
     'plugin-description': pluginDescription,
-    'token-format': tokenFormat
+    'token-format': tokenFormat,
     'no-untranslated-string': noUntranslatedString
   },
   configs: {
@@ -24,7 +24,7 @@ const plugin = {
         'jupyter/plugin-activation-args': 'error',
         'jupyter/command-described-by': 'warn',
         'jupyter/plugin-description': 'warn',
-        'jupyter/token-format': 'error'
+        'jupyter/token-format': 'error',
         'jupyter/no-untranslated-string': 'warn'
       }
     },
@@ -33,7 +33,7 @@ const plugin = {
         'jupyter/plugin-activation-args': 'error',
         'jupyter/command-described-by': 'warn',
         'jupyter/plugin-description': 'warn',
-        'jupyter/token-format': 'error'
+        'jupyter/token-format': 'error',
         'jupyter/no-untranslated-string': 'warn'
       }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,12 +6,14 @@
 import pluginActivationArgs from './rules/plugin-activation-args';
 import commandDescribedBy from './rules/command-described-by';
 import pluginDescription from './rules/plugin-description';
+import tokenFormat from './rules/token-format';
 
 const plugin = {
   rules: {
     'plugin-activation-args': pluginActivationArgs,
     'command-described-by': commandDescribedBy,
-    'plugin-description': pluginDescription
+    'plugin-description': pluginDescription,
+    'token-format': tokenFormat
   },
   configs: {
     recommended: {
@@ -19,14 +21,16 @@ const plugin = {
       rules: {
         'jupyter/plugin-activation-args': 'error',
         'jupyter/command-described-by': 'warn',
-        'jupyter/plugin-description': 'warn'
+        'jupyter/plugin-description': 'warn',
+        'jupyter/token-format': 'error'
       }
     },
     'recommended-legacy': {
       rules: {
         'jupyter/plugin-activation-args': 'error',
         'jupyter/command-described-by': 'warn',
-        'jupyter/plugin-description': 'warn'
+        'jupyter/plugin-description': 'warn',
+        'jupyter/token-format': 'error'
       }
     }
   }

--- a/src/rules/token-format.ts
+++ b/src/rules/token-format.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import { createRule } from '../utils/create-rule';
+
+/**
+ * Token symbol (part after the first ':') must be a valid JavaScript identifier.
+ */
+const VALID_TOKEN_SYMBOL = /^[a-zA-Z_$][a-zA-Z0-9_$]*$/;
+
+const tokenFormat = createRule({
+  name: 'token-format',
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Ensure JupyterLab Token ids follow the <package>:<TokenSymbol> naming convention',
+      url: 'https://eslint-plugin.readthedocs.io/en/latest/rules/token-format/'
+    },
+    messages: {
+      missingColon:
+        'Token id "{{ tokenId }}" must follow the format "<package>:<TokenSymbol>" (no colon found).',
+      invalidTokenSymbol:
+        'Token id "{{ tokenId }}" has an invalid symbol "{{ symbol }}". ' +
+        'The part after ":" must be a valid JavaScript identifier.'
+    },
+    schema: []
+  },
+  defaultOptions: [],
+
+  create(context) {
+    return {
+      NewExpression(node) {
+        if (
+          node.callee.type !== 'Identifier' ||
+          node.callee.name !== 'Token'
+        ) {
+          return;
+        }
+
+        if (node.arguments.length === 0) {
+          return;
+        }
+
+        const firstArg = node.arguments[0];
+
+        if (firstArg.type !== 'Literal' || typeof firstArg.value !== 'string') {
+          return;
+        }
+
+        const tokenId: string = firstArg.value;
+        const colonIndex = tokenId.indexOf(':');
+
+        if (colonIndex === -1) {
+          context.report({
+            node: firstArg,
+            messageId: 'missingColon',
+            data: { tokenId }
+          });
+          return;
+        }
+
+        const symbol = tokenId.slice(colonIndex + 1);
+
+        if (!VALID_TOKEN_SYMBOL.test(symbol)) {
+          context.report({
+            node: firstArg,
+            messageId: 'invalidTokenSymbol',
+            data: { tokenId, symbol }
+          });
+        }
+      }
+    };
+  }
+});
+
+export = tokenFormat;

--- a/tests/jupyter-token-format.test.ts
+++ b/tests/jupyter-token-format.test.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import tokenFormat from '../src/rules/token-format';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parser: require('@typescript-eslint/parser'),
+    parserOptions: {
+      ecmaVersion: 2020,
+      sourceType: 'module'
+    }
+  }
+});
+
+ruleTester.run('token-format', tokenFormat, {
+  valid: [
+    {
+      // Standard format
+      code: `new Token<IFoo>('@test/pkg:IFoo', 'A test service')`
+    },
+    {
+      code: `new Token<void>('@test/pkg:IFoo')`
+    },
+    {
+      // Package name with hyphens is fine — only the symbol after ':' is checked
+      code: `new Token<void>('@test/my-pkg:IFoo')`
+    },
+    {
+      // Underscore prefix in symbol
+      code: `new Token<void>('@test/pkg:_IPrivate')`
+    },
+    {
+      // new Token() with no arguments is skipped
+      code: `new Token()`
+    },
+    {
+      // new Token(variable) is skipped — non-literal first arg
+      code: `new Token(myTokenId)`
+    },
+    {
+      // Template literal first arg cannot be statically validated — skipped
+      code: 'new Token(`@test/pkg:kebab-case`)'
+    },
+    {
+      // Unrelated new expressions are not checked
+      code: `new SomeOtherClass('@test/pkg:kebab-case', 'desc')`
+    },
+  ],
+
+  invalid: [
+    {
+      // Kebab-case symbol
+      code: `new Token<IFoo>('@test/pkg:foo-service', 'A test service')`,
+      errors: [
+        {
+          messageId: 'invalidTokenSymbol',
+          data: {
+            tokenId: '@test/pkg:foo-service',
+            symbol: 'foo-service'
+          }
+        }
+      ]
+    },
+    {
+      // No colon at all
+      code: `new Token<void>('testpkgIFoo')`,
+      errors: [
+        {
+          messageId: 'missingColon',
+          data: { tokenId: 'testpkgIFoo' }
+        }
+      ]
+    },
+    {
+      // Empty symbol after colon
+      code: `new Token<void>('@test/pkg:')`,
+      errors: [
+        {
+          messageId: 'invalidTokenSymbol',
+          data: { tokenId: '@test/pkg:', symbol: '' }
+        }
+      ]
+    },
+    {
+      // Symbol with a dot
+      code: `new Token<void>('@test/pkg:IFoo.IBar')`,
+      errors: [
+        {
+          messageId: 'invalidTokenSymbol',
+          data: { tokenId: '@test/pkg:IFoo.IBar', symbol: 'IFoo.IBar' }
+        }
+      ]
+    }
+  ]
+});

--- a/website/docs/rules/index.md
+++ b/website/docs/rules/index.md
@@ -7,6 +7,7 @@ This section documents all rules currently provided by `eslint-plugin-jupyter`.
 - [command-described-by](./command-described-by)
 - [plugin-activation-args](./plugin-activation-args)
 - [plugin-description](./plugin-description)
+- [token-format](./token-format)
 
 Each page includes intent, examples, configuration, and when to apply the rule.
 
@@ -19,6 +20,7 @@ The plugin ships with a recommended configuration that enables all current rules
 | [jupyter/plugin-activation-args](./plugin-activation-args) | `error` |
 | [jupyter/command-described-by](./command-described-by) | `warn` |
 | [jupyter/plugin-description](./plugin-description) | `warn` |
+| [jupyter/token-format](./token-format) | `error` |
 
 These defaults are the same in both `jupyterPlugin.configs.recommended` (flat config) and `plugin:@jupyter/eslint-plugin/recommended-legacy`.
 

--- a/website/docs/rules/token-format.md
+++ b/website/docs/rules/token-format.md
@@ -1,0 +1,34 @@
+# `jupyter/token-format`
+
+Ensure JupyterLab `Token` ids follow the `<package>:<TokenSymbol>` naming convention where the symbol is a valid JavaScript identifier.
+
+## Rule details
+
+The rule inspects `new Token(id, ...)` expressions where `id` is a string literal and reports when:
+
+- The id contains no `:` separator
+- The symbol after `:` is not a valid JavaScript identifier (`/^[a-zA-Z_$][a-zA-Z0-9_$]*$/`)
+
+Non-literal first arguments (variables, template literals) are not checked.
+
+## Incorrect
+
+```ts
+export const IFooService = new Token<IFooService>(
+  '@test/pkg:foo-service',
+  'A foo service'
+);
+```
+
+## Correct
+
+```ts
+export const IFooService = new Token<IFooService>(
+  '@test/pkg:IFooService',
+  'A foo service'
+);
+```
+
+## Options
+
+This rule has no options.


### PR DESCRIPTION
### Fixes #39 

### Description

Added a new rule `jupyter/token-format` that ensures JupyterLab Token ids follow the `<package>:<TokenSymbol>` naming convention where TokenSymbol (part after the first ':') must be a valid JavaScript identifier.