### PR TITLE
Add `require-soft-assertions-before-snapshots` rule

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -93,6 +93,7 @@ jobs:
             'notebook/packages/*/src/**/*.tsx' \
             'notebook/**/*.spec.ts' \
             'notebook/**/*.test.ts' \
+            --no-warn-ignored \
             --max-warnings=9999
         env:
           NODE_PATH: ./notebook/node_modules
@@ -138,6 +139,7 @@ jobs:
             'jupyterlite/packages/*/src/**/*.tsx' \
             'jupyterlite/**/*.spec.ts' \
             'jupyterlite/**/*.test.ts' \
+            --no-warn-ignored \
             --max-warnings=9999
         env:
           NODE_PATH: ./jupyterlite/node_modules

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -92,8 +92,6 @@ jobs:
             'notebook/packages/*/src/**/*.ts' \
             'notebook/packages/*/src/**/*.tsx' \
             'notebook/**/*.spec.ts' \
-            'notebook/**/*.test.ts' \
-            --no-warn-ignored \
             --max-warnings=9999
         env:
           NODE_PATH: ./notebook/node_modules
@@ -138,8 +136,6 @@ jobs:
             'jupyterlite/packages/*/src/**/*.ts' \
             'jupyterlite/packages/*/src/**/*.tsx' \
             'jupyterlite/**/*.spec.ts' \
-            'jupyterlite/**/*.test.ts' \
-            --no-warn-ignored \
             --max-warnings=9999
         env:
           NODE_PATH: ./jupyterlite/node_modules

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -46,6 +46,8 @@ jobs:
           npx eslint --config eslint.downstream.config.mjs \
             'jupyterlab/packages/*/src/**/*.ts' \
             'jupyterlab/packages/*/src/**/*.tsx' \
+            'jupyterlab/**/*.spec.ts' \
+            'jupyterlab/**/*.test.ts' \
             --max-warnings=9999
         env:
           NODE_PATH: ./jupyterlab/node_modules
@@ -89,6 +91,8 @@ jobs:
           npx eslint --config eslint.downstream.config.mjs \
             'notebook/packages/*/src/**/*.ts' \
             'notebook/packages/*/src/**/*.tsx' \
+            'notebook/**/*.spec.ts' \
+            'notebook/**/*.test.ts' \
             --max-warnings=9999
         env:
           NODE_PATH: ./notebook/node_modules
@@ -132,6 +136,8 @@ jobs:
           npx eslint --config eslint.downstream.config.mjs \
             'jupyterlite/packages/*/src/**/*.ts' \
             'jupyterlite/packages/*/src/**/*.tsx' \
+            'jupyterlite/**/*.spec.ts' \
+            'jupyterlite/**/*.test.ts' \
             --max-warnings=9999
         env:
           NODE_PATH: ./jupyterlite/node_modules

--- a/eslint.downstream.config.mjs
+++ b/eslint.downstream.config.mjs
@@ -17,100 +17,42 @@ const resolvedParser = parserModule.default ?? parserModule;
 const tsPlugin = await import('@typescript-eslint/eslint-plugin');
 const resolvedTsPlugin = tsPlugin.default ?? tsPlugin;
 
+function makeProjectConfig(projectName) {
+  return {
+    basePath: __dirname,
+    files: [
+      `${projectName}/packages/*/src/**/*.ts`,
+      `${projectName}/packages/*/src/**/*.tsx`
+    ],
+    plugins: {
+      'jupyter': resolvedPlugin,
+      '@typescript-eslint': resolvedTsPlugin
+    },
+    rules: {
+      'jupyter/command-described-by': 'error',
+      'jupyter/no-untranslated-string': 'error',
+      'jupyter/plugin-activation-args': 'error',
+      'jupyter/plugin-description': 'error',
+      'jupyter/no-translation-concatenation': 'error',
+      'jupyter/token-format': 'error',
+      'jupyter/require-soft-assertions-before-snapshots': 'error'
+    },
+    languageOptions: {
+      parser: resolvedParser,
+      parserOptions: {
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+        project: path.resolve(__dirname, `${projectName}/tsconfig.eslint.json`)
+      }
+    },
+    linterOptions: {
+      reportUnusedDisableDirectives: 'off'
+    }
+  };
+}
+
 export default [
-  // JupyterLab
-  {
-    basePath: __dirname,
-    files: [
-      'jupyterlab/packages/*/src/**/*.ts',
-      'jupyterlab/packages/*/src/**/*.tsx'
-    ],
-    plugins: {
-      'jupyter': resolvedPlugin,
-      '@typescript-eslint': resolvedTsPlugin
-    },
-    rules: {
-      'jupyter/command-described-by': 'error',
-      'jupyter/no-untranslated-string': 'error',
-      'jupyter/plugin-activation-args': 'error',
-      'jupyter/plugin-description': 'error',
-      'jupyter/no-translation-concatenation': 'error',
-      'jupyter/token-format': 'error'
-    },
-    languageOptions: {
-      parser: resolvedParser,
-      parserOptions: {
-        ecmaVersion: 'latest',
-        sourceType: 'module',
-        project: path.resolve(__dirname, 'jupyterlab/tsconfig.eslint.json')
-      }
-    },
-    linterOptions: {
-      reportUnusedDisableDirectives: 'off'
-    }
-  },
-
-  // Notebook
-  {
-    basePath: __dirname,
-    files: [
-      'notebook/packages/*/src/**/*.ts',
-      'notebook/packages/*/src/**/*.tsx'
-    ],
-    plugins: {
-      'jupyter': resolvedPlugin,
-      '@typescript-eslint': resolvedTsPlugin
-    },
-    rules: {
-      'jupyter/command-described-by': 'error',
-      'jupyter/no-untranslated-string': 'error',
-      'jupyter/plugin-activation-args': 'error',
-      'jupyter/plugin-description': 'error',
-      'jupyter/no-translation-concatenation': 'error',
-      'jupyter/token-format': 'error'
-    },
-    languageOptions: {
-      parser: resolvedParser,
-      parserOptions: {
-        ecmaVersion: 'latest',
-        sourceType: 'module',
-        project: path.resolve(__dirname, 'notebook/tsconfig.eslint.json')
-      }
-    },
-    linterOptions: {
-      reportUnusedDisableDirectives: 'off'
-    }
-  },
-
-  // Jupyterlite
-  {
-    basePath: __dirname,
-    files: [
-      'jupyterlite/packages/*/src/**/*.ts',
-      'jupyterlite/packages/*/src/**/*.tsx'
-    ],
-    plugins: {
-      'jupyter': resolvedPlugin,
-      '@typescript-eslint': resolvedTsPlugin
-    },
-    rules: {
-      'jupyter/command-described-by': 'error',
-      'jupyter/no-untranslated-string': 'error',
-      'jupyter/plugin-activation-args': 'error',
-      'jupyter/plugin-description': 'error',
-      'jupyter/no-translation-concatenation': 'error',
-      'jupyter/token-format': 'error'
-    },
-    languageOptions: {
-      parser: resolvedParser,
-      parserOptions: {
-        ecmaVersion: 'latest',
-        sourceType: 'module',
-        project: path.resolve(__dirname, 'jupyterlite/tsconfig.eslint.json')
-      }
-    },
-    linterOptions: {
-      reportUnusedDisableDirectives: 'off'
-    }
-  }
+  makeProjectConfig('jupyterlab'),
+  makeProjectConfig('notebook'),
+  makeProjectConfig('jupyterlite')
 ];

--- a/eslint.downstream.config.mjs
+++ b/eslint.downstream.config.mjs
@@ -66,7 +66,8 @@ function makeTestConfig(projectName) {
     ],
     plugins: {
       'jupyter': resolvedPlugin,
-      'jest': jestStub
+      '@typescript-eslint': resolvedTsPlugin,
+      'jest': jestStub,
     },
     rules: {
       'jupyter/require-soft-assertions-before-snapshots': 'error'

--- a/eslint.downstream.config.mjs
+++ b/eslint.downstream.config.mjs
@@ -13,11 +13,14 @@ const resolvedPlugin = pluginModule.default?.rules ? pluginModule.default : plug
 const parserModule = await import('@typescript-eslint/parser');
 const resolvedParser = parserModule.default ?? parserModule;
 
-// These prevent "Definition for rule not found" errors from eslint-disable comments
+// Prevents "Definition for rule not found" errors from eslint-disable comments
 const tsPlugin = await import('@typescript-eslint/eslint-plugin');
 const resolvedTsPlugin = tsPlugin.default ?? tsPlugin;
-const jestPlugin = await import('eslint-plugin-jest');
-const resolvedJestPlugin = jestPlugin.default ?? jestPlugin;
+
+// Stub: satisfies ESLint's rule-name validation for jest/* disable comments
+// without importing the real plugin or enabling any jest rules.
+const noopRule = { create: () => ({}) };
+const jestStub = { rules: new Proxy({}, { get: () => noopRule }) };
 
 function makeProjectConfig(projectName) {
   return {
@@ -29,7 +32,7 @@ function makeProjectConfig(projectName) {
     plugins: {
       'jupyter': resolvedPlugin,
       '@typescript-eslint': resolvedTsPlugin,
-      'jest': resolvedJestPlugin
+      'jest': jestStub
     },
     rules: {
       'jupyter/command-described-by': 'error',
@@ -63,7 +66,7 @@ function makeTestConfig(projectName) {
     ],
     plugins: {
       'jupyter': resolvedPlugin,
-      'jest': resolvedJestPlugin
+      'jest': jestStub
     },
     rules: {
       'jupyter/require-soft-assertions-before-snapshots': 'error'

--- a/eslint.downstream.config.mjs
+++ b/eslint.downstream.config.mjs
@@ -51,8 +51,35 @@ function makeProjectConfig(projectName) {
   };
 }
 
+function makeTestConfig(projectName) {
+  return {
+    basePath: __dirname,
+    files: [
+      `${projectName}/**/*.spec.ts`,
+      `${projectName}/**/*.test.ts`
+    ],
+    plugins: {
+      'jupyter': resolvedPlugin
+    },
+    rules: {
+      'jupyter/require-soft-assertions-before-snapshots': 'error'
+    },
+    languageOptions: {
+      parser: resolvedParser,
+      parserOptions: {
+        ecmaVersion: 'latest',
+        sourceType: 'module'
+      }
+    },
+    linterOptions: {
+      reportUnusedDisableDirectives: 'off'
+    }
+  };
+}
+
+const projects = ['jupyterlab', 'notebook', 'jupyterlite'];
+
 export default [
-  makeProjectConfig('jupyterlab'),
-  makeProjectConfig('notebook'),
-  makeProjectConfig('jupyterlite')
+  ...projects.map(makeProjectConfig),
+  ...projects.map(makeTestConfig)
 ];

--- a/eslint.downstream.config.mjs
+++ b/eslint.downstream.config.mjs
@@ -13,9 +13,11 @@ const resolvedPlugin = pluginModule.default?.rules ? pluginModule.default : plug
 const parserModule = await import('@typescript-eslint/parser');
 const resolvedParser = parserModule.default ?? parserModule;
 
-// This prevents "Definition for rule not found" errors from eslint-disable comments
+// These prevent "Definition for rule not found" errors from eslint-disable comments
 const tsPlugin = await import('@typescript-eslint/eslint-plugin');
 const resolvedTsPlugin = tsPlugin.default ?? tsPlugin;
+const jestPlugin = await import('eslint-plugin-jest');
+const resolvedJestPlugin = jestPlugin.default ?? jestPlugin;
 
 function makeProjectConfig(projectName) {
   return {
@@ -26,7 +28,8 @@ function makeProjectConfig(projectName) {
     ],
     plugins: {
       'jupyter': resolvedPlugin,
-      '@typescript-eslint': resolvedTsPlugin
+      '@typescript-eslint': resolvedTsPlugin,
+      'jest': resolvedJestPlugin
     },
     rules: {
       'jupyter/command-described-by': 'error',
@@ -59,7 +62,8 @@ function makeTestConfig(projectName) {
       `${projectName}/**/*.test.ts`
     ],
     plugins: {
-      'jupyter': resolvedPlugin
+      'jupyter': resolvedPlugin,
+      'jest': resolvedJestPlugin
     },
     rules: {
       'jupyter/require-soft-assertions-before-snapshots': 'error'

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "@typescript-eslint/rule-tester": "^8.57.0",
         "eslint": "^9.39.2",
         "eslint-plugin": "^1.0.1",
-        "eslint-plugin-jest": "^29.15.2",
         "jest": "^30.2.0",
         "pre-commit": "^1.2.2",
         "prettier": "^3.8.1",
@@ -1237,7 +1236,6 @@
       "integrity": "sha512-XsauDV82o5qXbhalKxD7p4TZYYdwcaEXC77PPD2HixEFF+6YGppjrAAQurTl2ECWcEomHBMMNS9AH3kcCFx8jA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.27.4",
         "@jest/types": "30.2.0",
@@ -1265,7 +1263,6 @@
       "integrity": "sha512-H9xg1/sfVvyfU7o3zMfBEjQ1gcsdeTMgqHoYdN79tuLqfTtuu7WckRA1R5whDwOzxaZAeMKTYWqP+WCAi0CHsg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/pattern": "30.0.1",
         "@jest/schemas": "30.0.5",
@@ -1589,6 +1586,7 @@
       "integrity": "sha512-XZzOmihLIr8AD1b9hL9ccNMzEMWt/dE2u7NyTY9jJG6YNiNthaD5XtUHVF2uCXZ15ng+z2hT3MVuxnUYhq6k1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.0",
         "@typescript-eslint/types": "8.57.0",
@@ -2551,7 +2549,6 @@
       "integrity": "sha512-0YiBEOxWqKkSQWL9nNGGEgndoeL0ZpWrbLMNL5u/Kaxrli3Eaxlt3ZtIDktEvXt4L/R9r3ODr2zKwGM/2BjxVw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/transform": "30.2.0",
         "@types/babel__core": "^7.20.5",
@@ -3196,36 +3193,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/eslint-plugin-jest": {
-      "version": "29.15.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-29.15.2.tgz",
-      "integrity": "sha512-kEN4r9RZl1xcsb4arGq89LrcVdOUFII/JSCwtTPJyv16mDwmPrcuEQwpxqZHeINvcsd7oK5O/rhdGlxFRaZwvQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/utils": "^8.0.0"
-      },
-      "engines": {
-        "node": "^20.12.0 || ^22.0.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "@typescript-eslint/eslint-plugin": "^8.0.0",
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "jest": "*",
-        "typescript": ">=4.8.4 <7.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@typescript-eslint/eslint-plugin": {
-          "optional": true
-        },
-        "jest": {
-          "optional": true
-        },
-        "typescript": {
-          "optional": true
-        }
       }
     },
     "node_modules/eslint-scope": {
@@ -4433,7 +4400,6 @@
       "integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/types": "30.2.0",
         "@types/node": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@typescript-eslint/rule-tester": "^8.57.0",
         "eslint": "^9.39.2",
         "eslint-plugin": "^1.0.1",
+        "eslint-plugin-jest": "^29.15.2",
         "jest": "^30.2.0",
         "pre-commit": "^1.2.2",
         "prettier": "^3.8.1",
@@ -65,6 +66,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1235,6 +1237,7 @@
       "integrity": "sha512-XsauDV82o5qXbhalKxD7p4TZYYdwcaEXC77PPD2HixEFF+6YGppjrAAQurTl2ECWcEomHBMMNS9AH3kcCFx8jA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.27.4",
         "@jest/types": "30.2.0",
@@ -1262,6 +1265,7 @@
       "integrity": "sha512-H9xg1/sfVvyfU7o3zMfBEjQ1gcsdeTMgqHoYdN79tuLqfTtuu7WckRA1R5whDwOzxaZAeMKTYWqP+WCAi0CHsg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/pattern": "30.0.1",
         "@jest/schemas": "30.0.5",
@@ -2444,6 +2448,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2546,6 +2551,7 @@
       "integrity": "sha512-0YiBEOxWqKkSQWL9nNGGEgndoeL0ZpWrbLMNL5u/Kaxrli3Eaxlt3ZtIDktEvXt4L/R9r3ODr2zKwGM/2BjxVw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/transform": "30.2.0",
         "@types/babel__core": "^7.20.5",
@@ -2697,6 +2703,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3123,6 +3130,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz",
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3188,6 +3196,36 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eslint-plugin-jest": {
+      "version": "29.15.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-29.15.2.tgz",
+      "integrity": "sha512-kEN4r9RZl1xcsb4arGq89LrcVdOUFII/JSCwtTPJyv16mDwmPrcuEQwpxqZHeINvcsd7oK5O/rhdGlxFRaZwvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/utils": "^8.0.0"
+      },
+      "engines": {
+        "node": "^20.12.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "^8.0.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "jest": "*",
+        "typescript": ">=4.8.4 <7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        },
+        "jest": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint-scope": {
@@ -3916,6 +3954,7 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -4394,6 +4433,7 @@
       "integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/types": "30.2.0",
         "@types/node": "*",
@@ -5785,6 +5825,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5945,6 +5986,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "@typescript-eslint/rule-tester": "^8.57.0",
     "eslint": "^9.39.2",
     "eslint-plugin": "^1.0.1",
-    "eslint-plugin-jest": "^29.15.2",
     "jest": "^30.2.0",
     "pre-commit": "^1.2.2",
     "prettier": "^3.8.1",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@typescript-eslint/rule-tester": "^8.57.0",
     "eslint": "^9.39.2",
     "eslint-plugin": "^1.0.1",
+    "eslint-plugin-jest": "^29.15.2",
     "jest": "^30.2.0",
     "pre-commit": "^1.2.2",
     "prettier": "^3.8.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import pluginDescription from './rules/plugin-description';
 import noTranslationConcatenation from './rules/no-translation-concatenation';
 import tokenFormat from './rules/token-format';
 import noUntranslatedString from './rules/no-untranslated-string';
+import requireSoftAssertionsBeforeSnapshots from './rules/require-soft-assertions-before-snapshots';
 
 const plugin = {
   rules: {
@@ -17,7 +18,9 @@ const plugin = {
     'plugin-description': pluginDescription,
     'no-translation-concatenation': noTranslationConcatenation,
     'token-format': tokenFormat,
-    'no-untranslated-string': noUntranslatedString
+    'no-untranslated-string': noUntranslatedString,
+    'require-soft-assertions-before-snapshots':
+      requireSoftAssertionsBeforeSnapshots
   },
   configs: {
     recommended: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,18 +23,30 @@ const plugin = {
       requireSoftAssertionsBeforeSnapshots
   },
   configs: {
-    recommended: {
-      files: ['**/*.js', '**/*.ts', '**/*.jsx', '**/*.tsx'],
-      rules: {
-        'jupyter/plugin-activation-args': 'error',
-        'jupyter/command-described-by': 'warn',
-        'jupyter/plugin-description': 'warn',
-        'jupyter/no-translation-concatenation': 'error',
-        'jupyter/token-format': 'error',
-        'jupyter/no-untranslated-string': 'warn',
-        'jupyter/require-soft-assertions-before-snapshots': 'warn'
+    recommended: [
+      {
+        files: ['**/*.js', '**/*.ts', '**/*.jsx', '**/*.tsx'],
+        rules: {
+          'jupyter/plugin-activation-args': 'error',
+          'jupyter/command-described-by': 'warn',
+          'jupyter/plugin-description': 'warn',
+          'jupyter/no-translation-concatenation': 'error',
+          'jupyter/token-format': 'error',
+          'jupyter/no-untranslated-string': 'warn'
+        }
+      },
+      {
+        files: [
+          '**/*.spec.ts',
+          '**/*.spec.js',
+          '**/*.test.ts',
+          '**/*.test.js'
+        ],
+        rules: {
+          'jupyter/require-soft-assertions-before-snapshots': 'warn'
+        }
       }
-    },
+    ],
     'recommended-legacy': {
       rules: {
         'jupyter/plugin-activation-args': 'error',
@@ -42,9 +54,21 @@ const plugin = {
         'jupyter/plugin-description': 'warn',
         'jupyter/no-translation-concatenation': 'error',
         'jupyter/token-format': 'error',
-        'jupyter/no-untranslated-string': 'warn',
-        'jupyter/require-soft-assertions-before-snapshots': 'warn'
-      }
+        'jupyter/no-untranslated-string': 'warn'
+      },
+      overrides: [
+        {
+          files: [
+            '**/*.spec.ts',
+            '**/*.spec.js',
+            '**/*.test.ts',
+            '**/*.test.js'
+          ],
+          rules: {
+            'jupyter/require-soft-assertions-before-snapshots': 'warn'
+          }
+        }
+      ]
     }
   }
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,8 @@ const plugin = {
         'jupyter/plugin-description': 'warn',
         'jupyter/no-translation-concatenation': 'error',
         'jupyter/token-format': 'error',
-        'jupyter/no-untranslated-string': 'warn'
+        'jupyter/no-untranslated-string': 'warn',
+        'jupyter/require-soft-assertions-before-snapshots': 'warn'
       }
     },
     'recommended-legacy': {
@@ -41,7 +42,8 @@ const plugin = {
         'jupyter/plugin-description': 'warn',
         'jupyter/no-translation-concatenation': 'error',
         'jupyter/token-format': 'error',
-        'jupyter/no-untranslated-string': 'warn'
+        'jupyter/no-untranslated-string': 'warn',
+        'jupyter/require-soft-assertions-before-snapshots': 'warn'
       }
     }
   }

--- a/src/rules/require-soft-assertions-before-snapshots.ts
+++ b/src/rules/require-soft-assertions-before-snapshots.ts
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import { TSESTree } from '@typescript-eslint/utils';
+import { createRule } from '../utils/create-rule';
+
+type MessageIds = 'requireSoftAssertion';
+type Options = [];
+
+interface SnapshotCall {
+  node: TSESTree.CallExpression;
+  isSoft: boolean;
+}
+
+function isTestBlock(node: TSESTree.CallExpression): boolean {
+  const { callee } = node;
+  if (callee.type === 'Identifier') {
+    return callee.name === 'test' || callee.name === 'it';
+  }
+  if (
+    callee.type === 'MemberExpression' &&
+    !callee.computed &&
+    callee.object.type === 'Identifier' &&
+    (callee.object.name === 'test' || callee.object.name === 'it') &&
+    callee.property.type === 'Identifier'
+  ) {
+    return true;
+  }
+  return false;
+}
+
+function getSnapshotInfo(
+  node: TSESTree.CallExpression
+): { isSoft: boolean } | null {
+  const { callee } = node;
+  if (callee.type !== 'MemberExpression' || callee.computed) return null;
+
+  const prop = callee.property;
+  if (prop.type !== 'Identifier' || prop.name !== 'toMatchSnapshot') {
+    return null;
+  }
+
+  const expectCall = callee.object;
+  if (expectCall.type !== 'CallExpression') return null;
+
+  const expectCallee = expectCall.callee;
+
+  if (expectCallee.type === 'Identifier' && expectCallee.name === 'expect') {
+    return { isSoft: false };
+  }
+
+  if (
+    expectCallee.type === 'MemberExpression' &&
+    !expectCallee.computed &&
+    expectCallee.object.type === 'Identifier' &&
+    expectCallee.object.name === 'expect' &&
+    expectCallee.property.type === 'Identifier' &&
+    expectCallee.property.name === 'soft'
+  ) {
+    return { isSoft: true };
+  }
+
+  return null;
+}
+
+const requireSoftAssertionsBeforeSnapshots = createRule<Options, MessageIds>({
+  name: 'require-soft-assertions-before-snapshots',
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Require expect.soft() for snapshot assertions that precede other snapshot assertions in the same test block'
+    },
+    messages: {
+      requireSoftAssertion:
+        'Use expect.soft() for snapshot assertions that are not the last in the test block. Hard assertions short-circuit on failure, preventing subsequent snapshots from being updated.'
+    },
+    schema: []
+  },
+  defaultOptions: [],
+  create(context) {
+    const testContextStack: SnapshotCall[][] = [];
+
+    return {
+      CallExpression(node) {
+        if (isTestBlock(node)) {
+          testContextStack.push([]);
+          return;
+        }
+
+        const info = getSnapshotInfo(node);
+        if (info && testContextStack.length > 0) {
+          testContextStack[testContextStack.length - 1].push({
+            node,
+            isSoft: info.isSoft
+          });
+        }
+      },
+
+      'CallExpression:exit'(node) {
+        if (!isTestBlock(node)) return;
+
+        const snapshots = testContextStack.pop();
+        if (!snapshots || snapshots.length <= 1) return;
+
+        for (let i = 0; i < snapshots.length - 1; i++) {
+          if (!snapshots[i].isSoft) {
+            context.report({
+              node: snapshots[i].node,
+              messageId: 'requireSoftAssertion'
+            });
+          }
+        }
+      }
+    };
+  }
+});
+
+export = requireSoftAssertionsBeforeSnapshots;

--- a/src/rules/require-soft-assertions-before-snapshots.ts
+++ b/src/rules/require-soft-assertions-before-snapshots.ts
@@ -26,7 +26,7 @@ function isTestBlock(node: TSESTree.CallExpression): boolean {
     (callee.object.name === 'test' || callee.object.name === 'it') &&
     callee.property.type === 'Identifier'
   ) {
-    return true;
+    return callee.property.name !== 'step';
   }
   return false;
 }

--- a/tests/jupyter-require-soft-assertions-before-snapshots.test.ts
+++ b/tests/jupyter-require-soft-assertions-before-snapshots.test.ts
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import rule from '../src/rules/require-soft-assertions-before-snapshots';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parser: require('@typescript-eslint/parser'),
+    parserOptions: {
+      ecmaVersion: 2020,
+      sourceType: 'module'
+    }
+  }
+});
+
+ruleTester.run('require-soft-assertions-before-snapshots', rule, {
+  valid: [
+    {
+      code: `
+        test('single hard snapshot', async () => {
+          expect(await page.screenshot()).toMatchSnapshot('page.png');
+        });
+      `
+    },
+    {
+      code: `
+        test('single soft snapshot', async () => {
+          expect.soft(await page.screenshot()).toMatchSnapshot('page.png');
+        });
+      `
+    },
+    {
+      code: `
+        test('all soft', async () => {
+          expect.soft(await popup.screenshot()).toMatchSnapshot('before.png');
+          await popup.locator('button').click();
+          expect.soft(await popup.screenshot()).toMatchSnapshot('after.png');
+          expect.soft(await popup.screenshot()).toMatchSnapshot();
+        });
+      `
+    },
+    {
+      code: `
+        test('soft except last', async () => {
+          expect.soft(await popup.screenshot()).toMatchSnapshot('before.png');
+          await popup.locator('button').click();
+          expect(await popup.screenshot()).toMatchSnapshot('after.png');
+        });
+      `
+    },
+    {
+      code: `
+        test('non-snapshot hard assertion ok', async () => {
+          expect.soft(await popup.screenshot()).toMatchSnapshot('before.png');
+          await expect(popup.locator('h1')).toBeVisible();
+          expect(await popup.screenshot()).toMatchSnapshot('after.png');
+        });
+      `
+    },
+    {
+      code: `
+        test.beforeAll('test beforeAll', async () => {
+          expect.soft(await page.screenshot()).toMatchSnapshot('before.png');
+          expect(await page.screenshot()).toMatchSnapshot('after.png');
+        });
+      `
+    },
+    {
+      code: `
+        it('using it', async () => {
+          expect.soft(await page.screenshot()).toMatchSnapshot('before.png');
+          expect(await page.screenshot()).toMatchSnapshot('after.png');
+        });
+      `
+    },
+    // Nested test blocks: inner test has soft-before-last pattern
+    {
+      code: `
+        test('outer', async () => {
+          test('inner', async () => {
+            expect.soft(await page.screenshot()).toMatchSnapshot('a.png');
+            expect(await page.screenshot()).toMatchSnapshot('b.png');
+          });
+        });
+      `
+    }
+  ],
+
+  invalid: [
+    {
+      code: `
+        test('two snapshots first hard', async () => {
+          expect(await page.screenshot()).toMatchSnapshot('before.png');
+          expect(await page.screenshot()).toMatchSnapshot('after.png');
+        });
+      `,
+      errors: [{ messageId: 'requireSoftAssertion' }]
+    },
+    {
+      code: `
+        it('hard soft hard', async () => {
+          expect(await page.screenshot()).toMatchSnapshot('a.png');
+          expect.soft(await page.screenshot()).toMatchSnapshot('b.png');
+          expect(await page.screenshot()).toMatchSnapshot('c.png');
+        });
+      `,
+      errors: [{ messageId: 'requireSoftAssertion' }]
+    },
+    {
+      code: `
+        test.beforeAll('soft hard hard', async () => {
+          expect.soft(await page.screenshot()).toMatchSnapshot('a.png');
+          expect(await page.screenshot()).toMatchSnapshot('b.png');
+          expect(await page.screenshot()).toMatchSnapshot('c.png');
+        });
+      `,
+      errors: [{ messageId: 'requireSoftAssertion' }]
+    },
+    // Nested test block: outer test has violation
+    {
+      code: `
+        test('outer with violation', async () => {
+          expect(await page.screenshot()).toMatchSnapshot('outer-a.png');
+          test('inner', async () => {
+            expect.soft(await page.screenshot()).toMatchSnapshot('inner-a.png');
+            expect(await page.screenshot()).toMatchSnapshot('inner-b.png');
+          });
+          expect(await page.screenshot()).toMatchSnapshot('outer-b.png');
+        });
+      `,
+      errors: [{ messageId: 'requireSoftAssertion' }]
+    }
+  ]
+});

--- a/website/docs/rules/index.md
+++ b/website/docs/rules/index.md
@@ -26,6 +26,9 @@ The plugin ships with a recommended configuration that enables all current rules
 | [jupyter/plugin-description](./plugin-description) | `warn` |
 | [jupyter/no-translation-concatenation](./no-translation-concatenation) | `error` |
 | [jupyter/token-format](./token-format) | `error` |
+| [jupyter/require-soft-assertions-before-snapshots](./require-soft-assertions-before-snapshots) | `warn` ¹ |
+
+¹ Applied only to `**/*.spec.{ts,js}` and `**/*.test.{ts,js}` files.
 
 These defaults are the same in both `jupyterPlugin.configs.recommended` (flat config) and `plugin:@jupyter/eslint-plugin/recommended-legacy`.
 

--- a/website/docs/rules/index.md
+++ b/website/docs/rules/index.md
@@ -9,6 +9,7 @@ This section documents all rules currently provided by `eslint-plugin-jupyter`.
 - [no-untranslated-string](./no-untranslated-string)
 - [plugin-activation-args](./plugin-activation-args)
 - [plugin-description](./plugin-description)
+- [require-soft-assertions-before-snapshots](./require-soft-assertions-before-snapshots)
 - [token-format](./token-format)
 
 Each page includes intent, examples, configuration, and when to apply the rule.

--- a/website/docs/rules/require-soft-assertions-before-snapshots.md
+++ b/website/docs/rules/require-soft-assertions-before-snapshots.md
@@ -8,7 +8,7 @@ Playwright's `toMatchSnapshot()` paired with a hard `expect()` call short-circui
 
 ## Rule details
 
-The rule inspects `test(...)` and `it(...)` blocks and collects every `expect(...).toMatchSnapshot(...)` call found within them. When a block contains more than one snapshot assertion:
+The rule inspects any callback passed to `test(...)`, `it(...)`, or their dot-property variants — including modifiers (`test.only`, `test.skip`, `test.fixme`, `test.fail`) and hooks (`test.beforeAll`, `test.beforeEach`, `test.afterAll`, `test.afterEach`) — and collects every `expect(...).toMatchSnapshot(...)` call found within that callback. When a block contains more than one snapshot assertion:
 
 - All assertions **except the last** must use `expect.soft(...)`.
 - The last assertion may use either `expect(...)` or `expect.soft(...)`.

--- a/website/docs/rules/require-soft-assertions-before-snapshots.md
+++ b/website/docs/rules/require-soft-assertions-before-snapshots.md
@@ -1,0 +1,49 @@
+# `require-soft-assertions-before-snapshots`
+
+Require `expect.soft()` for snapshot assertions that are not the last in a Playwright test block.
+
+## Why
+
+Playwright's `toMatchSnapshot()` paired with a hard `expect()` call short-circuits on the first failure: subsequent snapshot assertions never run, so their snapshots cannot be captured or updated in the same run. Using `expect.soft()` for all but the last snapshot ensures every snapshot is evaluated even when one fails, keeping the full suite updatable with `--update-snapshots`.
+
+## Rule details
+
+The rule inspects `test(...)` and `it(...)` blocks and collects every `expect(...).toMatchSnapshot(...)` call found within them. When a block contains more than one snapshot assertion:
+
+- All assertions **except the last** must use `expect.soft(...)`.
+- The last assertion may use either `expect(...)` or `expect.soft(...)`.
+- Non-snapshot assertions (e.g. `await expect(locator).toBeVisible()`) are ignored entirely.
+
+## Incorrect
+
+```ts
+test('multi-step screenshot', async ({ page }) => {
+  expect(await page.screenshot()).toMatchSnapshot('step-1.png'); // ❌ not last, must be soft
+  await page.click('button');
+  expect(await page.screenshot()).toMatchSnapshot('step-2.png'); // ❌ not last, must be soft
+  expect.soft(await page.screenshot()).toMatchSnapshot('step-3.png');
+});
+```
+
+## Correct
+
+```ts
+test('multi-step screenshot', async ({ page }) => {
+  expect.soft(await page.screenshot()).toMatchSnapshot('step-1.png');
+  await page.click('button');
+  expect.soft(await page.screenshot()).toMatchSnapshot('step-2.png');
+  expect(await page.screenshot()).toMatchSnapshot('step-3.png'); // last — hard is fine
+});
+```
+
+A single snapshot per test requires no change:
+
+```ts
+test('single screenshot', async ({ page }) => {
+  expect(await page.screenshot()).toMatchSnapshot('page.png'); // only snapshot — fine
+});
+```
+
+## Options
+
+This rule has no options.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -24,6 +24,7 @@ const sidebars: SidebarsConfig = {
         'rules/no-untranslated-string',
         'rules/plugin-activation-args',
         'rules/plugin-description',
+        'rules/require-soft-assertions-before-snapshots',
         'rules/token-format'
       ]
     }


### PR DESCRIPTION
## Fixes #50 

### Description
Adds new rule `require-soft-assertions-before-snapshots` which enforces `expect.soft()` for all but the last `toMatchSnapshot()` call in a Playwright test block.