### PR TITLE
Fix unresolved types in `plugin-activation-arg` for `'optionalNotNullable'`

### DIFF
--- a/src/rules/plugin-activation-args.ts
+++ b/src/rules/plugin-activation-args.ts
@@ -269,6 +269,11 @@ const jupyterPluginActivationArgs = createRule({
           const tsNode = services?.esTreeNodeToTSNodeMap.get(paramNode);
           if (tsNode) {
             const type = checker.getTypeAtLocation(tsNode);
+            // Fall back to the syntactic check so `T | null` annotations are still
+            // accepted even when T cannot be resolved. (happens when package is unbuilt)
+            if (type.flags & ts.TypeFlags.Any) {
+              return isNullableAnnotation(paramNode);
+            }
             if (type.isUnion()) {
               return type.types.some(
                 t =>


### PR DESCRIPTION
## Fixes #61 

### Description

Handles cases when type can't be resolved (in unbuilt package) when checking for `'optionalNotNullable'` rule.
Fall back to the syntactic check so `T | null` annotations are still accepted even when T cannot be resolved.
Cause of issue was that the `any | null` simplifies to `any` in TypeScript (not a union)