### PR TITLE
Improve `@jupyter/no-untranslated-string` for `JSX`

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -44,6 +44,8 @@ jobs:
       - name: Run integration lint check
         run: |
           npx eslint --config eslint.downstream.config.mjs \
+            'jupyterlab/packages/*/src/**/*.ts' \
+            'jupyterlab/packages/*/src/**/*.tsx' \
             --max-warnings=9999
         env:
           NODE_PATH: ./jupyterlab/node_modules
@@ -85,6 +87,8 @@ jobs:
       - name: Run integration lint check
         run: |
           npx eslint --config eslint.downstream.config.mjs \
+            'notebook/packages/*/src/**/*.ts' \
+            'notebook/packages/*/src/**/*.tsx' \
             --max-warnings=9999
         env:
           NODE_PATH: ./notebook/node_modules
@@ -126,6 +130,8 @@ jobs:
       - name: Run integration lint check
         run: |
           npx eslint --config eslint.downstream.config.mjs \
+            'jupyterlite/packages/*/src/**/*.ts' \
+            'jupyterlite/packages/*/src/**/*.tsx' \
             --max-warnings=9999
         env:
           NODE_PATH: ./jupyterlite/node_modules

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -44,7 +44,6 @@ jobs:
       - name: Run integration lint check
         run: |
           npx eslint --config eslint.downstream.config.mjs \
-            'jupyterlab/packages/*/src/**/*.ts' \
             --max-warnings=9999
         env:
           NODE_PATH: ./jupyterlab/node_modules
@@ -86,7 +85,6 @@ jobs:
       - name: Run integration lint check
         run: |
           npx eslint --config eslint.downstream.config.mjs \
-            'notebook/packages/*/src/**/*.ts' \
             --max-warnings=9999
         env:
           NODE_PATH: ./notebook/node_modules
@@ -128,7 +126,6 @@ jobs:
       - name: Run integration lint check
         run: |
           npx eslint --config eslint.downstream.config.mjs \
-            'jupyterlite/packages/*/src/**/*.ts' \
             --max-warnings=9999
         env:
           NODE_PATH: ./jupyterlite/node_modules

--- a/eslint.downstream.config.mjs
+++ b/eslint.downstream.config.mjs
@@ -21,7 +21,10 @@ export default [
   // JupyterLab
   {
     basePath: __dirname,
-    files: ['jupyterlab/packages/*/src/**/*.ts'],
+    files: [
+      'jupyterlab/packages/*/src/**/*.ts',
+      'jupyterlab/packages/*/src/**/*.tsx'
+    ],
     plugins: {
       'jupyter': resolvedPlugin,
       '@typescript-eslint': resolvedTsPlugin
@@ -50,7 +53,10 @@ export default [
   // Notebook
   {
     basePath: __dirname,
-    files: ['notebook/packages/*/src/**/*.ts'],
+    files: [
+      'notebook/packages/*/src/**/*.ts',
+      'notebook/packages/*/src/**/*.tsx'
+    ],
     plugins: {
       'jupyter': resolvedPlugin,
       '@typescript-eslint': resolvedTsPlugin
@@ -79,7 +85,10 @@ export default [
   // Jupyterlite
   {
     basePath: __dirname,
-    files: ['jupyterlite/packages/*/src/**/*.ts'],
+    files: [
+      'jupyterlite/packages/*/src/**/*.ts',
+      'jupyterlite/packages/*/src/**/*.tsx'
+    ],
     plugins: {
       'jupyter': resolvedPlugin,
       '@typescript-eslint': resolvedTsPlugin

--- a/src/rules/no-untranslated-string.ts
+++ b/src/rules/no-untranslated-string.ts
@@ -299,6 +299,24 @@ const noUntranslatedString = createRule({
         }
       },
 
+      // Accessibility attribute with a plain string: <span aria-label="text" />
+      JSXAttribute(node) {
+        if (!node.value || node.value.type === 'JSXExpressionContainer') {
+          return;
+        }
+        const attrName =
+          node.name.type === 'JSXIdentifier' ? node.name.name : null;
+        if (!attrName || !MONITORED_JSX_ATTRS.includes(attrName)) {
+          return;
+        }
+        if (isRawStringNode(node.value)) {
+          context.report({
+            node: node.value,
+            messageId: 'untranslatedJsxText'
+          });
+        }
+      },
+
       // Raw text between JSX tags: <span>Untranslated text</span>
       JSXText(node) {
         if (node.value.trim().length > 0 && (enforcePunctuation || hasLetters(node.value))) {
@@ -332,7 +350,7 @@ const noUntranslatedString = createRule({
         }
         if (isRawStringNode(node.expression)) {
           const value = getRawStringValue(node.expression);
-          if (value !== null && (enforcePunctuation ? value.length > 0 : hasLetters(value))) {
+          if (value !== null && (enforcePunctuation ? value.trim().length > 0 : hasLetters(value))) {
             context.report({
               node: node.expression,
               messageId: 'untranslatedJsxText'

--- a/src/rules/no-untranslated-string.ts
+++ b/src/rules/no-untranslated-string.ts
@@ -122,11 +122,23 @@ const noUntranslatedString = createRule({
       untranslatedJsxText:
         'JSX text content has an untranslated string literal. Wrap it with {trans.__(...)}'
     },
-    schema: []
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          enforcePunctuation: { type: 'boolean' }
+        },
+        additionalProperties: false
+      }
+    ]
   },
-  defaultOptions: [],
+  defaultOptions: [{ enforcePunctuation: false }],
 
   create(context) {
+    const enforcePunctuation =
+      (context.options[0] as { enforcePunctuation?: boolean })
+        ?.enforcePunctuation ?? false;
+
     return {
       CallExpression(node) {
         // Branch A: commands.addCommand(id, { label, caption, usage })
@@ -289,7 +301,7 @@ const noUntranslatedString = createRule({
 
       // Raw text between JSX tags: <span>Untranslated text</span>
       JSXText(node) {
-        if (node.value.trim().length > 0 && hasLetters(node.value)) {
+        if (node.value.trim().length > 0 && (enforcePunctuation || hasLetters(node.value))) {
           context.report({
             node,
             messageId: 'untranslatedJsxText'
@@ -310,7 +322,6 @@ const noUntranslatedString = createRule({
           if (!attrName || !MONITORED_JSX_ATTRS.includes(attrName)) {
             return;
           }
-          // Accessibility attributes: flag any raw string regardless of content
           if (isRawStringNode(node.expression)) {
             context.report({
               node: node.expression,
@@ -321,7 +332,7 @@ const noUntranslatedString = createRule({
         }
         if (isRawStringNode(node.expression)) {
           const value = getRawStringValue(node.expression);
-          if (value !== null && hasLetters(value)) {
+          if (value !== null && (enforcePunctuation ? value.length > 0 : hasLetters(value))) {
             context.report({
               node: node.expression,
               messageId: 'untranslatedJsxText'

--- a/src/rules/no-untranslated-string.ts
+++ b/src/rules/no-untranslated-string.ts
@@ -30,29 +30,11 @@ function getRawStringValue(node: TSESTree.Node): string | null {
 
 /**
  * Returns true if the node is a non-empty raw string literal that should be
- * wrapped in a translation call. Handles:
- *   - String Literal: 'string' or "string"
- *   - TemplateLiteral with no expressions: `string`
- *   - Concise ArrowFunctionExpression whose body is one of the above
+ * wrapped in a translation call.
  */
 function isRawStringNode(node: TSESTree.Node): boolean {
-  if (node.type === 'Literal') {
-    return typeof node.value === 'string' && node.value.length > 0;
-  }
-  if (node.type === 'TemplateLiteral') {
-    if (node.expressions.length > 0) {
-      return false;
-    }
-    const cooked = node.quasis.map(q => q.value.cooked ?? '').join('');
-    return cooked.length > 0;
-  }
-  if (
-    node.type === 'ArrowFunctionExpression' &&
-    node.body.type !== 'BlockStatement'
-  ) {
-    return isRawStringNode(node.body);
-  }
-  return false;
+  const rawValue = getRawStringValue(node);
+  return rawValue !== null && rawValue.trim().length > 0;
 }
 
 function isSetAttributeCall(node: TSESTree.CallExpression): boolean {

--- a/src/rules/no-untranslated-string.ts
+++ b/src/rules/no-untranslated-string.ts
@@ -91,10 +91,11 @@ function isDialogButtonCall(node: TSESTree.CallExpression): boolean {
 }
 
 const MONITORED_COMMAND_PROPS = ['label', 'caption', 'usage'];
-const MONITORED_SET_ATTRIBUTE_ATTRS = ['aria-label', 'aria-description', 'title'];
+const MONITORED_A11Y_ATTRS = ['aria-label', 'aria-description', 'title'];
+const MONITORED_SET_ATTRIBUTE_ATTRS = MONITORED_A11Y_ATTRS;
 const MONITORED_ASSIGNMENT_PROPS = ['title', 'ariaLabel'];
 const MONITORED_DIALOG_PROPS = ['title', 'body'];
-const MONITORED_JSX_ATTRS = ['aria-label', 'aria-description', 'title'];
+const MONITORED_JSX_ATTRS = MONITORED_A11Y_ATTRS;
 
 const noUntranslatedString = createRule({
   name: 'no-untranslated-string',
@@ -316,13 +317,6 @@ const noUntranslatedString = createRule({
               messageId: 'untranslatedJsxText'
             });
           }
-          return;
-        }
-        if (node.expression.type === 'Identifier') {
-          context.report({
-            node: node.expression,
-            messageId: 'untranslatedJsxText'
-          });
           return;
         }
         if (isRawStringNode(node.expression)) {

--- a/src/rules/no-untranslated-string.ts
+++ b/src/rules/no-untranslated-string.ts
@@ -10,11 +10,28 @@ import { createRule } from '../utils/create-rule';
 
 /**
  * Returns true if the node is a non-empty raw string literal that should be
- * wrapped in a translation call. Handles:
- *   - String Literal: 'string' or "string"
- *   - TemplateLiteral with no expressions: `string`
- *   - Concise ArrowFunctionExpression whose body is one of the above
+ * wrapped in a translation call.
  */
+function hasLetters(str: string): boolean {
+  return /\p{L}/u.test(str);
+}
+
+function getRawStringValue(node: TSESTree.Node): string | null {
+  if (node.type === 'Literal' && typeof node.value === 'string') {
+    return node.value;
+  }
+  if (node.type === 'TemplateLiteral' && node.expressions.length === 0) {
+    return node.quasis.map(q => q.value.cooked ?? '').join('');
+  }
+  if (
+    node.type === 'ArrowFunctionExpression' &&
+    node.body.type !== 'BlockStatement'
+  ) {
+    return getRawStringValue(node.body);
+  }
+  return null;
+}
+
 function isRawStringNode(node: TSESTree.Node): boolean {
   if (node.type === 'Literal') {
     return typeof node.value === 'string' && node.value.length > 0;
@@ -74,6 +91,7 @@ const MONITORED_COMMAND_PROPS = ['label', 'caption', 'usage'];
 const MONITORED_SET_ATTRIBUTE_ATTRS = ['aria-label', 'aria-description', 'title'];
 const MONITORED_ASSIGNMENT_PROPS = ['title', 'ariaLabel'];
 const MONITORED_DIALOG_PROPS = ['title', 'body'];
+const MONITORED_JSX_ATTRS = ['aria-label', 'aria-description', 'title'];
 
 const noUntranslatedString = createRule({
   name: 'no-untranslated-string',
@@ -267,7 +285,7 @@ const noUntranslatedString = createRule({
 
       // Raw text between JSX tags: <span>Untranslated text</span>
       JSXText(node) {
-        if (node.value.trim().length > 0) {
+        if (node.value.trim().length > 0 && hasLetters(node.value)) {
           context.report({
             node,
             messageId: 'untranslatedJsxText'
@@ -280,11 +298,38 @@ const noUntranslatedString = createRule({
         if (node.expression.type === 'JSXEmptyExpression') {
           return;
         }
-        if (isRawStringNode(node.expression)) {
+        if (node.parent.type === 'JSXAttribute') {
+          const attrName =
+            node.parent.name.type === 'JSXIdentifier'
+              ? node.parent.name.name
+              : null;
+          if (!attrName || !MONITORED_JSX_ATTRS.includes(attrName)) {
+            return;
+          }
+          // Accessibility attributes: flag any raw string regardless of content
+          if (isRawStringNode(node.expression)) {
+            context.report({
+              node: node.expression,
+              messageId: 'untranslatedJsxText'
+            });
+          }
+          return;
+        }
+        if (node.expression.type === 'Identifier') {
           context.report({
             node: node.expression,
             messageId: 'untranslatedJsxText'
           });
+          return;
+        }
+        if (isRawStringNode(node.expression)) {
+          const value = getRawStringValue(node.expression);
+          if (value !== null && hasLetters(value)) {
+            context.report({
+              node: node.expression,
+              messageId: 'untranslatedJsxText'
+            });
+          }
         }
       }
     };

--- a/src/rules/no-untranslated-string.ts
+++ b/src/rules/no-untranslated-string.ts
@@ -8,10 +8,6 @@ import { isAddCommandCall } from '../utils/commands';
 import { getObjectProperties } from '../utils/plugin-utils';
 import { createRule } from '../utils/create-rule';
 
-/**
- * Returns true if the node is a non-empty raw string literal that should be
- * wrapped in a translation call.
- */
 function hasLetters(str: string): boolean {
   return /\p{L}/u.test(str);
 }
@@ -32,6 +28,13 @@ function getRawStringValue(node: TSESTree.Node): string | null {
   return null;
 }
 
+/**
+ * Returns true if the node is a non-empty raw string literal that should be
+ * wrapped in a translation call. Handles:
+ *   - String Literal: 'string' or "string"
+ *   - TemplateLiteral with no expressions: `string`
+ *   - Concise ArrowFunctionExpression whose body is one of the above
+ */
 function isRawStringNode(node: TSESTree.Node): boolean {
   if (node.type === 'Literal') {
     return typeof node.value === 'string' && node.value.length > 0;

--- a/tests/jupyter-no-untranslated-string.test.ts
+++ b/tests/jupyter-no-untranslated-string.test.ts
@@ -279,6 +279,10 @@ jsxRuleTester.run('no-untranslated-string (JSX)', noUntranslatedString, {
     {
       code: `<span aria-description={'Describes something'} />`,
       errors: [{ messageId: 'untranslatedJsxText' }]
+    },
+    {
+      code: `<span aria-description="Describes something" />`,
+      errors: [{ messageId: 'untranslatedJsxText' }]
     }
   ]
 });

--- a/tests/jupyter-no-untranslated-string.test.ts
+++ b/tests/jupyter-no-untranslated-string.test.ts
@@ -251,8 +251,6 @@ jsxRuleTester.run('no-untranslated-string (JSX)', noUntranslatedString, {
     { code: `<div className={'normal-class-string'} />` },
     { code: `<div id={'my-id'} />` },
     { code: `<span aria-label={trans.__('Close')} />` },
-    // Variables aren't flagged
-    { code: `<span>{myVar}</span>` },
     // Punctuation-only JSX text should not be flagged
     { code: `<span>{','}</span>` },
     { code: `<span>{' + '}</span>` }
@@ -280,6 +278,32 @@ jsxRuleTester.run('no-untranslated-string (JSX)', noUntranslatedString, {
     },
     {
       code: `<span aria-description={'Describes something'} />`,
+      errors: [{ messageId: 'untranslatedJsxText' }]
+    }
+  ]
+});
+
+// enforcePunctuation option tests
+jsxRuleTester.run('no-untranslated-string (JSX, enforcePunctuation)', noUntranslatedString, {
+  valid: [
+    // Empty strings still ignored even with enforcePunctuation
+    { code: `<span>{''}</span>`, options: [{ enforcePunctuation: true }] }
+  ],
+  invalid: [
+    // Punctuation-only JSX text flagged when enforcePunctuation: true
+    {
+      code: `<div>,</div>`,
+      options: [{ enforcePunctuation: true }],
+      errors: [{ messageId: 'untranslatedJsxText' }]
+    },
+    {
+      code: `<span>{' - '}</span>`,
+      options: [{ enforcePunctuation: true }],
+      errors: [{ messageId: 'untranslatedJsxText' }]
+    },
+    {
+      code: `<span>{'.'}</span>`,
+      options: [{ enforcePunctuation: true }],
       errors: [{ messageId: 'untranslatedJsxText' }]
     }
   ]

--- a/tests/jupyter-no-untranslated-string.test.ts
+++ b/tests/jupyter-no-untranslated-string.test.ts
@@ -252,7 +252,7 @@ jsxRuleTester.run('no-untranslated-string (JSX)', noUntranslatedString, {
     { code: `<div id={'my-id'} />` },
     { code: `<span aria-label={trans.__('Close')} />` },
     // Punctuation-only JSX text should not be flagged
-    { code: `<span>{','}</span>` },
+    { code: `<span>,</span>` },
     { code: `<span>{' + '}</span>` }
   ],
 

--- a/tests/jupyter-no-untranslated-string.test.ts
+++ b/tests/jupyter-no-untranslated-string.test.ts
@@ -251,6 +251,8 @@ jsxRuleTester.run('no-untranslated-string (JSX)', noUntranslatedString, {
     { code: `<div className={'normal-class-string'} />` },
     { code: `<div id={'my-id'} />` },
     { code: `<span aria-label={trans.__('Close')} />` },
+    // Variables aren't flagged
+    { code: `<span>{myVar}</span>` },
     // Punctuation-only JSX text should not be flagged
     { code: `<span>{','}</span>` },
     { code: `<span>{' + '}</span>` }
@@ -278,11 +280,6 @@ jsxRuleTester.run('no-untranslated-string (JSX)', noUntranslatedString, {
     },
     {
       code: `<span aria-description={'Describes something'} />`,
-      errors: [{ messageId: 'untranslatedJsxText' }]
-    },
-    // --- JSX identifier in text content must be translated ---
-    {
-      code: `<span>{myVar}</span>`,
       errors: [{ messageId: 'untranslatedJsxText' }]
     }
   ]

--- a/tests/jupyter-no-untranslated-string.test.ts
+++ b/tests/jupyter-no-untranslated-string.test.ts
@@ -247,7 +247,13 @@ jsxRuleTester.run('no-untranslated-string (JSX)', noUntranslatedString, {
   valid: [
     // --- JSX: translated expression ---
     { code: `const el = <span>{trans.__('Error message:')}</span>;` },
-    { code: `const el = (\n  <div>\n    <span>{trans.__('Label')}</span>\n  </div>\n);` }
+    { code: `const el = (\n  <div>\n    <span>{trans.__('Label')}</span>\n  </div>\n);` },
+    { code: `<div className={'normal-class-string'} />` },
+    { code: `<div id={'my-id'} />` },
+    { code: `<span aria-label={trans.__('Close')} />` },
+    // Punctuation-only JSX text should not be flagged
+    { code: `<span>{','}</span>` },
+    { code: `<span>{' + '}</span>` }
   ],
 
   invalid: [
@@ -259,6 +265,24 @@ jsxRuleTester.run('no-untranslated-string (JSX)', noUntranslatedString, {
     // --- JSXExpressionContainer: raw string literal ---
     {
       code: `const el = <span>{'raw string'}</span>;`,
+      errors: [{ messageId: 'untranslatedJsxText' }]
+    },
+    // --- JSX accessibility attributes must be translated ---
+    {
+      code: `<button aria-label={'Close dialog'} />`,
+      errors: [{ messageId: 'untranslatedJsxText' }]
+    },
+    {
+      code: `<div title={'My tooltip'} />`,
+      errors: [{ messageId: 'untranslatedJsxText' }]
+    },
+    {
+      code: `<span aria-description={'Describes something'} />`,
+      errors: [{ messageId: 'untranslatedJsxText' }]
+    },
+    // --- JSX identifier in text content must be translated ---
+    {
+      code: `<span>{myVar}</span>`,
       errors: [{ messageId: 'untranslatedJsxText' }]
     }
   ]

--- a/website/docs/rules/command-described-by.md
+++ b/website/docs/rules/command-described-by.md
@@ -1,4 +1,4 @@
-# `jupyter/command-described-by`
+# `command-described-by`
 
 Ensure JupyterLab command registrations include a `describedBy` property.
 

--- a/website/docs/rules/no-translation-concatenation.md
+++ b/website/docs/rules/no-translation-concatenation.md
@@ -1,4 +1,4 @@
-# `jupyter/no-translation-concatenation`
+# `no-translation-concatenation`
 
 Forbid string concatenation inside JupyterLab translation wrapper calls.
 

--- a/website/docs/rules/no-untranslated-string.md
+++ b/website/docs/rules/no-untranslated-string.md
@@ -1,4 +1,4 @@
-# `jupyter/no-untranslated-string`
+# `no-untranslated-string`
 
 Require user-facing string literals to be wrapped in a translation call such as `trans.__()`.
 

--- a/website/docs/rules/no-untranslated-string.md
+++ b/website/docs/rules/no-untranslated-string.md
@@ -94,4 +94,10 @@ const el = <span>{trans.__('Error message:')}</span>;
 
 ## Options
 
-This rule has no options.
+```ts
+{
+  "enforcePunctuation": false
+}
+```
+
+Set `enforcePunctuation` option to `true` to enforce translation of punctuation characters such as `,`, `-`, `+`, and other symbols.

--- a/website/docs/rules/plugin-activation-args.md
+++ b/website/docs/rules/plugin-activation-args.md
@@ -1,4 +1,4 @@
-# `jupyter/plugin-activation-args`
+# `plugin-activation-args`
 
 Ensure JupyterLab plugin `activate` arguments match the order and count of `requires` and `optional` tokens.
 

--- a/website/docs/rules/plugin-description.md
+++ b/website/docs/rules/plugin-description.md
@@ -1,4 +1,4 @@
-# `jupyter/plugin-description`
+# `plugin-description`
 
 Ensure all `JupyterFrontEndPlugin` objects define a non-empty `description` property.
 

--- a/website/docs/rules/token-format.md
+++ b/website/docs/rules/token-format.md
@@ -1,4 +1,4 @@
-# `jupyter/token-format`
+# `token-format`
 
 Ensure JupyterLab `Token` ids follow the `<package>:<TokenSymbol>` naming convention where the symbol is a valid JavaScript identifier.
 

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -20,8 +20,11 @@ const sidebars: SidebarsConfig = {
       items: [
         'rules/index',
         'rules/command-described-by',
+        'rules/no-translation-concatenation',
+        'rules/no-untranslated-string',
         'rules/plugin-activation-args',
-        'rules/plugin-description'
+        'rules/plugin-description',
+        'rules/token-format'
       ]
     }
   ]


### PR DESCRIPTION
### References issues identified in https://github.com/jupyterlab/jupyterlab/pull/18781

### Description

- Fixed false positives on non-accessibility JSX attribute values (e.g. `className={'...'}`, `id={'...'}`) — these are no longer flagged  
- Still flags monitored accessibility attributes in JSX: `aria-label`, `aria-description`, `title`  
- Skips punctuation/symbol-only JSX text (e.g. `,`, `.`, `' '`) — only flags text containing actual letters  
- Do not flag identifier expressions in JSX text content (e.g. `{myVar}`)