### PR TITLE
Add `jupyter/no-translation-concatenation`

### DIFF
--- a/eslint.downstream.config.mjs
+++ b/eslint.downstream.config.mjs
@@ -29,7 +29,8 @@ export default [
     rules: {
       'jupyter/command-described-by': 'error',
       'jupyter/plugin-activation-args': 'error',
-      'jupyter/plugin-description': 'error'
+      'jupyter/plugin-description': 'error',
+      'jupyter/no-translation-concatenation': 'error'
     },
     languageOptions: {
       parser: resolvedParser,

--- a/eslint.downstream.config.mjs
+++ b/eslint.downstream.config.mjs
@@ -31,7 +31,7 @@ export default [
       'jupyter/no-untranslated-string': 'error',
       'jupyter/plugin-activation-args': 'error',
       'jupyter/plugin-description': 'error',
-      'jupyter/no-translation-concatenation': 'error'
+      'jupyter/no-translation-concatenation': 'error',
       'jupyter/token-format': 'error'
     },
     languageOptions: {
@@ -60,6 +60,7 @@ export default [
       'jupyter/no-untranslated-string': 'error',
       'jupyter/plugin-activation-args': 'error',
       'jupyter/plugin-description': 'error',
+      'jupyter/no-translation-concatenation': 'error',
       'jupyter/token-format': 'error'
     },
     languageOptions: {
@@ -85,8 +86,11 @@ export default [
     },
     rules: {
       'jupyter/command-described-by': 'error',
+      'jupyter/no-untranslated-string': 'error',
       'jupyter/plugin-activation-args': 'error',
-      'jupyter/plugin-description': 'error'
+      'jupyter/plugin-description': 'error',
+      'jupyter/no-translation-concatenation': 'error',
+      'jupyter/token-format': 'error'
     },
     languageOptions: {
       parser: resolvedParser,

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ const plugin = {
     'plugin-activation-args': pluginActivationArgs,
     'command-described-by': commandDescribedBy,
     'plugin-description': pluginDescription,
-    'no-translation-concatenation': noTranslationConcatenation
+    'no-translation-concatenation': noTranslationConcatenation,
     'no-untranslated-string': noUntranslatedString
   },
   configs: {
@@ -24,7 +24,7 @@ const plugin = {
         'jupyter/plugin-activation-args': 'error',
         'jupyter/command-described-by': 'warn',
         'jupyter/plugin-description': 'warn',
-        'jupyter/no-translation-concatenation': 'error'
+        'jupyter/no-translation-concatenation': 'error',
         'jupyter/no-untranslated-string': 'warn'
       }
     },
@@ -33,7 +33,7 @@ const plugin = {
         'jupyter/plugin-activation-args': 'error',
         'jupyter/command-described-by': 'warn',
         'jupyter/plugin-description': 'warn',
-        'jupyter/no-translation-concatenation': 'error'
+        'jupyter/no-translation-concatenation': 'error',
         'jupyter/no-untranslated-string': 'warn'
       }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,12 +6,14 @@
 import pluginActivationArgs from './rules/plugin-activation-args';
 import commandDescribedBy from './rules/command-described-by';
 import pluginDescription from './rules/plugin-description';
+import noTranslationConcatenation from './rules/no-translation-concatenation';
 
 const plugin = {
   rules: {
     'plugin-activation-args': pluginActivationArgs,
     'command-described-by': commandDescribedBy,
-    'plugin-description': pluginDescription
+    'plugin-description': pluginDescription,
+    'no-translation-concatenation': noTranslationConcatenation
   },
   configs: {
     recommended: {
@@ -19,14 +21,16 @@ const plugin = {
       rules: {
         'jupyter/plugin-activation-args': 'error',
         'jupyter/command-described-by': 'warn',
-        'jupyter/plugin-description': 'warn'
+        'jupyter/plugin-description': 'warn',
+        'jupyter/no-translation-concatenation': 'error'
       }
     },
     'recommended-legacy': {
       rules: {
         'jupyter/plugin-activation-args': 'error',
         'jupyter/command-described-by': 'warn',
-        'jupyter/plugin-description': 'warn'
+        'jupyter/plugin-description': 'warn',
+        'jupyter/no-translation-concatenation': 'error'
       }
     }
   }

--- a/src/rules/no-translation-concatenation.ts
+++ b/src/rules/no-translation-concatenation.ts
@@ -9,14 +9,28 @@ import { TSESTree } from '@typescript-eslint/types';
 const TRANS_METHOD = '__';
 
 /**
- * Returns the first `+` BinaryExpression found anywhere in the subtree,
- * or null if none exists.
+ * Returns true when every leaf of a `+` expression tree is a string literal.
+ * Such concatenation is static and translation tools can handle it.
+ */
+function isAllStringLiterals(node: TSESTree.Node): boolean {
+  if (node.type === 'Literal') {
+    return typeof node.value === 'string';
+  }
+  if (node.type === 'BinaryExpression' && node.operator === '+') {
+    return isAllStringLiterals(node.left) && isAllStringLiterals(node.right);
+  }
+  return false;
+}
+
+/**
+ * Returns the first `+` BinaryExpression found anywhere in the subtree that
+ * involves a non-literal operand, or null if none exists.
  */
 function findConcatenation(
   node: TSESTree.Node
 ): TSESTree.BinaryExpression | null {
   if (node.type === 'BinaryExpression' && node.operator === '+') {
-    return node;
+    return isAllStringLiterals(node) ? null : node;
   }
   const record = node as unknown as Record<string, unknown>;
   for (const key of Object.keys(record)) {

--- a/src/rules/no-translation-concatenation.ts
+++ b/src/rules/no-translation-concatenation.ts
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import { createRule } from '../utils/create-rule';
+import { TSESTree } from '@typescript-eslint/types';
+
+const TRANS_METHOD = '__';
+
+/**
+ * Returns true if the node is a recognized JupyterLab translation bundle:
+ * trans | this.trans | this._trans | props.trans | this.props.trans
+ * Refer jupyterlab.readthedocs.io/en/stable/extension/internationalization.html#rules
+ */
+function isTransBundle(node: TSESTree.Node): boolean {
+  if (node.type === 'Identifier') {
+    return node.name === 'trans';
+  }
+
+  if (node.type === 'MemberExpression' && !node.computed) {
+    const prop = node.property;
+    if (prop.type !== 'Identifier') {
+      return false;
+    }
+
+    // this.trans / this._trans
+    if (node.object.type === 'ThisExpression') {
+      return prop.name === 'trans' || prop.name === '_trans';
+    }
+
+    // props.trans
+    if (
+      prop.name === 'trans' &&
+      node.object.type === 'Identifier' &&
+      node.object.name === 'props'
+    ) {
+      return true;
+    }
+
+    // this.props.trans
+    if (
+      prop.name === 'trans' &&
+      node.object.type === 'MemberExpression' &&
+      !node.object.computed &&
+      node.object.object.type === 'ThisExpression' &&
+      node.object.property.type === 'Identifier' &&
+      node.object.property.name === 'props'
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+const noTranslationConcatenation = createRule({
+  name: 'no-translation-concatenation',
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Forbid string concatenation inside translation wrapper calls',
+      url: 'https://eslint-plugin.readthedocs.io/en/latest/rules/no-translation-concatenation/'
+    },
+    messages: {
+      noConcatenation:
+        'Do not use string concatenation inside translation wrappers. Use a placeholder instead, e.g. trans.__("Hello %1", name).'
+    },
+    schema: []
+  },
+  defaultOptions: [],
+
+  create(context) {
+    return {
+      CallExpression(node) {
+        if (node.callee.type !== 'MemberExpression') {
+          return;
+        }
+        const callee = node.callee;
+        if (callee.computed || callee.property.type !== 'Identifier') {
+          return;
+        }
+        if (callee.property.name !== TRANS_METHOD) {
+          return;
+        }
+        if (!isTransBundle(callee.object)) {
+          return;
+        }
+
+        for (const arg of node.arguments) {
+          if (arg.type === 'BinaryExpression' && arg.operator === '+') {
+            context.report({ node: arg, messageId: 'noConcatenation' });
+          }
+        }
+      }
+    };
+  }
+});
+
+export = noTranslationConcatenation;

--- a/src/rules/no-translation-concatenation.ts
+++ b/src/rules/no-translation-concatenation.ts
@@ -9,9 +9,42 @@ import { TSESTree } from '@typescript-eslint/types';
 const TRANS_METHOD = '__';
 
 /**
+ * Returns the first `+` BinaryExpression found anywhere in the subtree,
+ * or null if none exists.
+ */
+function findConcatenation(
+  node: TSESTree.Node
+): TSESTree.BinaryExpression | null {
+  if (node.type === 'BinaryExpression' && node.operator === '+') {
+    return node;
+  }
+  const record = node as unknown as Record<string, unknown>;
+  for (const key of Object.keys(record)) {
+    if (key === 'type' || key === 'loc' || key === 'range' || key === 'parent') {
+      continue;
+    }
+    const child = record[key];
+    if (child && typeof child === 'object') {
+      if (Array.isArray(child)) {
+        for (const item of child) {
+          if (item && typeof (item as TSESTree.Node).type === 'string') {
+            const found = findConcatenation(item as TSESTree.Node);
+            if (found) return found;
+          }
+        }
+      } else if (typeof (child as TSESTree.Node).type === 'string') {
+        const found = findConcatenation(child as TSESTree.Node);
+        if (found) return found;
+      }
+    }
+  }
+  return null;
+}
+
+/**
  * Returns true if the node is a recognized JupyterLab translation bundle:
  * trans | this.trans | this._trans | props.trans | this.props.trans
- * Refer jupyterlab.readthedocs.io/en/stable/extension/internationalization.html#rules
+ * See jupyterlab.readthedocs.io/en/stable/extension/internationalization.html#rules
  */
 function isTransBundle(node: TSESTree.Node): boolean {
   if (node.type === 'Identifier') {
@@ -88,10 +121,13 @@ const noTranslationConcatenation = createRule({
           return;
         }
 
-        for (const arg of node.arguments) {
-          if (arg.type === 'BinaryExpression' && arg.operator === '+') {
-            context.report({ node: arg, messageId: 'noConcatenation' });
-          }
+        const message = node.arguments[0];
+        if (!message) {
+          return;
+        }
+        const concat = findConcatenation(message);
+        if (concat) {
+          context.report({ node: concat, messageId: 'noConcatenation' });
         }
       }
     };

--- a/tests/jupyter-no-translation-concatenation.test.ts
+++ b/tests/jupyter-no-translation-concatenation.test.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import noTranslationConcatenation from '../src/rules/no-translation-concatenation';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parser: require('@typescript-eslint/parser'),
+    parserOptions: {
+      ecmaVersion: 2020,
+      sourceType: 'module'
+    }
+  }
+});
+
+ruleTester.run('no-translation-concatenation', noTranslationConcatenation, {
+  valid: [
+    { code: `trans.__("Delete %1", fileName)` },
+    { code: `this.trans.__("Hello")` },
+    { code: `this._trans.__("Hello %1", x)` },
+    { code: `this.props.trans.__("Hello")` },
+    { code: `props.trans.__("Hello %1", x)` },
+  ],
+
+  invalid: [
+    {
+      code: `trans.__("Delete " + fileName)`,
+      errors: [{ messageId: 'noConcatenation' }]
+    },
+    {
+      code: `this.trans.__("Hello " + name)`,
+      errors: [{ messageId: 'noConcatenation' }]
+    },
+    {
+      code: `this._trans.__("x" + y)`,
+      errors: [{ messageId: 'noConcatenation' }]
+    },
+    {
+      code: `this.props.trans.__("a" + "b")`,
+      errors: [{ messageId: 'noConcatenation' }]
+    },
+    {
+      code: `props.trans.__("a" + "b")`,
+      errors: [{ messageId: 'noConcatenation' }]
+    }
+  ]
+});

--- a/tests/jupyter-no-translation-concatenation.test.ts
+++ b/tests/jupyter-no-translation-concatenation.test.ts
@@ -24,6 +24,10 @@ ruleTester.run('no-translation-concatenation', noTranslationConcatenation, {
     { code: `this.props.trans.__("Hello")` },
     { code: `props.trans.__("Hello %1", x)` },
     { code: `trans.__('Total %1', a + b)` },
+    // Pure string literal concatenation is static — translation tools handle it
+    { code: `trans.__('Part 1 of long message.\\n' + 'Part 2 of long message.\\n')` },
+    { code: `this.props.trans.__("a" + "b")` },
+    { code: `props.trans.__("a" + "b")` },
   ],
 
   invalid: [
@@ -37,14 +41,6 @@ ruleTester.run('no-translation-concatenation', noTranslationConcatenation, {
     },
     {
       code: `this._trans.__("x" + y)`,
-      errors: [{ messageId: 'noConcatenation' }]
-    },
-    {
-      code: `this.props.trans.__("a" + "b")`,
-      errors: [{ messageId: 'noConcatenation' }]
-    },
-    {
-      code: `props.trans.__("a" + "b")`,
       errors: [{ messageId: 'noConcatenation' }]
     },
     {

--- a/tests/jupyter-no-translation-concatenation.test.ts
+++ b/tests/jupyter-no-translation-concatenation.test.ts
@@ -23,6 +23,7 @@ ruleTester.run('no-translation-concatenation', noTranslationConcatenation, {
     { code: `this._trans.__("Hello %1", x)` },
     { code: `this.props.trans.__("Hello")` },
     { code: `props.trans.__("Hello %1", x)` },
+    { code: `trans.__('Total %1', a + b)` },
   ],
 
   invalid: [
@@ -44,6 +45,10 @@ ruleTester.run('no-translation-concatenation', noTranslationConcatenation, {
     },
     {
       code: `props.trans.__("a" + "b")`,
+      errors: [{ messageId: 'noConcatenation' }]
+    },
+    {
+      code: `trans.__(("Delete " + fileName).trim())`,
       errors: [{ messageId: 'noConcatenation' }]
     }
   ]

--- a/website/docs/rules/index.md
+++ b/website/docs/rules/index.md
@@ -5,6 +5,7 @@ This section documents all rules currently provided by `eslint-plugin-jupyter`.
 ## Available rules
 
 - [command-described-by](./command-described-by)
+- [no-translation-concatenation](./no-translation-concatenation)
 - [plugin-activation-args](./plugin-activation-args)
 - [plugin-description](./plugin-description)
 
@@ -19,6 +20,7 @@ The plugin ships with a recommended configuration that enables all current rules
 | [jupyter/plugin-activation-args](./plugin-activation-args) | `error` |
 | [jupyter/command-described-by](./command-described-by) | `warn` |
 | [jupyter/plugin-description](./plugin-description) | `warn` |
+| [jupyter/no-translation-concatenation](./no-translation-concatenation) | `error` |
 
 These defaults are the same in both `jupyterPlugin.configs.recommended` (flat config) and `plugin:@jupyter/eslint-plugin/recommended-legacy`.
 

--- a/website/docs/rules/no-translation-concatenation.md
+++ b/website/docs/rules/no-translation-concatenation.md
@@ -1,0 +1,34 @@
+# `jupyter/no-translation-concatenation`
+
+Forbid string concatenation inside JupyterLab translation wrapper calls.
+
+## Why
+
+Translation extractors only pick up static string literals in calls like `trans.__("...")`. If you use concatenation (e.g., `"Hello " + name`), the full message becomes dynamic and cannot be extracted, so it never gets translated.
+Refer [Rules](https://jupyterlab.readthedocs.io/en/stable/extension/internationalization.html#rules)
+
+## Rule details
+
+The rule reports any `+` binary expression passed as an argument to a translation method (`__`) called on a recognized translation bundle:
+
+- `trans`
+- `this.trans`
+- `this._trans`
+- `this.props.trans`
+- `props.trans`
+
+## Incorrect
+
+```ts
+this.trans.__("Hello " + userName);
+```
+
+## Correct
+
+```ts
+this.trans.__("Hello %1", userName);
+```
+
+## Options
+
+This rule has no options.

--- a/website/docs/rules/no-translation-concatenation.md
+++ b/website/docs/rules/no-translation-concatenation.md
@@ -5,7 +5,7 @@ Forbid string concatenation inside JupyterLab translation wrapper calls.
 ## Why
 
 Translation extractors only pick up static string literals in calls like `trans.__("...")`. If you use concatenation (e.g., `"Hello " + name`), the full message becomes dynamic and cannot be extracted, so it never gets translated.
-Refer [Rules](https://jupyterlab.readthedocs.io/en/stable/extension/internationalization.html#rules)
+See [Rules](https://jupyterlab.readthedocs.io/en/stable/extension/internationalization.html#rules)
 
 ## Rule details
 

--- a/website/docs/rules/no-translation-concatenation.md
+++ b/website/docs/rules/no-translation-concatenation.md
@@ -4,8 +4,8 @@ Forbid string concatenation inside JupyterLab translation wrapper calls.
 
 ## Why
 
-Translation extractors only pick up static string literals in calls like `trans.__("...")`. If you use concatenation (e.g., `"Hello " + name`), the full message becomes dynamic and cannot be extracted, so it never gets translated.
-See [Rules](https://jupyterlab.readthedocs.io/en/stable/extension/internationalization.html#rules)
+Translation extractors only pick up static string content in calls like `trans.__("...")`. Pure string-literal concatenation (for example, `"a" + "b"`) is still static and allowed, but concatenation with a variable (for example, `"Hello " + name`) is dynamic and cannot be extracted, so it never gets translated.
+See [Rules](https://jupyterlab.readthedocs.io/en/stable/extension/internationalization.html#rules).
 
 ## Rule details
 


### PR DESCRIPTION
### Fixes #43 

### Description
This rule reports any `+` binary expression passed as an argument to a translation method (`__`) called on a recognized translation bundle: