### PR TITLE
Add a new rule `jupyter/no-untranslated-string`

### DIFF
--- a/eslint.downstream.config.mjs
+++ b/eslint.downstream.config.mjs
@@ -28,6 +28,7 @@ export default [
     },
     rules: {
       'jupyter/command-described-by': 'error',
+      'jupyter/no-untranslated-string': 'error',
       'jupyter/plugin-activation-args': 'error',
       'jupyter/plugin-description': 'error'
     },
@@ -54,6 +55,7 @@ export default [
     },
     rules: {
       'jupyter/command-described-by': 'error',
+      'jupyter/no-untranslated-string': 'error',
       'jupyter/plugin-activation-args': 'error',
       'jupyter/plugin-description': 'error'
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,12 +6,14 @@
 import pluginActivationArgs from './rules/plugin-activation-args';
 import commandDescribedBy from './rules/command-described-by';
 import pluginDescription from './rules/plugin-description';
+import noUntranslatedString from './rules/no-untranslated-string';
 
 const plugin = {
   rules: {
     'plugin-activation-args': pluginActivationArgs,
     'command-described-by': commandDescribedBy,
-    'plugin-description': pluginDescription
+    'plugin-description': pluginDescription,
+    'no-untranslated-string': noUntranslatedString
   },
   configs: {
     recommended: {
@@ -19,14 +21,16 @@ const plugin = {
       rules: {
         'jupyter/plugin-activation-args': 'error',
         'jupyter/command-described-by': 'warn',
-        'jupyter/plugin-description': 'warn'
+        'jupyter/plugin-description': 'warn',
+        'jupyter/no-untranslated-string': 'warn'
       }
     },
     'recommended-legacy': {
       rules: {
         'jupyter/plugin-activation-args': 'error',
         'jupyter/command-described-by': 'warn',
-        'jupyter/plugin-description': 'warn'
+        'jupyter/plugin-description': 'warn',
+        'jupyter/no-untranslated-string': 'warn'
       }
     }
   }

--- a/src/rules/no-untranslated-string.ts
+++ b/src/rules/no-untranslated-string.ts
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import { TSESTree } from '@typescript-eslint/types';
+import { isAddCommandCall } from '../utils/commands';
+import { getObjectProperties } from '../utils/plugin-utils';
+import { createRule } from '../utils/create-rule';
+
+/**
+ * Returns true if the node is a non-empty raw string literal that should be
+ * wrapped in a translation call. Handles:
+ *   - String Literal: 'string' or "string"
+ *   - TemplateLiteral with no expressions: `string`
+ *   - Concise ArrowFunctionExpression whose body is one of the above
+ */
+function isRawStringNode(node: TSESTree.Node): boolean {
+  if (node.type === 'Literal') {
+    return typeof node.value === 'string' && node.value.length > 0;
+  }
+  if (node.type === 'TemplateLiteral') {
+    if (node.expressions.length > 0) {
+      return false;
+    }
+    const cooked = node.quasis.map(q => q.value.cooked ?? '').join('');
+    return cooked.length > 0;
+  }
+  if (
+    node.type === 'ArrowFunctionExpression' &&
+    node.body.type !== 'BlockStatement'
+  ) {
+    return isRawStringNode(node.body);
+  }
+  return false;
+}
+
+function isSetAttributeCall(node: TSESTree.CallExpression): boolean {
+  if (node.callee.type === 'MemberExpression') {
+    const callee = node.callee;
+    if (
+      callee.property.type === 'Identifier' &&
+      callee.property.name === 'setAttribute'
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+const MONITORED_COMMAND_PROPS = ['label', 'caption', 'description'];
+const MONITORED_SET_ATTRIBUTE_ATTRS = ['aria-label', 'aria-description', 'title'];
+const MONITORED_ASSIGNMENT_PROPS = ['title', 'ariaLabel'];
+
+const noUntranslatedString = createRule({
+  name: 'no-untranslated-string',
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Require user-facing string literals to be wrapped in a translation call such as trans.__()',
+      url: 'https://eslint-plugin.readthedocs.io/en/latest/rules/no-untranslated-string/'
+    },
+    messages: {
+      untranslatedCommandProp:
+        'Command property "{{ prop }}" has an untranslated string literal. Wrap it with trans.__().',
+      untranslatedSetAttribute:
+        'setAttribute("{{ attr }}", ...) has an untranslated string literal. Wrap the value with trans.__().',
+      untranslatedPropertyAssign:
+        'Assignment to "{{ prop }}" has an untranslated string literal. Wrap it with trans.__().'
+    },
+    schema: []
+  },
+  defaultOptions: [],
+
+  create(context) {
+    return {
+      CallExpression(node) {
+        // commands.addCommand(id, { label, caption, description })
+        if (isAddCommandCall(node)) {
+          if (node.arguments.length < 2) {
+            return;
+          }
+          const optionsArg = node.arguments[1];
+          if (optionsArg.type !== 'ObjectExpression') {
+            return;
+          }
+          const properties = getObjectProperties(optionsArg);
+          for (const propName of MONITORED_COMMAND_PROPS) {
+            const prop = properties.get(propName);
+            if (prop && isRawStringNode(prop.value)) {
+              context.report({
+                node: prop.value,
+                messageId: 'untranslatedCommandProp',
+                data: { prop: propName }
+              });
+            }
+          }
+          return;
+        }
+
+        // element.setAttribute('aria-label'/'title', string)
+        if (isSetAttributeCall(node)) {
+          if (node.arguments.length < 2) {
+            return;
+          }
+          const attrNameArg = node.arguments[0];
+          if (
+            attrNameArg.type !== 'Literal' ||
+            typeof attrNameArg.value !== 'string'
+          ) {
+            return;
+          }
+          if (!MONITORED_SET_ATTRIBUTE_ATTRS.includes(attrNameArg.value)) {
+            return;
+          }
+          const attrValueArg = node.arguments[1];
+          if (isRawStringNode(attrValueArg)) {
+            context.report({
+              node: attrValueArg,
+              messageId: 'untranslatedSetAttribute',
+              data: { attr: attrNameArg.value }
+            });
+          }
+        }
+      },
+
+      AssignmentExpression(node) {
+        if (node.operator !== '=') {
+          return;
+        }
+        const left = node.left;
+        if (
+          left.type !== 'MemberExpression' ||
+          left.computed ||
+          left.property.type !== 'Identifier'
+        ) {
+          return;
+        }
+        const propName = left.property.name;
+        if (
+          MONITORED_ASSIGNMENT_PROPS.includes(propName) &&
+          isRawStringNode(node.right)
+        ) {
+          context.report({
+            node: node.right,
+            messageId: 'untranslatedPropertyAssign',
+            data: { prop: propName }
+          });
+        }
+      }
+    };
+  }
+});
+
+export = noUntranslatedString;

--- a/src/rules/no-untranslated-string.ts
+++ b/src/rules/no-untranslated-string.ts
@@ -36,21 +36,44 @@ function isRawStringNode(node: TSESTree.Node): boolean {
 }
 
 function isSetAttributeCall(node: TSESTree.CallExpression): boolean {
-  if (node.callee.type === 'MemberExpression') {
-    const callee = node.callee;
-    if (
-      callee.property.type === 'Identifier' &&
-      callee.property.name === 'setAttribute'
-    ) {
-      return true;
-    }
-  }
-  return false;
+  return (
+    node.callee.type === 'MemberExpression' &&
+    !node.callee.computed &&
+    node.callee.property.type === 'Identifier' &&
+    node.callee.property.name === 'setAttribute'
+  );
 }
 
-const MONITORED_COMMAND_PROPS = ['label', 'caption', 'description'];
+function isShowDialogCall(node: TSESTree.CallExpression): boolean {
+  return (
+    node.callee.type === 'Identifier' && node.callee.name === 'showDialog'
+  );
+}
+
+function isDialogConstructor(node: TSESTree.NewExpression): boolean {
+  return node.callee.type === 'Identifier' && node.callee.name === 'Dialog';
+}
+
+const DIALOG_BUTTON_BUILDERS = [
+  'okButton',
+  'cancelButton',
+  'warnButton',
+  'errorButton'
+];
+
+function isDialogButtonCall(node: TSESTree.CallExpression): boolean {
+  return (
+    node.callee.type === 'MemberExpression' &&
+    !node.callee.computed &&
+    node.callee.property.type === 'Identifier' &&
+    DIALOG_BUTTON_BUILDERS.includes(node.callee.property.name)
+  );
+}
+
+const MONITORED_COMMAND_PROPS = ['label', 'caption', 'usage'];
 const MONITORED_SET_ATTRIBUTE_ATTRS = ['aria-label', 'aria-description', 'title'];
 const MONITORED_ASSIGNMENT_PROPS = ['title', 'ariaLabel'];
+const MONITORED_DIALOG_PROPS = ['title', 'body'];
 
 const noUntranslatedString = createRule({
   name: 'no-untranslated-string',
@@ -67,7 +90,15 @@ const noUntranslatedString = createRule({
       untranslatedSetAttribute:
         'setAttribute("{{ attr }}", ...) has an untranslated string literal. Wrap the value with trans.__().',
       untranslatedPropertyAssign:
-        'Assignment to "{{ prop }}" has an untranslated string literal. Wrap it with trans.__().'
+        'Assignment to "{{ prop }}" has an untranslated string literal. Wrap it with trans.__().',
+      untranslatedTitleProp:
+        'Assignment to "title.{{ prop }}" has an untranslated string literal. Wrap it with trans.__().',
+      untranslatedDialogOption:
+        'Dialog/showDialog "{{ prop }}" option has an untranslated string literal. Wrap it with trans.__().',
+      untranslatedDialogButtonLabel:
+        'Dialog button "label" option has an untranslated string literal. Wrap it with trans.__().',
+      untranslatedJsxText:
+        'JSX text content has an untranslated string literal. Wrap it with {trans.__(...)}'
     },
     schema: []
   },
@@ -76,7 +107,7 @@ const noUntranslatedString = createRule({
   create(context) {
     return {
       CallExpression(node) {
-        // commands.addCommand(id, { label, caption, description })
+        // Branch A: commands.addCommand(id, { label, caption, usage })
         if (isAddCommandCall(node)) {
           if (node.arguments.length < 2) {
             return;
@@ -99,7 +130,7 @@ const noUntranslatedString = createRule({
           return;
         }
 
-        // element.setAttribute('aria-label'/'title', string)
+        // Branch B: element.setAttribute('aria-label'/'aria-description'/'title', string)
         if (isSetAttributeCall(node)) {
           if (node.arguments.length < 2) {
             return;
@@ -107,11 +138,9 @@ const noUntranslatedString = createRule({
           const attrNameArg = node.arguments[0];
           if (
             attrNameArg.type !== 'Literal' ||
-            typeof attrNameArg.value !== 'string'
+            typeof attrNameArg.value !== 'string' ||
+            !MONITORED_SET_ATTRIBUTE_ATTRS.includes(attrNameArg.value)
           ) {
-            return;
-          }
-          if (!MONITORED_SET_ATTRIBUTE_ATTRS.includes(attrNameArg.value)) {
             return;
           }
           const attrValueArg = node.arguments[1];
@@ -120,6 +149,74 @@ const noUntranslatedString = createRule({
               node: attrValueArg,
               messageId: 'untranslatedSetAttribute',
               data: { attr: attrNameArg.value }
+            });
+          }
+          return;
+        }
+
+        // Branch C: showDialog({ title, body })
+        if (isShowDialogCall(node)) {
+          if (node.arguments.length < 1) {
+            return;
+          }
+          const optionsArg = node.arguments[0];
+          if (optionsArg.type !== 'ObjectExpression') {
+            return;
+          }
+          const properties = getObjectProperties(optionsArg);
+          for (const propName of MONITORED_DIALOG_PROPS) {
+            const prop = properties.get(propName);
+            if (prop && isRawStringNode(prop.value)) {
+              context.report({
+                node: prop.value,
+                messageId: 'untranslatedDialogOption',
+                data: { prop: propName }
+              });
+            }
+          }
+          return;
+        }
+
+        // Branch D: Dialog.okButton/cancelButton/warnButton/errorButton({ label })
+        if (isDialogButtonCall(node)) {
+          if (node.arguments.length < 1) {
+            return;
+          }
+          const optionsArg = node.arguments[0];
+          if (optionsArg.type !== 'ObjectExpression') {
+            return;
+          }
+          const properties = getObjectProperties(optionsArg);
+          const labelProp = properties.get('label');
+          if (labelProp && isRawStringNode(labelProp.value)) {
+            context.report({
+              node: labelProp.value,
+              messageId: 'untranslatedDialogButtonLabel'
+            });
+          }
+        }
+      },
+
+      // new Dialog({ title, body })
+      NewExpression(node) {
+        if (!isDialogConstructor(node)) {
+          return;
+        }
+        if (node.arguments.length < 1) {
+          return;
+        }
+        const optionsArg = node.arguments[0];
+        if (optionsArg.type !== 'ObjectExpression') {
+          return;
+        }
+        const properties = getObjectProperties(optionsArg);
+        for (const propName of MONITORED_DIALOG_PROPS) {
+          const prop = properties.get(propName);
+          if (prop && isRawStringNode(prop.value)) {
+            context.report({
+              node: prop.value,
+              messageId: 'untranslatedDialogOption',
+              data: { prop: propName }
             });
           }
         }
@@ -137,15 +234,56 @@ const noUntranslatedString = createRule({
         ) {
           return;
         }
-        const propName = left.property.name;
+
+        // element.title = STRING  or  element.ariaLabel = STRING
         if (
-          MONITORED_ASSIGNMENT_PROPS.includes(propName) &&
+          MONITORED_ASSIGNMENT_PROPS.includes(left.property.name) &&
           isRawStringNode(node.right)
         ) {
           context.report({
             node: node.right,
             messageId: 'untranslatedPropertyAssign',
-            data: { prop: propName }
+            data: { prop: left.property.name }
+          });
+          return;
+        }
+
+        // *.title.label = STRING  or  *.title.caption = STRING
+        if (
+          (left.property.name === 'label' || left.property.name === 'caption') &&
+          left.object.type === 'MemberExpression' &&
+          !left.object.computed &&
+          left.object.property.type === 'Identifier' &&
+          left.object.property.name === 'title' &&
+          isRawStringNode(node.right)
+        ) {
+          context.report({
+            node: node.right,
+            messageId: 'untranslatedTitleProp',
+            data: { prop: left.property.name }
+          });
+        }
+      },
+
+      // Raw text between JSX tags: <span>Untranslated text</span>
+      JSXText(node) {
+        if (node.value.trim().length > 0) {
+          context.report({
+            node,
+            messageId: 'untranslatedJsxText'
+          });
+        }
+      },
+
+      // String literal inside JSX expression: <span>{'raw string'}</span>
+      JSXExpressionContainer(node) {
+        if (node.expression.type === 'JSXEmptyExpression') {
+          return;
+        }
+        if (isRawStringNode(node.expression)) {
+          context.report({
+            node: node.expression,
+            messageId: 'untranslatedJsxText'
           });
         }
       }

--- a/tests/jupyter-no-untranslated-string.test.ts
+++ b/tests/jupyter-no-untranslated-string.test.ts
@@ -18,6 +18,7 @@ const ruleTester = new RuleTester({
 
 ruleTester.run('no-untranslated-string', noUntranslatedString, {
   valid: [
+    // --- addCommand: translated values ---
     {
       code: `
         commands.addCommand('file-download', {
@@ -39,11 +40,11 @@ ruleTester.run('no-untranslated-string', noUntranslatedString, {
         commands.addCommand('file-download', {
           label: trans.__('Save'),
           caption: trans.__('Save notebook'),
-          description: trans.__('Save the current notebook'),
           execute: () => {}
         });
       `
     },
+    // --- addCommand: non-literal values ---
     {
       code: `
         commands.addCommand('file-download', {
@@ -52,6 +53,7 @@ ruleTester.run('no-untranslated-string', noUntranslatedString, {
         });
       `
     },
+    // --- addCommand: empty strings ---
     {
       code: `
         commands.addCommand('file-download', {
@@ -60,49 +62,42 @@ ruleTester.run('no-untranslated-string', noUntranslatedString, {
         });
       `
     },
-    
-    // setAttribute: translated values are OK
+    // --- setAttribute: translated values ---
+    { code: `el.setAttribute('aria-label', trans.__('main sidebar'));` },
+    { code: `el.setAttribute('title', trans.__('Close Tab'));` },
+    // --- direct property assignment: translated ---
+    { code: `el.title = trans.__('Close Tab');` },
+    { code: `el.ariaLabel = trans.__('Search results');` },
+    // --- title.label / title.caption: translated ---
+    { code: `this.title.label = trans.__('Source');` },
+    { code: `this.title.caption = trans.__('Source file');` },
+    // --- showDialog: translated options ---
     {
-      code: `el.setAttribute('aria-label', trans.__('main sidebar'));`
+      code: `
+        showDialog({
+          title: trans.__('Build Recommended'),
+          body,
+          buttons: [Dialog.cancelButton(), Dialog.okButton({ label: trans.__('Build') })]
+        });
+      `
     },
+    // --- new Dialog: translated options ---
     {
-      code: `el.setAttribute('title', trans.__('Close Tab'));`
+      code: `
+        const dialog = new Dialog({
+          title: trans.__('Select Kernel'),
+          body,
+          buttons
+        });
+      `
     },
-    {
-      code: `el.setAttribute('data-custom', 'some-value');`
-    },
-    {
-      code: `el.setAttribute('class', 'jp-widget');`
-    },
-    {
-      code: `el.setAttribute('aria-label', labelVar);`
-    },
-    {
-      code: `el.setAttribute('title', '');`
-    },
-    // property assignment: translated values are OK
-    {
-      code: `el.title = trans.__('Close Tab');`
-    },
-    {
-      code: `el.ariaLabel = trans.__('Search results');`
-    },
-    {
-      code: `el.id = 'my-element';`
-    },
-    // Variable is OK
-    {
-      code: `el.title = titleVar;`
-    },
-    {
-      code: `el['title'] = 'Close Tab';`
-    },
-    {
-      code: `el.title += 'Close Tab';`
-    }
+
+    // --- Dialog button builders: translated label ---
+    { code: `Dialog.okButton({ label: trans.__('Build') });` },
   ],
 
   invalid: [
+    // --- addCommand: raw string in label ---
     {
       code: `
         commands.addCommand('file-download', {
@@ -112,6 +107,7 @@ ruleTester.run('no-untranslated-string', noUntranslatedString, {
       `,
       errors: [{ messageId: 'untranslatedCommandProp', data: { prop: 'label' } }]
     },
+    // --- addCommand: raw string in caption ---
     {
       code: `
         commands.addCommand('file-save', {
@@ -123,17 +119,19 @@ ruleTester.run('no-untranslated-string', noUntranslatedString, {
         { messageId: 'untranslatedCommandProp', data: { prop: 'caption' } }
       ]
     },
+    // --- addCommand: raw string in usage ---
     {
       code: `
         commands.addCommand('filebrowser:open', {
-          description: 'Opens the file browser',
+          usage: 'Opens the file browser',
           execute: () => {}
         });
       `,
       errors: [
-        { messageId: 'untranslatedCommandProp', data: { prop: 'description' } }
+        { messageId: 'untranslatedCommandProp', data: { prop: 'usage' } }
       ]
     },
+    // --- addCommand: concise arrow returning raw string ---
     {
       code: `
         commands.addCommand(CommandIDs.close, {
@@ -143,6 +141,7 @@ ruleTester.run('no-untranslated-string', noUntranslatedString, {
       `,
       errors: [{ messageId: 'untranslatedCommandProp', data: { prop: 'label' } }]
     },
+    // --- addCommand: template literal ---
     {
       code: `
         commands.addCommand('file-download', {
@@ -152,50 +151,115 @@ ruleTester.run('no-untranslated-string', noUntranslatedString, {
       `,
       errors: [{ messageId: 'untranslatedCommandProp', data: { prop: 'label' } }]
     },
-   
-    // setAttribute: raw string with aria-label
+    // --- setAttribute: raw string with aria-label ---
     {
       code: `el.setAttribute('aria-label', 'main sidebar');`,
       errors: [
         { messageId: 'untranslatedSetAttribute', data: { attr: 'aria-label' } }
       ]
     },
+    // --- setAttribute: raw string with title ---
     {
       code: `el.setAttribute('title', 'Close Tab');`,
       errors: [
         { messageId: 'untranslatedSetAttribute', data: { attr: 'title' } }
       ]
     },
-    // setAttribute: raw string with aria-descriptin
-    {
-      code: `el.setAttribute('aria-description', 'Describes the widget');`,
-      errors: [
-        {
-          messageId: 'untranslatedSetAttribute',
-          data: { attr: 'aria-description' }
-        }
-      ]
-    },
-    // setAttribute: template literal with no expressions
+    // --- setAttribute: template literal ---
     {
       code: `el.setAttribute('aria-label', \`main sidebar\`);`,
       errors: [
         { messageId: 'untranslatedSetAttribute', data: { attr: 'aria-label' } }
       ]
     },
-    // Property assignment: raw string to title
+
+    // --- direct property assignment: raw string to title ---
     {
       code: `el.title = 'Close Tab';`,
       errors: [
         { messageId: 'untranslatedPropertyAssign', data: { prop: 'title' } }
       ]
     },
-    // Property assignment: raw string to ariaLabel
+    // --- direct property assignment: raw string to ariaLabel ---
     {
       code: `el.ariaLabel = 'Search results';`,
       errors: [
         { messageId: 'untranslatedPropertyAssign', data: { prop: 'ariaLabel' } }
       ]
+    },
+    // --- title.label: raw string ---
+    {
+      code: `this.title.label = 'Source';`,
+      errors: [
+        { messageId: 'untranslatedTitleProp', data: { prop: 'label' } }
+      ]
+    },
+    // --- title.label: arbitrary receiver ---
+    {
+      code: `widget.title.label = 'My Panel';`,
+      errors: [
+        { messageId: 'untranslatedTitleProp', data: { prop: 'label' } }
+      ]
+    },
+    // --- showDialog: raw string title ---
+    {
+      code: `showDialog({ title: 'Confirm' });`,
+      errors: [
+        { messageId: 'untranslatedDialogOption', data: { prop: 'title' } }
+      ]
+    },
+    // --- showDialog: raw string body ---
+    {
+      code: `showDialog({ title: trans.__('Build'), body: 'Are you sure?' });`,
+      errors: [
+        { messageId: 'untranslatedDialogOption', data: { prop: 'body' } }
+      ]
+    },
+    // --- new Dialog: raw string title ---
+    {
+      code: `const d = new Dialog({ title: 'Select Kernel', body });`,
+      errors: [
+        { messageId: 'untranslatedDialogOption', data: { prop: 'title' } }
+      ]
+    },
+
+    // --- Dialog button builders: raw string label ---
+    {
+      code: `Dialog.okButton({ label: 'Build' });`,
+      errors: [{ messageId: 'untranslatedDialogButtonLabel' }]
+    },
+  ]
+});
+
+// JSX tests require a separate tester with JSX parsing enabled
+const jsxRuleTester = new RuleTester({
+  languageOptions: {
+    parser: require('@typescript-eslint/parser'),
+    parserOptions: {
+      ecmaVersion: 2020,
+      sourceType: 'module',
+      ecmaFeatures: { jsx: true }
+    }
+  }
+});
+
+jsxRuleTester.run('no-untranslated-string (JSX)', noUntranslatedString, {
+  valid: [
+    // --- JSX: translated expression ---
+    { code: `const el = <span>{trans.__('Error message:')}</span>;` },
+    { code: `const el = (\n  <div>\n    <span>{trans.__('Label')}</span>\n  </div>\n);` }
+  ],
+
+  invalid: [
+    // --- JSXText: raw text content ---
+    {
+      code: `const el = <span>Hello world</span>;`,
+      errors: [{ messageId: 'untranslatedJsxText' }]
+    },
+    // --- JSXExpressionContainer: raw string literal ---
+    {
+      code: `const el = <span>{'raw string'}</span>;`,
+      errors: [{ messageId: 'untranslatedJsxText' }]
     }
   ]
 });

--- a/tests/jupyter-no-untranslated-string.test.ts
+++ b/tests/jupyter-no-untranslated-string.test.ts
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import noUntranslatedString from '../src/rules/no-untranslated-string';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parser: require('@typescript-eslint/parser'),
+    parserOptions: {
+      ecmaVersion: 2020,
+      sourceType: 'module'
+    }
+  }
+});
+
+ruleTester.run('no-untranslated-string', noUntranslatedString, {
+  valid: [
+    {
+      code: `
+        commands.addCommand('file-download', {
+          label: trans.__('Download'),
+          execute: () => {}
+        });
+      `
+    },
+    {
+      code: `
+        commands.addCommand('file-download', {
+          label: () => trans.__('Download'),
+          execute: () => {}
+        });
+      `
+    },
+    {
+      code: `
+        commands.addCommand('file-download', {
+          label: trans.__('Save'),
+          caption: trans.__('Save notebook'),
+          description: trans.__('Save the current notebook'),
+          execute: () => {}
+        });
+      `
+    },
+    {
+      code: `
+        commands.addCommand('file-download', {
+          label: someVar,
+          execute: () => {}
+        });
+      `
+    },
+    {
+      code: `
+        commands.addCommand('file-download', {
+          label: '',
+          execute: () => {}
+        });
+      `
+    },
+    
+    // setAttribute: translated values are OK
+    {
+      code: `el.setAttribute('aria-label', trans.__('main sidebar'));`
+    },
+    {
+      code: `el.setAttribute('title', trans.__('Close Tab'));`
+    },
+    {
+      code: `el.setAttribute('data-custom', 'some-value');`
+    },
+    {
+      code: `el.setAttribute('class', 'jp-widget');`
+    },
+    {
+      code: `el.setAttribute('aria-label', labelVar);`
+    },
+    {
+      code: `el.setAttribute('title', '');`
+    },
+    // property assignment: translated values are OK
+    {
+      code: `el.title = trans.__('Close Tab');`
+    },
+    {
+      code: `el.ariaLabel = trans.__('Search results');`
+    },
+    {
+      code: `el.id = 'my-element';`
+    },
+    // Variable is OK
+    {
+      code: `el.title = titleVar;`
+    },
+    {
+      code: `el['title'] = 'Close Tab';`
+    },
+    {
+      code: `el.title += 'Close Tab';`
+    }
+  ],
+
+  invalid: [
+    {
+      code: `
+        commands.addCommand('file-download', {
+          label: 'Download',
+          execute: () => {}
+        });
+      `,
+      errors: [{ messageId: 'untranslatedCommandProp', data: { prop: 'label' } }]
+    },
+    {
+      code: `
+        commands.addCommand('file-save', {
+          caption: 'Save file',
+          execute: () => {}
+        });
+      `,
+      errors: [
+        { messageId: 'untranslatedCommandProp', data: { prop: 'caption' } }
+      ]
+    },
+    {
+      code: `
+        commands.addCommand('filebrowser:open', {
+          description: 'Opens the file browser',
+          execute: () => {}
+        });
+      `,
+      errors: [
+        { messageId: 'untranslatedCommandProp', data: { prop: 'description' } }
+      ]
+    },
+    {
+      code: `
+        commands.addCommand(CommandIDs.close, {
+          label: () => 'Close Tab',
+          execute: () => {}
+        });
+      `,
+      errors: [{ messageId: 'untranslatedCommandProp', data: { prop: 'label' } }]
+    },
+    {
+      code: `
+        commands.addCommand('file-download', {
+          label: \`Download\`,
+          execute: () => {}
+        });
+      `,
+      errors: [{ messageId: 'untranslatedCommandProp', data: { prop: 'label' } }]
+    },
+   
+    // setAttribute: raw string with aria-label
+    {
+      code: `el.setAttribute('aria-label', 'main sidebar');`,
+      errors: [
+        { messageId: 'untranslatedSetAttribute', data: { attr: 'aria-label' } }
+      ]
+    },
+    {
+      code: `el.setAttribute('title', 'Close Tab');`,
+      errors: [
+        { messageId: 'untranslatedSetAttribute', data: { attr: 'title' } }
+      ]
+    },
+    // setAttribute: raw string with aria-descriptin
+    {
+      code: `el.setAttribute('aria-description', 'Describes the widget');`,
+      errors: [
+        {
+          messageId: 'untranslatedSetAttribute',
+          data: { attr: 'aria-description' }
+        }
+      ]
+    },
+    // setAttribute: template literal with no expressions
+    {
+      code: `el.setAttribute('aria-label', \`main sidebar\`);`,
+      errors: [
+        { messageId: 'untranslatedSetAttribute', data: { attr: 'aria-label' } }
+      ]
+    },
+    // Property assignment: raw string to title
+    {
+      code: `el.title = 'Close Tab';`,
+      errors: [
+        { messageId: 'untranslatedPropertyAssign', data: { prop: 'title' } }
+      ]
+    },
+    // Property assignment: raw string to ariaLabel
+    {
+      code: `el.ariaLabel = 'Search results';`,
+      errors: [
+        { messageId: 'untranslatedPropertyAssign', data: { prop: 'ariaLabel' } }
+      ]
+    }
+  ]
+});

--- a/website/docs/rules/index.md
+++ b/website/docs/rules/index.md
@@ -5,6 +5,7 @@ This section documents all rules currently provided by `eslint-plugin-jupyter`.
 ## Available rules
 
 - [command-described-by](./command-described-by)
+- [no-untranslated-string](./no-untranslated-string)
 - [plugin-activation-args](./plugin-activation-args)
 - [plugin-description](./plugin-description)
 
@@ -18,6 +19,7 @@ The plugin ships with a recommended configuration that enables all current rules
 | --- | --- |
 | [jupyter/plugin-activation-args](./plugin-activation-args) | `error` |
 | [jupyter/command-described-by](./command-described-by) | `warn` |
+| [jupyter/no-untranslated-string](./no-untranslated-string) | `warn` |
 | [jupyter/plugin-description](./plugin-description) | `warn` |
 
 These defaults are the same in both `jupyterPlugin.configs.recommended` (flat config) and `plugin:@jupyter/eslint-plugin/recommended-legacy`.

--- a/website/docs/rules/no-untranslated-string.md
+++ b/website/docs/rules/no-untranslated-string.md
@@ -8,62 +8,88 @@ The rule reports raw string literals (and template literals without expressions)
 
 ### 1. `commands.addCommand()` properties
 
-The `label`, `caption`, and `description` properties of a command registration must not contain bare string literals. Concise arrow functions that return a raw string (e.g. `() => 'string'`) are also flagged.
-
-#### Incorrect
+The `label`, `caption`, and `usage` properties must not contain bare strings. Concise arrow functions returning a raw string (e.g. `() => 'string'`) are also flagged.
 
 ```ts
-commands.addCommand('file-download', {
-  label: 'Download',
-  caption: 'Download the file',
-  execute: () => { /* ... */ }
-});
+// Incorrect
+commands.addCommand('file-download', { label: 'Download' });
+
+// Correct
+commands.addCommand('file-download', { label: trans.__('Download') });
+commands.addCommand('file-download', { label: () => trans.__('Download') });
 ```
-
-#### Correct
-
-```ts
-commands.addCommand('file-download', {
-  label: trans.__('Download'),
-  caption: trans.__('Download the file'),
-  execute: () => { /* ... */ }
-});
-```
-
----
 
 ### 2. `element.setAttribute()` with accessibility attributes
 
-The second argument of `setAttribute` must not be a raw string when the attribute is `aria-label`, `aria-description`, or `title`.
-
-#### Incorrect
+Applies to `aria-label`, `aria-description`, and `title`.
 
 ```ts
+// Incorrect
 node.setAttribute('aria-label', 'main sidebar');
-```
 
-#### Correct
-
-```ts
+// Correct
 node.setAttribute('aria-label', trans.__('main sidebar'));
 ```
 
----
-
 ### 3. Direct assignment to `title` and `ariaLabel`
 
-Assigning a raw string literal to `element.title` or `element.ariaLabel` is flagged.
-
-#### Incorrect
-
 ```ts
+// Incorrect
 element.title = 'Close Tab';
+element.ariaLabel = 'Search results';
+
+// Correct
+element.title = trans.__('Close Tab');
+element.ariaLabel = trans.__('Search results');
 ```
 
-#### Correct
+### 4. Lumino widget title properties
+
+Applies to `*.title.label` and `*.title.caption` assignments.
 
 ```ts
-element.title = trans.__('Close Tab');
+// Incorrect
+this.title.label = 'Source';
+
+// Correct
+this.title.label = trans.__('Source');
+```
+
+### 5. `showDialog()` and `new Dialog()` options
+
+The `title` and `body` options must not be raw strings.
+
+```ts
+// Incorrect
+showDialog({ title: 'Confirm', body: 'Are you sure?' });
+
+// Correct
+showDialog({ title: trans.__('Confirm'), body: trans.__('Are you sure?') });
+```
+
+### 6. Dialog button builder labels
+
+Applies to `Dialog.okButton`, `Dialog.cancelButton`, `Dialog.warnButton`, and `Dialog.errorButton`.
+
+```ts
+// Incorrect
+Dialog.okButton({ label: 'Build' });
+
+// Correct
+Dialog.okButton({ label: trans.__('Build') });
+```
+
+### 7. JSX text content
+
+Raw text between JSX tags and string literals inside `{...}` expressions are flagged.
+
+```tsx
+// Incorrect
+const el = <span>Error message:</span>;
+const el = <span>{'raw string'}</span>;
+
+// Correct
+const el = <span>{trans.__('Error message:')}</span>;
 ```
 
 ## Options

--- a/website/docs/rules/no-untranslated-string.md
+++ b/website/docs/rules/no-untranslated-string.md
@@ -1,0 +1,71 @@
+# `jupyter/no-untranslated-string`
+
+Require user-facing string literals to be wrapped in a translation call such as `trans.__()`.
+
+## Rule details
+
+The rule reports raw string literals (and template literals without expressions) in the following positions:
+
+### 1. `commands.addCommand()` properties
+
+The `label`, `caption`, and `description` properties of a command registration must not contain bare string literals. Concise arrow functions that return a raw string (e.g. `() => 'string'`) are also flagged.
+
+#### Incorrect
+
+```ts
+commands.addCommand('file-download', {
+  label: 'Download',
+  caption: 'Download the file',
+  execute: () => { /* ... */ }
+});
+```
+
+#### Correct
+
+```ts
+commands.addCommand('file-download', {
+  label: trans.__('Download'),
+  caption: trans.__('Download the file'),
+  execute: () => { /* ... */ }
+});
+```
+
+---
+
+### 2. `element.setAttribute()` with accessibility attributes
+
+The second argument of `setAttribute` must not be a raw string when the attribute is `aria-label`, `aria-description`, or `title`.
+
+#### Incorrect
+
+```ts
+node.setAttribute('aria-label', 'main sidebar');
+```
+
+#### Correct
+
+```ts
+node.setAttribute('aria-label', trans.__('main sidebar'));
+```
+
+---
+
+### 3. Direct assignment to `title` and `ariaLabel`
+
+Assigning a raw string literal to `element.title` or `element.ariaLabel` is flagged.
+
+#### Incorrect
+
+```ts
+element.title = 'Close Tab';
+```
+
+#### Correct
+
+```ts
+element.title = trans.__('Close Tab');
+```
+
+## Options
+
+This rule has no options.


### PR DESCRIPTION
### References https://github.com/jupyterlab/jupyterlab/issues/17763#issuecomment-3368400976

### Description
Add a new rule `jupyter/no-untranslated-string` which require user-facing string literals to be wrapped in a translation call.

The rule reports raw string literals (and template literals without expressions) in the following positions:

#### 1. `commands.addCommand()` properties

The `label`, `caption`, and `description` properties of a command registration must not contain bare string literals.

#### 2. `element.setAttribute()` with accessibility attributes

The second argument of `setAttribute` must not be a raw string when the attribute is `aria-label`, `aria-description`, or `title`.

#### 3. Direct assignment to `title` and `ariaLabel`

Assigning a raw string literal to `element.title` or `element.ariaLabel` is flagged.


Feedbacks on the approach is welcome.