### PR TITLE
`plugin-activation-args`: enforce `| null` on optional token parameters  

### DIFF
--- a/src/rules/plugin-activation-args.ts
+++ b/src/rules/plugin-activation-args.ts
@@ -158,7 +158,7 @@ const jupyterPluginActivationArgs = createRule({
       unresolvableTokenType:
         'Token "{{ token }}" type could not be resolved. The package may be unbuilt or type checking may not be configured.',
       optionalNotNullable:
-        'Activation argument "{{ arg }}" for optional token "{{ type }}" must include "| null" in its type annotation.'
+        'Activation argument "{{ arg }}" for optional token "{{ type }}" must be nullable (use "| null", "| undefined", or optional parameter "?").'
     },
     fixable: 'code',
     schema: [
@@ -255,6 +255,33 @@ const jupyterPluginActivationArgs = createRule({
         // Fall through
       }
       return null;
+    }
+
+    /**
+     * Returns true when the activate parameter's resolved type includes null or
+     * undefined. Falls back to a syntactic AST check when the checker is
+     * unavailable.
+     */
+    function isParamNullable(paramNode: TSESTree.Identifier): boolean {
+      if (checker) {
+        try {
+          const tsNode = services?.esTreeNodeToTSNodeMap.get(paramNode);
+          if (tsNode) {
+            const type = checker.getTypeAtLocation(tsNode);
+            if (type.isUnion()) {
+              return type.types.some(
+                t =>
+                  !!(t.flags & ts.TypeFlags.Null) ||
+                  !!(t.flags & ts.TypeFlags.Undefined)
+              );
+            }
+            return false;
+          }
+        } catch {
+          // Fall through to syntactic check
+        }
+      }
+      return isNullableAnnotation(paramNode);
     }
 
     /**
@@ -450,7 +477,7 @@ const jupyterPluginActivationArgs = createRule({
                 }
               } else if (i >= requires.length && paramNode) {
                 // Token matched and is optional — param must be nullable.
-                if (!isNullableAnnotation(paramNode)) {
+                if (!isParamNullable(paramNode)) {
                   context.report({
                     node: activateInfo.node,
                     messageId: 'optionalNotNullable',

--- a/src/rules/plugin-activation-args.ts
+++ b/src/rules/plugin-activation-args.ts
@@ -10,6 +10,7 @@ import {
   getJupyterPluginKind,
   extractParameterType,
   extractArrayTokens,
+  isNullableAnnotation,
   TokenEntry
 } from '../utils/plugin-utils';
 import { createRule } from '../utils/create-rule';
@@ -155,7 +156,9 @@ const jupyterPluginActivationArgs = createRule({
       wrongArgumentCount:
         'Expected {{ expected }} activation arguments (app + {{ tokenCount }} tokens), got {{ actual }}.',
       unresolvableTokenType:
-        'Token "{{ token }}" type could not be resolved. The package may be unbuilt or type checking may not be configured.'
+        'Token "{{ token }}" type could not be resolved. The package may be unbuilt or type checking may not be configured.',
+      optionalNotNullable:
+        'Activation argument "{{ arg }}" for optional token "{{ type }}" must include "| null" in its type annotation.'
     },
     fixable: 'code',
     schema: [
@@ -443,6 +446,15 @@ const jupyterPluginActivationArgs = createRule({
                       type: paramType,
                       expected: expectedToken.name
                     }
+                  });
+                }
+              } else if (i >= requires.length && paramNode) {
+                // Token matched and is optional — param must be nullable.
+                if (!isNullableAnnotation(paramNode)) {
+                  context.report({
+                    node: activateInfo.node,
+                    messageId: 'optionalNotNullable',
+                    data: { arg: paramNames[i + 1], type: expectedToken.name }
                   });
                 }
               }

--- a/src/rules/plugin-activation-args.ts
+++ b/src/rules/plugin-activation-args.ts
@@ -263,6 +263,7 @@ const jupyterPluginActivationArgs = createRule({
      * unavailable.
      */
     function isParamNullable(paramNode: TSESTree.Identifier): boolean {
+      if (paramNode.optional) return true; // param?: T always implies | undefined
       if (checker) {
         try {
           const tsNode = services?.esTreeNodeToTSNodeMap.get(paramNode);

--- a/src/utils/plugin-utils.ts
+++ b/src/utils/plugin-utils.ts
@@ -119,7 +119,6 @@ export function extractArrayTokens(
   return entries;
 }
 export function isNullableAnnotation(param: TSESTree.Identifier): boolean {
-  if (param.optional) return true; // param?: Type  implies | undefined
   if (!param.typeAnnotation) return false;
   const typeNode = param.typeAnnotation.typeAnnotation;
   if (typeNode.type !== 'TSUnionType') return false;

--- a/src/utils/plugin-utils.ts
+++ b/src/utils/plugin-utils.ts
@@ -118,6 +118,15 @@ export function extractArrayTokens(
 
   return entries;
 }
+export function isNullableAnnotation(param: TSESTree.Identifier): boolean {
+  if (!param.typeAnnotation) return false;
+  const typeNode = param.typeAnnotation.typeAnnotation;
+  if (typeNode.type !== 'TSUnionType') return false;
+  return typeNode.types.some(
+    t => t.type === 'TSNullKeyword' || t.type === 'TSUndefinedKeyword'
+  );
+}
+
 export function extractParameterType(
   param: TSESTree.Identifier
 ): string | null {

--- a/src/utils/plugin-utils.ts
+++ b/src/utils/plugin-utils.ts
@@ -119,6 +119,7 @@ export function extractArrayTokens(
   return entries;
 }
 export function isNullableAnnotation(param: TSESTree.Identifier): boolean {
+  if (param.optional) return true; // param?: Type  implies | undefined
   if (!param.typeAnnotation) return false;
   const typeNode = param.typeAnnotation.typeAnnotation;
   if (typeNode.type !== 'TSUnionType') return false;

--- a/tests/fixtures/types.d.ts
+++ b/tests/fixtures/types.d.ts
@@ -27,3 +27,9 @@ export declare const IRenderMimeRegistry: Token<IRenderMimeRegistry>;
 
 export declare interface IToolbarWidgetRegistry {}
 export declare const IToolbarWidgetRegistry: Token<IToolbarWidgetRegistry>;
+
+export declare interface ISettingRegistry {}
+export declare const ISettingRegistry: Token<ISettingRegistry>;
+
+export declare interface ICommandPalette {}
+export declare const ICommandPalette: Token<ICommandPalette>;

--- a/tests/jupyter-plugin-activation-args.test.ts
+++ b/tests/jupyter-plugin-activation-args.test.ts
@@ -40,7 +40,7 @@ nonTypeAwareTester.run('plugin-activation-args (non-type-aware)', pluginActivati
     {
       filename: 'tests/type-aware-fixture.ts',
       code: `
-        import { IDebuggerSidebar, IDebugger } from './fixtures/debugger-types';
+        import { IDebuggerSidebar, IDebugger } from './fixtures/types';
         const plugin: JupyterFrontEndPlugin<void> = {
           id: 'test-plugin',
           requires: [IDebuggerSidebar],
@@ -78,6 +78,7 @@ ruleTester.run('plugin-activation-args', pluginActivationArgs, {
       // Both requires and optional token
       filename: 'tests/type-aware-fixture.ts',
       code: `
+        import { INotebookTracker, IRenderMimeRegistry, IToolbarWidgetRegistry, ITranslator } from './fixtures/types';
         const plugin: JupyterFrontEndPlugin<void> = {
           id: 'test-plugin',
           requires: [INotebookTracker, IRenderMimeRegistry],
@@ -98,6 +99,7 @@ ruleTester.run('plugin-activation-args', pluginActivationArgs, {
       // Only optional tokens
       filename: 'tests/type-aware-fixture.ts',
       code: `
+        import { ISettingRegistry, ITranslator } from './fixtures/types';
         const plugin: JupyterFrontEndPlugin<void> = {
           id: 'test-plugin',
           optional: [ISettingRegistry, ITranslator],
@@ -141,6 +143,7 @@ ruleTester.run('plugin-activation-args', pluginActivationArgs, {
       // Multiple required and optional tokens
       filename: 'tests/type-aware-fixture.ts',
       code: `
+        import { INotebookTracker, IRenderMimeRegistry, ILabShell, IToolbarWidgetRegistry, ITranslator, ISettingRegistry, ICommandPalette } from './fixtures/types';
         const plugin: JupyterFrontEndPlugin<void> = {
           id: 'test-plugin',
           requires: [INotebookTracker, IRenderMimeRegistry, ILabShell],
@@ -164,7 +167,7 @@ ruleTester.run('plugin-activation-args', pluginActivationArgs, {
       // Namespace pattern with type info
       filename: 'tests/type-aware-fixture.ts',
       code: `
-       import { IDebugger, IDebuggerSidebar } from './fixtures/debugger-types';
+       import { IDebugger, IDebuggerSidebar } from './fixtures/types';
         const plugin: JupyterFrontEndPlugin<void> = {
           id: 'test-plugin',
           requires: [IDebuggerSidebar],
@@ -181,6 +184,7 @@ ruleTester.run('plugin-activation-args', pluginActivationArgs, {
       // Tokens with qualified names (JupyterFrontEnd.IPaths)
       filename: 'tests/type-aware-fixture.ts',
       code: `
+        import { INotebookTracker, IRenderMimeRegistry, ILabShell, IToolbarWidgetRegistry, ITranslator, ISettingRegistry, ICommandPalette } from './fixtures/types';
         const plugin: JupyterFrontEndPlugin<void> = {
           id: 'test-plugin',
           requires: [INotebookTracker, IRenderMimeRegistry, ILabShell, JupyterFrontEnd.IPaths],
@@ -286,7 +290,7 @@ ruleTester.run('plugin-activation-args', pluginActivationArgs, {
     // Namespace pattern with optional token
     filename: 'tests/type-aware-fixture.ts',
     code: `
-      import { IDebugger, IDebuggerSidebar } from './fixtures/debugger-types';
+      import { IDebugger, IDebuggerSidebar } from './fixtures/types';
       const plugin: JupyterFrontEndPlugin<void> = {
         id: 'test-plugin',
         requires: [INotebookTracker],
@@ -305,7 +309,7 @@ ruleTester.run('plugin-activation-args', pluginActivationArgs, {
       // Cross-file: token and interface declared in a separate .d.ts.
     filename: 'tests/type-aware-fixture.ts',
     code: `
-      import { IDebugger, IDebuggerSidebar, INotebookTracker } from './fixtures/debugger-types';
+      import { IDebugger, IDebuggerSidebar, INotebookTracker } from './fixtures/types';
       declare class JupyterFrontEnd {}
       declare class JupyterFrontEndPlugin<T> {}
       const plugin: JupyterFrontEndPlugin<void> = {
@@ -322,9 +326,28 @@ ruleTester.run('plugin-activation-args', pluginActivationArgs, {
     `
     },
     {
+      // Type alias that resolves to T | null is acceptable (type-checker path)
+      filename: 'tests/type-aware-fixture.ts',
+      code: `
+      import { IToolbarWidgetRegistry } from './fixtures/types';
+        type NullableToolbar = IToolbarWidgetRegistry | null;
+        const plugin: JupyterFrontEndPlugin<void> = {
+          id: 'test-plugin',
+          optional: [IToolbarWidgetRegistry],
+          activate: (
+            app: JupyterFrontEnd,
+            toolbarRegistry: NullableToolbar,
+          ) => {
+            console.log('Activated');
+          }
+        };
+      `
+    },
+    {
       // Optional token with | undefined is acceptable
       filename: 'tests/type-aware-fixture.ts',
       code: `
+       import { ISettingRegistry } from './fixtures/types';
         const plugin: JupyterFrontEndPlugin<void> = {
           id: 'test-plugin',
           optional: [ISettingRegistry],
@@ -338,9 +361,27 @@ ruleTester.run('plugin-activation-args', pluginActivationArgs, {
       `
     },
     {
+      // Reverse ordering
+      filename: 'tests/type-aware-fixture.ts',
+      code: `
+        import { ISettingRegistry } from './fixtures/types';
+        const plugin: JupyterFrontEndPlugin<void> = {
+          id: 'test-plugin',
+          optional: [ISettingRegistry],
+          activate: (
+            app: JupyterFrontEnd,
+            settingRegistry: undefined | ISettingRegistry,
+          ) => {
+            console.log('Activated');
+          }
+        };
+      `
+    },
+    {
       // Optional token with ?: syntax (implies | undefined) is acceptable
       filename: 'tests/type-aware-fixture.ts',
       code: `
+      import { ISettingRegistry, ITranslator } from './fixtures/types';
         const plugin: JupyterFrontEndPlugin<void> = {
           id: 'test-plugin',
           optional: [ISettingRegistry, ITranslator],
@@ -361,7 +402,7 @@ ruleTester.run('plugin-activation-args', pluginActivationArgs, {
       // Arguments in wrong order (requires)
       filename: 'tests/type-aware-fixture.ts',
       code: `
-        import { INotebookTracker, ITranslator } from './fixtures/debugger-types';
+        import { INotebookTracker, ITranslator } from './fixtures/types';
         const plugin: JupyterFrontEndPlugin<void> = {
           id: 'test-plugin',
           requires: [INotebookTracker, ITranslator],
@@ -448,7 +489,7 @@ ruleTester.run('plugin-activation-args', pluginActivationArgs, {
       // Wrong order in requires and optional mix
       filename: 'tests/type-aware-fixture.ts',
       code: `
-        import { INotebookTracker, ITranslator, IRenderMimeRegistry, IToolbarWidgetRegistry } from './fixtures/debugger-types';
+        import { INotebookTracker, ITranslator, IRenderMimeRegistry, IToolbarWidgetRegistry } from './fixtures/types';
         const plugin: JupyterFrontEndPlugin<void> = {
           id: 'test-plugin',
           requires: [INotebookTracker, IRenderMimeRegistry],
@@ -483,7 +524,7 @@ ruleTester.run('plugin-activation-args', pluginActivationArgs, {
       // Missing optional argument
       filename: 'tests/type-aware-fixture.ts',
       code: `
-        import { INotebookTracker, ITranslator, IToolbarWidgetRegistry } from './fixtures/debugger-types';
+        import { INotebookTracker, ITranslator, IToolbarWidgetRegistry } from './fixtures/types';
         const plugin: JupyterFrontEndPlugin<void> = {
           id: 'test-plugin',
           requires: [INotebookTracker],
@@ -603,7 +644,7 @@ ruleTester.run('plugin-activation-args', pluginActivationArgs, {
       // Incorrect type (null)
       filename: 'tests/type-aware-fixture.ts',
       code: `
-        import { INotebookTracker } from './fixtures/debugger-types';
+        import { INotebookTracker } from './fixtures/types';
         const plugin: JupyterFrontEndPlugin<void> = {
           id: 'test-plugin',
           requires: [INotebookTracker],
@@ -623,7 +664,7 @@ ruleTester.run('plugin-activation-args', pluginActivationArgs, {
       // Incorrect type
       filename: 'tests/type-aware-fixture.ts',
       code: `
-        import { INotebookTracker, IRenderMimeRegistry } from './fixtures/debugger-types';
+        import { INotebookTracker, IRenderMimeRegistry } from './fixtures/types';
         const plugin: JupyterFrontEndPlugin<void> = {
           id: 'test-plugin',
           requires: [INotebookTracker, IRenderMimeRegistry],
@@ -662,7 +703,7 @@ ruleTester.run('plugin-activation-args', pluginActivationArgs, {
     // Namespace pattern but wrong order
     filename: 'tests/type-aware-fixture.ts',
     code: `
-      import { IDebugger, IDebuggerSidebar, INotebookTracker } from './fixtures/debugger-types';
+      import { IDebugger, IDebuggerSidebar, INotebookTracker } from './fixtures/types';
       const plugin: JupyterFrontEndPlugin<void> = {
         id: 'test-plugin',
         requires: [INotebookTracker, IDebuggerSidebar],
@@ -684,6 +725,7 @@ ruleTester.run('plugin-activation-args', pluginActivationArgs, {
       // Optional token without | null
       filename: 'tests/type-aware-fixture.ts',
       code: `
+        import { IToolbarWidgetRegistry } from './fixtures/types';
         const plugin: JupyterFrontEndPlugin<void> = {
           id: 'test-plugin',
           optional: [IToolbarWidgetRegistry],
@@ -705,6 +747,7 @@ ruleTester.run('plugin-activation-args', pluginActivationArgs, {
     {
       filename: 'tests/type-aware-fixture.ts',
       code: `
+        import { INotebookTracker, IToolbarWidgetRegistry, ITranslator } from './fixtures/types';
         const plugin: JupyterFrontEndPlugin<void> = {
           id: 'test-plugin',
           requires: [INotebookTracker],

--- a/tests/jupyter-plugin-activation-args.test.ts
+++ b/tests/jupyter-plugin-activation-args.test.ts
@@ -320,6 +320,22 @@ ruleTester.run('plugin-activation-args', pluginActivationArgs, {
         }
       };
     `
+    },
+    {
+      // Optional token with | undefined is acceptable
+      filename: 'tests/type-aware-fixture.ts',
+      code: `
+        const plugin: JupyterFrontEndPlugin<void> = {
+          id: 'test-plugin',
+          optional: [ISettingRegistry],
+          activate: (
+            app: JupyterFrontEnd,
+            settingRegistry: ISettingRegistry | undefined,
+          ) => {
+            console.log('Activated');
+          }
+        };
+      `
     }
   ],
 
@@ -645,6 +661,52 @@ ruleTester.run('plugin-activation-args', pluginActivationArgs, {
       errors: [
         { messageId: 'mismatchedOrder', data: { arg: 'debuggerSidebar' } },
         { messageId: 'mismatchedOrder', data: { arg: 'tracker' } }
+      ]
+    },
+    {
+      // Optional token without | null
+      filename: 'tests/type-aware-fixture.ts',
+      code: `
+        const plugin: JupyterFrontEndPlugin<void> = {
+          id: 'test-plugin',
+          optional: [IToolbarWidgetRegistry],
+          activate: (
+            app: JupyterFrontEnd,
+            toolbarRegistry: IToolbarWidgetRegistry,
+          ) => {
+            console.log('Activated');
+          }
+        };
+      `,
+      errors: [
+        {
+          messageId: 'optionalNotNullable',
+          data: { arg: 'toolbarRegistry', type: 'IToolbarWidgetRegistry' }
+        }
+      ]
+    },
+    {
+      filename: 'tests/type-aware-fixture.ts',
+      code: `
+        const plugin: JupyterFrontEndPlugin<void> = {
+          id: 'test-plugin',
+          requires: [INotebookTracker],
+          optional: [IToolbarWidgetRegistry, ITranslator],
+          activate: (
+            app: JupyterFrontEnd,
+            tracker: INotebookTracker,
+            toolbarRegistry: IToolbarWidgetRegistry,
+            translator: ITranslator | null,
+          ) => {
+            console.log('Activated');
+          }
+        };
+      `,
+      errors: [
+        {
+          messageId: 'optionalNotNullable',
+          data: { arg: 'toolbarRegistry', type: 'IToolbarWidgetRegistry' }
+        }
       ]
     }
   ]

--- a/tests/jupyter-plugin-activation-args.test.ts
+++ b/tests/jupyter-plugin-activation-args.test.ts
@@ -336,6 +336,23 @@ ruleTester.run('plugin-activation-args', pluginActivationArgs, {
           }
         };
       `
+    },
+    {
+      // Optional token with ?: syntax (implies | undefined) is acceptable
+      filename: 'tests/type-aware-fixture.ts',
+      code: `
+        const plugin: JupyterFrontEndPlugin<void> = {
+          id: 'test-plugin',
+          optional: [ISettingRegistry, ITranslator],
+          activate: (
+            app: JupyterFrontEnd,
+            settingRegistry?: ISettingRegistry,
+            translator?: ITranslator,
+          ) => {
+            console.log('Activated');
+          }
+        };
+      `
     }
   ],
 

--- a/website/docs/rules/plugin-activation-args.md
+++ b/website/docs/rules/plugin-activation-args.md
@@ -19,6 +19,7 @@ This rule reports the following errors:
 - `missingArgument` — a token from `requires`/`optional` has no corresponding argument
 - `extraArgument` — an argument has no corresponding token in `requires`/`optional`
 - `serviceManagerFirstArgNotNull` — `ServiceManagerPlugin` first argument is not `null`
+- `optionalNotNullable` — an argument for an `optional` token is missing `| null` or `| undefined`
 
 ## Incorrect
 


### PR DESCRIPTION
## Fixes #51 

### Description
Optional tokens can be null at runtime if JupyterLab cannot resolve them. This change adds a new `optionalNotNullable` error to `plugin-activation-args` rule that fires when an activate parameter corresponding to an optional token is not typed as `T | null` (or `T | undefined`).