### PR TITLE
Add `no-schema-enum` rule: forbid enum in settings schema, suggest `oneOf`  

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -50,6 +50,12 @@ jobs:
         env:
           NODE_PATH: ./jupyterlab/node_modules
 
+      - name: Run schema JSON lint check
+        run: |
+          npx eslint --config eslint.downstream.config.mjs \
+            'jupyterlab/packages/*/schema/*.json' \
+            --max-warnings=9999
+
   notebook:
     runs-on: ubuntu-latest
     steps:
@@ -93,6 +99,12 @@ jobs:
         env:
           NODE_PATH: ./notebook/node_modules
 
+      - name: Run schema JSON lint check
+        run: |
+          npx eslint --config eslint.downstream.config.mjs \
+            'notebook/packages/*/schema/*.json' \
+            --max-warnings=9999
+
   jupyterlite:
     runs-on: ubuntu-latest
     steps:
@@ -135,3 +147,9 @@ jobs:
             --max-warnings=9999
         env:
           NODE_PATH: ./jupyterlite/node_modules
+
+      - name: Run schema JSON lint check
+        run: |
+          npx eslint --config eslint.downstream.config.mjs \
+            'jupyterlite/packages/*/schema/*.json' \
+            --max-warnings=9999

--- a/eslint.downstream.config.mjs
+++ b/eslint.downstream.config.mjs
@@ -13,52 +13,14 @@ const resolvedPlugin = pluginModule.default?.rules ? pluginModule.default : plug
 const parserModule = await import('@typescript-eslint/parser');
 const resolvedParser = parserModule.default ?? parserModule;
 
-// Prevents "Definition for rule not found" errors from eslint-disable comments
+// Prevents "Definition for rule not found" errors
 const tsPlugin = await import('@typescript-eslint/eslint-plugin');
 const resolvedTsPlugin = tsPlugin.default ?? tsPlugin;
-
-<<<<<<< forbid-enum
-const jsoncParserModule = await import('jsonc-eslint-parser');
-const resolvedJsoncParser = jsoncParserModule.default ?? jsoncParserModule;
-
-export default [
-  // JupyterLab
-  {
-    basePath: __dirname,
-    files: [
-      'jupyterlab/packages/*/src/**/*.ts',
-      'jupyterlab/packages/*/src/**/*.tsx'
-    ],
-    plugins: {
-      'jupyter': resolvedPlugin,
-      '@typescript-eslint': resolvedTsPlugin
-    },
-    rules: {
-      'jupyter/command-described-by': 'error',
-      'jupyter/no-untranslated-string': 'error',
-      'jupyter/plugin-activation-args': 'error',
-      'jupyter/plugin-description': 'error',
-      'jupyter/no-translation-concatenation': 'error',
-      'jupyter/token-format': 'error'
-    },
-    languageOptions: {
-      parser: resolvedParser,
-      parserOptions: {
-        ecmaVersion: 'latest',
-        sourceType: 'module',
-        project: path.resolve(__dirname, 'jupyterlab/tsconfig.eslint.json')
-      }
-    },
-    linterOptions: {
-      reportUnusedDisableDirectives: 'off'
-    }
-  },
-=======
-// Stub: satisfies ESLint's rule-name validation for jest/* disable comments
-// without importing the real plugin or enabling any jest rules.
 const noopRule = { create: () => ({}) };
 const jestStub = { rules: new Proxy({}, { get: () => noopRule }) };
->>>>>>> main
+
+const jsoncParserModule = await import('jsonc-eslint-parser');
+const resolvedJsoncParser = jsoncParserModule.default ?? jsoncParserModule;
 
 function makeProjectConfig(projectName) {
   return {
@@ -96,67 +58,65 @@ function makeProjectConfig(projectName) {
 }
 
 function makeTestConfig(projectName) {
-  return {
-    basePath: __dirname,
-    files: [
-      `${projectName}/**/*.spec.ts`,
-      `${projectName}/**/*.test.ts`
-    ],
-    plugins: {
-      'jupyter': resolvedPlugin,
-      '@typescript-eslint': resolvedTsPlugin,
-      'jest': jestStub,
-    },
-    rules: {
-      'jupyter/require-soft-assertions-before-snapshots': 'error'
-    },
-    languageOptions: {
-      parser: resolvedParser,
-      parserOptions: {
-        ecmaVersion: 'latest',
-        sourceType: 'module'
+  return [
+    {
+      basePath: __dirname,
+      files: [
+        `${projectName}/**/*.spec.ts`,
+        `${projectName}/**/*.test.ts`
+      ],
+      plugins: {
+        'jupyter': resolvedPlugin,
+        '@typescript-eslint': resolvedTsPlugin,
+        'jest': jestStub,
+      },
+      rules: {
+        'jupyter/require-soft-assertions-before-snapshots': 'error'
+      },
+      languageOptions: {
+        parser: resolvedParser,
+        parserOptions: {
+          ecmaVersion: 'latest',
+          sourceType: 'module'
+        }
+      },
+      linterOptions: {
+        reportUnusedDisableDirectives: 'off'
       }
     },
-    linterOptions: {
-      reportUnusedDisableDirectives: 'off'
+
+    // JupyterLab — settings schema JSON files
+    {
+      basePath: __dirname,
+      files: ['jupyterlab/packages/*/schema/*.json'],
+      plugins: { 'jupyter': resolvedPlugin },
+      rules: { 'jupyter/no-schema-enum': 'error' },
+      languageOptions: { parser: resolvedJsoncParser }
+    },
+
+    // Notebook — settings schema JSON files
+    {
+      basePath: __dirname,
+      files: ['notebook/packages/*/schema/*.json'],
+      plugins: { 'jupyter': resolvedPlugin },
+      rules: { 'jupyter/no-schema-enum': 'error' },
+      languageOptions: { parser: resolvedJsoncParser }
+    },
+
+    // JupyterLite — settings schema JSON files
+    {
+      basePath: __dirname,
+      files: ['jupyterlite/packages/*/schema/*.json'],
+      plugins: { 'jupyter': resolvedPlugin },
+      rules: { 'jupyter/no-schema-enum': 'error' },
+      languageOptions: { parser: resolvedJsoncParser }
     }
-<<<<<<< forbid-enum
-  },
-
-  // JupyterLab — settings schema JSON files
-  {
-    basePath: __dirname,
-    files: ['jupyterlab/packages/*/schema/*.json'],
-    plugins: { 'jupyter': resolvedPlugin },
-    rules: { 'jupyter/no-schema-enum': 'error' },
-    languageOptions: { parser: resolvedJsoncParser }
-  },
-
-  // Notebook — settings schema JSON files
-  {
-    basePath: __dirname,
-    files: ['notebook/packages/*/schema/*.json'],
-    plugins: { 'jupyter': resolvedPlugin },
-    rules: { 'jupyter/no-schema-enum': 'error' },
-    languageOptions: { parser: resolvedJsoncParser }
-  },
-
-  // JupyterLite — settings schema JSON files
-  {
-    basePath: __dirname,
-    files: ['jupyterlite/packages/*/schema/*.json'],
-    plugins: { 'jupyter': resolvedPlugin },
-    rules: { 'jupyter/no-schema-enum': 'error' },
-    languageOptions: { parser: resolvedJsoncParser }
-  }
-=======
-  };
+  ];
 }
 
 const projects = ['jupyterlab', 'notebook', 'jupyterlite'];
 
 export default [
   ...projects.map(makeProjectConfig),
-  ...projects.map(makeTestConfig)
->>>>>>> main
-];
+  ...projects.flatMap(makeTestConfig)
+]

--- a/eslint.downstream.config.mjs
+++ b/eslint.downstream.config.mjs
@@ -17,6 +17,9 @@ const resolvedParser = parserModule.default ?? parserModule;
 const tsPlugin = await import('@typescript-eslint/eslint-plugin');
 const resolvedTsPlugin = tsPlugin.default ?? tsPlugin;
 
+const jsoncParserModule = await import('jsonc-eslint-parser');
+const resolvedJsoncParser = jsoncParserModule.default ?? jsoncParserModule;
+
 export default [
   // JupyterLab
   {
@@ -112,5 +115,32 @@ export default [
     linterOptions: {
       reportUnusedDisableDirectives: 'off'
     }
+  },
+
+  // JupyterLab — settings schema JSON files
+  {
+    basePath: __dirname,
+    files: ['jupyterlab/packages/*/schema/*.json'],
+    plugins: { 'jupyter': resolvedPlugin },
+    rules: { 'jupyter/no-schema-enum': 'warn' },
+    languageOptions: { parser: resolvedJsoncParser }
+  },
+
+  // Notebook — settings schema JSON files
+  {
+    basePath: __dirname,
+    files: ['notebook/packages/*/schema/*.json'],
+    plugins: { 'jupyter': resolvedPlugin },
+    rules: { 'jupyter/no-schema-enum': 'warn' },
+    languageOptions: { parser: resolvedJsoncParser }
+  },
+
+  // JupyterLite — settings schema JSON files
+  {
+    basePath: __dirname,
+    files: ['jupyterlite/packages/*/schema/*.json'],
+    plugins: { 'jupyter': resolvedPlugin },
+    rules: { 'jupyter/no-schema-enum': 'warn' },
+    languageOptions: { parser: resolvedJsoncParser }
   }
 ];

--- a/eslint.downstream.config.mjs
+++ b/eslint.downstream.config.mjs
@@ -122,7 +122,7 @@ export default [
     basePath: __dirname,
     files: ['jupyterlab/packages/*/schema/*.json'],
     plugins: { 'jupyter': resolvedPlugin },
-    rules: { 'jupyter/no-schema-enum': 'warn' },
+    rules: { 'jupyter/no-schema-enum': 'error' },
     languageOptions: { parser: resolvedJsoncParser }
   },
 
@@ -131,7 +131,7 @@ export default [
     basePath: __dirname,
     files: ['notebook/packages/*/schema/*.json'],
     plugins: { 'jupyter': resolvedPlugin },
-    rules: { 'jupyter/no-schema-enum': 'warn' },
+    rules: { 'jupyter/no-schema-enum': 'error' },
     languageOptions: { parser: resolvedJsoncParser }
   },
 
@@ -140,7 +140,7 @@ export default [
     basePath: __dirname,
     files: ['jupyterlite/packages/*/schema/*.json'],
     plugins: { 'jupyter': resolvedPlugin },
-    rules: { 'jupyter/no-schema-enum': 'warn' },
+    rules: { 'jupyter/no-schema-enum': 'error' },
     languageOptions: { parser: resolvedJsoncParser }
   }
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "eslint": "^9.39.2",
         "eslint-plugin": "^1.0.1",
         "jest": "^30.2.0",
+        "jsonc-eslint-parser": "^2.4.2",
         "pre-commit": "^1.2.2",
         "prettier": "^3.8.1",
         "ts-jest": "^29.4.6",
@@ -65,6 +66,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1585,6 +1587,7 @@
       "integrity": "sha512-XZzOmihLIr8AD1b9hL9ccNMzEMWt/dE2u7NyTY9jJG6YNiNthaD5XtUHVF2uCXZ15ng+z2hT3MVuxnUYhq6k1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.0",
         "@typescript-eslint/types": "8.57.0",
@@ -2444,6 +2447,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2697,6 +2701,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3123,6 +3128,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz",
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3916,6 +3922,7 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -4571,6 +4578,43 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsonc-eslint-parser": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/jsonc-eslint-parser/-/jsonc-eslint-parser-2.4.2.tgz",
+      "integrity": "sha512-1e4qoRgnn448pRuMvKGsFFymUCquZV0mpGgOyIKNgD3JVDTsVJyRBGH/Fm0tBb8WsWGgmB1mDe6/yJMQM37DUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.5.0",
+        "eslint-visitor-keys": "^3.0.0",
+        "espree": "^9.0.0",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ota-meshi"
+      }
+    },
+    "node_modules/jsonc-eslint-parser/node_modules/espree": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.9.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/keyv": {
@@ -5785,6 +5829,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5945,6 +5990,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "eslint": "^9.39.2",
     "eslint-plugin": "^1.0.1",
     "jest": "^30.2.0",
+    "jsonc-eslint-parser": "^2.4.2",
     "pre-commit": "^1.2.2",
     "prettier": "^3.8.1",
     "ts-jest": "^29.4.6",

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@
  * Distributed under the terms of the Modified BSD License.
  */
 
+import * as jsoncParser from 'jsonc-eslint-parser';
 import pluginActivationArgs from './rules/plugin-activation-args';
 import commandDescribedBy from './rules/command-described-by';
 import pluginDescription from './rules/plugin-description';
@@ -35,9 +36,8 @@ const plugin = {
         }
       },
       {
-        // Requires jsonc-eslint-parser configured for JSON files in the
-        // consumer's ESLint config.
         files: ['**/schema/*.json'],
+        languageOptions: { parser: jsoncParser },
         rules: {
           'jupyter/no-schema-enum': 'warn'
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import pluginDescription from './rules/plugin-description';
 import noTranslationConcatenation from './rules/no-translation-concatenation';
 import tokenFormat from './rules/token-format';
 import noUntranslatedString from './rules/no-untranslated-string';
+import noSchemaEnum from './rules/no-schema-enum';
 
 const plugin = {
   rules: {
@@ -17,7 +18,8 @@ const plugin = {
     'plugin-description': pluginDescription,
     'no-translation-concatenation': noTranslationConcatenation,
     'token-format': tokenFormat,
-    'no-untranslated-string': noUntranslatedString
+    'no-untranslated-string': noUntranslatedString,
+    'no-schema-enum': noSchemaEnum
   },
   configs: {
     recommended: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,17 +22,27 @@ const plugin = {
     'no-schema-enum': noSchemaEnum
   },
   configs: {
-    recommended: {
-      files: ['**/*.js', '**/*.ts', '**/*.jsx', '**/*.tsx'],
-      rules: {
-        'jupyter/plugin-activation-args': 'error',
-        'jupyter/command-described-by': 'warn',
-        'jupyter/plugin-description': 'warn',
-        'jupyter/no-translation-concatenation': 'error',
-        'jupyter/token-format': 'error',
-        'jupyter/no-untranslated-string': 'warn'
+    recommended: [
+      {
+        files: ['**/*.js', '**/*.ts', '**/*.jsx', '**/*.tsx'],
+        rules: {
+          'jupyter/plugin-activation-args': 'error',
+          'jupyter/command-described-by': 'warn',
+          'jupyter/plugin-description': 'warn',
+          'jupyter/no-translation-concatenation': 'error',
+          'jupyter/token-format': 'error',
+          'jupyter/no-untranslated-string': 'warn'
+        }
+      },
+      {
+        // Requires jsonc-eslint-parser configured for JSON files in the
+        // consumer's ESLint config.
+        files: ['**/schema/*.json'],
+        rules: {
+          'jupyter/no-schema-enum': 'warn'
+        }
       }
-    },
+    ],
     'recommended-legacy': {
       rules: {
         'jupyter/plugin-activation-args': 'error',
@@ -40,7 +50,8 @@ const plugin = {
         'jupyter/plugin-description': 'warn',
         'jupyter/no-translation-concatenation': 'error',
         'jupyter/token-format': 'error',
-        'jupyter/no-untranslated-string': 'warn'
+        'jupyter/no-untranslated-string': 'warn',
+        'jupyter/no-schema-enum': 'warn'
       }
     }
   }

--- a/src/rules/no-schema-enum.ts
+++ b/src/rules/no-schema-enum.ts
@@ -4,6 +4,17 @@
  */
 
 import { createRule } from '../utils/create-rule';
+import type { TSESTree } from '@typescript-eslint/utils';
+
+type JSONKey =
+  | { type: 'JSONLiteral'; value: unknown }
+  | { type: 'JSONIdentifier'; name: string };
+
+interface JSONPropertyNode {
+  key: JSONKey;
+  value: { type: string };
+  loc: TSESTree.SourceLocation;
+}
 
 function isSchemaJsonFile(filename: string): boolean {
   return /[/\\]schema[/\\][^/\\]*\.json$/.test(filename);
@@ -26,26 +37,17 @@ const noSchemaEnum = createRule({
   defaultOptions: [],
 
   create(context) {
-    const filename: string =
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      context.filename ?? (context as any).getFilename?.() ?? '';
-
-    if (!isSchemaJsonFile(filename)) {
+    if (!isSchemaJsonFile(context.filename)) {
       return {};
     }
 
     return {
-      // Visitor for jsonc-eslint-parser JSON AST nodes
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      JSONProperty(node: any) {
-        const keyValue: unknown =
+      JSONProperty(node: JSONPropertyNode) {
+        const keyValue =
           node.key.type === 'JSONLiteral' ? node.key.value : node.key.name;
 
         if (keyValue === 'enum' && node.value.type === 'JSONArrayExpression') {
-          context.report({
-            node,
-            messageId: 'forbidEnum'
-          });
+          context.report({ loc: node.loc, messageId: 'forbidEnum' });
         }
       }
     };

--- a/src/rules/no-schema-enum.ts
+++ b/src/rules/no-schema-enum.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import { createRule } from '../utils/create-rule';
+
+function isSchemaJsonFile(filename: string): boolean {
+  return /[/\\]schema[/\\][^/\\]*\.json$/.test(filename);
+}
+
+const noSchemaEnum = createRule({
+  name: 'no-schema-enum',
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Disallow `enum` in settings JSON schema files; use `oneOf` with `const` and `title` instead'
+    },
+    messages: {
+      forbidEnum:
+        'Avoid `enum` in settings schema. Use `oneOf` with `const` and `title` per entry to support user-facing labels and translations.'
+    },
+    schema: []
+  },
+  defaultOptions: [],
+
+  create(context) {
+    const filename: string =
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      context.filename ?? (context as any).getFilename?.() ?? '';
+
+    if (!isSchemaJsonFile(filename)) {
+      return {};
+    }
+
+    return {
+      // Visitor for jsonc-eslint-parser JSON AST nodes
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      JSONProperty(node: any) {
+        const keyValue: unknown =
+          node.key.type === 'JSONLiteral' ? node.key.value : node.key.name;
+
+        if (keyValue === 'enum' && node.value.type === 'JSONArrayExpression') {
+          context.report({
+            node,
+            messageId: 'forbidEnum'
+          });
+        }
+      }
+    };
+  }
+});
+
+export = noSchemaEnum;

--- a/tests/jupyter-no-schema-enum.test.ts
+++ b/tests/jupyter-no-schema-enum.test.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import noSchemaEnum from '../src/rules/no-schema-enum';
+
+const SCHEMA_FILENAME = '/some/package/schema/plugin.json';
+const NON_SCHEMA_FILENAME = '/some/package/src/plugin.json';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parser: require('jsonc-eslint-parser')
+  }
+});
+
+// Cast needed because @typescript-eslint/rule-tester bundles its own copy of
+// @typescript-eslint/utils, causing a structural type mismatch at the IDE level.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+ruleTester.run('no-schema-enum', noSchemaEnum as any, {
+  valid: [
+    // oneOf is used instead of enum — correct pattern
+    {
+      filename: SCHEMA_FILENAME,
+      code: JSON.stringify({
+        properties: {
+          defaultZoom: {
+            oneOf: [
+              { const: 'fit-to-width', title: 'Fit to width' },
+              { const: 'fit-to-height', title: 'Fit to height' },
+              { const: '100%', title: '100%' }
+            ]
+          }
+        }
+      })
+    },
+    // enum in a non-schema directory is allowed
+    {
+      filename: NON_SCHEMA_FILENAME,
+      code: JSON.stringify({
+        properties: {
+          mode: {
+            type: 'string',
+            enum: ['a', 'b', 'c']
+          }
+        }
+      })
+    },
+    // enum used as a JSON Schema keyword outside a property value (e.g. as a
+    // string literal) — not an array, should not be flagged
+    {
+      filename: SCHEMA_FILENAME,
+      code: JSON.stringify({ enum: 'not-an-array' })
+    }
+  ],
+
+  invalid: [
+    // Top-level enum array
+    {
+      filename: SCHEMA_FILENAME,
+      code: JSON.stringify({ enum: ['a', 'b', 'c'] }),
+      errors: [{ messageId: 'forbidEnum' }]
+    },
+    // Nested inside a property definition
+    {
+      filename: SCHEMA_FILENAME,
+      code: JSON.stringify({
+        properties: {
+          defaultZoom: {
+            type: 'string',
+            enum: ['fit-to-width', 'fit-to-height', '100%']
+          }
+        }
+      }),
+      errors: [{ messageId: 'forbidEnum' }]
+    },
+    // Multiple enum usages in the same file
+    {
+      filename: SCHEMA_FILENAME,
+      code: JSON.stringify({
+        properties: {
+          mode: { enum: ['always', 'never'] },
+          zoom: { enum: ['fit', '100%'] }
+        }
+      }),
+      errors: [{ messageId: 'forbidEnum' }, { messageId: 'forbidEnum' }]
+    }
+  ]
+});

--- a/website/docs/rules/index.md
+++ b/website/docs/rules/index.md
@@ -5,6 +5,7 @@ This section documents all rules currently provided by `eslint-plugin-jupyter`.
 ## Available rules
 
 - [command-described-by](./command-described-by)
+- [no-schema-enum](./no-schema-enum)
 - [no-translation-concatenation](./no-translation-concatenation)
 - [no-untranslated-string](./no-untranslated-string)
 - [plugin-activation-args](./plugin-activation-args)

--- a/website/docs/rules/no-schema-enum.md
+++ b/website/docs/rules/no-schema-enum.md
@@ -1,0 +1,66 @@
+# `no-schema-enum`
+
+Disallow `enum` in settings JSON schema files; use `oneOf` with `const` and `title` instead.
+
+## Why
+
+In JupyterLab/Notebook v7+, using `enum` in a settings JSON schema prevents associating user-facing labels with values and makes the options untranslatable. The `oneOf` pattern with `const` and `title` per entry solves both problems: the `title` is what the user sees, and the `const` is the value stored — and `title` can be passed through the translation system.
+
+## Rule details
+
+The rule inspects JSON files located inside a `schema/` directory and reports any property named `"enum"` whose value is an array. It does not flag `enum` used with a non-array value, and it ignores JSON files outside of `schema/` directories.
+
+Requires [`jsonc-eslint-parser`](https://github.com/ota-meshi/jsonc-eslint-parser) (v2) to be configured as the parser for JSON files.
+
+## Incorrect
+
+```json
+{
+  "properties": {
+    "defaultZoom": {
+      "type": "string",
+      "enum": ["fit-to-width", "fit-to-height", "100%"]
+    }
+  }
+}
+```
+
+## Correct
+
+```json
+{
+  "properties": {
+    "defaultZoom": {
+      "oneOf": [
+        { "const": "fit-to-width",  "title": "Fit to width"  },
+        { "const": "fit-to-height", "title": "Fit to height" },
+        { "const": "100%",          "title": "100%"          }
+      ]
+    }
+  }
+}
+```
+
+## Options
+
+This rule has no options.
+
+## Configuration
+
+Add the rule to your ESLint flat config for schema JSON files:
+
+```js
+import jsoncParser from 'jsonc-eslint-parser';
+import jupyterPlugin from '@jupyter/eslint-plugin';
+
+export default [
+  {
+    files: ['**/schema/*.json'],
+    languageOptions: { parser: jsoncParser },
+    plugins: { jupyter: jupyterPlugin },
+    rules: {
+      'jupyter/no-schema-enum': 'error'
+    }
+  }
+];
+```

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -20,6 +20,7 @@ const sidebars: SidebarsConfig = {
       items: [
         'rules/index',
         'rules/command-described-by',
+        'rules/no-schema-enum',
         'rules/no-translation-concatenation',
         'rules/no-untranslated-string',
         'rules/plugin-activation-args',


### PR DESCRIPTION
## Fixes #52 

### Description
- New rule `jupyter/no-schema-enum`, visits `JSONProperty` nodes via `jsonc-eslint-parser`, only activates for files under a `schema/` directory
