### PR TITLE
Fix `prep-release` workflow

### DIFF
--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -4,7 +4,7 @@ on:
     inputs:
       version_spec:
         description: "New Version Specifier"
-        default: "next"
+        default: "patch"
         required: false
       branch:
         description: "The branch to target"


### PR DESCRIPTION
### Fixes #46 

### Description
Use `patch` instead of `next` in prep release workflow.