### PR TITLE
Add `jupyter/no-pageconfig-base-url`

### DIFF
--- a/eslint.downstream.config.mjs
+++ b/eslint.downstream.config.mjs
@@ -18,6 +18,7 @@ const tsPlugin = await import('@typescript-eslint/eslint-plugin');
 const resolvedTsPlugin = tsPlugin.default ?? tsPlugin;
 const noopRule = { create: () => ({}) };
 const jestStub = { rules: new Proxy({}, { get: () => noopRule }) };
+const regexStub = { rules: new Proxy({}, { get: () => noopRule }) };
 
 const jsoncParserModule = await import('jsonc-eslint-parser');
 const resolvedJsoncParser = jsoncParserModule.default ?? jsoncParserModule;
@@ -32,7 +33,8 @@ function makeProjectConfig(projectName) {
     plugins: {
       'jupyter': resolvedPlugin,
       '@typescript-eslint': resolvedTsPlugin,
-      'jest': jestStub
+      'jest': jestStub,
+      'regexp': regexStub
     },
     rules: {
       'jupyter/command-described-by': 'error',

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import tokenFormat from './rules/token-format';
 import noUntranslatedString from './rules/no-untranslated-string';
 import noSchemaEnum from './rules/no-schema-enum';
 import requireSoftAssertionsBeforeSnapshots from './rules/require-soft-assertions-before-snapshots';
+import noPageconfigBaseUrl from './rules/no-pageconfig-base-url';
 
 const plugin = {
   rules: {
@@ -23,7 +24,8 @@ const plugin = {
     'no-untranslated-string': noUntranslatedString,
     'no-schema-enum': noSchemaEnum,
     'require-soft-assertions-before-snapshots':
-      requireSoftAssertionsBeforeSnapshots
+      requireSoftAssertionsBeforeSnapshots,
+    'no-pageconfig-base-url': noPageconfigBaseUrl
   },
   configs: {
     recommended: [
@@ -35,7 +37,8 @@ const plugin = {
           'jupyter/plugin-description': 'warn',
           'jupyter/no-translation-concatenation': 'error',
           'jupyter/token-format': 'error',
-          'jupyter/no-untranslated-string': 'warn'
+          'jupyter/no-untranslated-string': 'warn',
+          'jupyter/no-pageconfig-base-url': 'warn'
         }
       },
       {
@@ -65,7 +68,8 @@ const plugin = {
         'jupyter/no-translation-concatenation': 'error',
         'jupyter/token-format': 'error',
         'jupyter/no-untranslated-string': 'warn',
-        'jupyter/no-schema-enum': 'warn'
+        'jupyter/no-schema-enum': 'warn',
+        'jupyter/no-pageconfig-base-url': 'warn'
       },
       overrides: [
         {

--- a/src/rules/no-pageconfig-base-url.ts
+++ b/src/rules/no-pageconfig-base-url.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import { createRule } from '../utils/create-rule';
+
+const jupyterNoPageconfigBaseUrl = createRule({
+  name: 'no-pageconfig-base-url',
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'Disallow PageConfig.getBaseUrl() outside of makeSettings()',
+      url: 'https://eslint-plugin.readthedocs.io/en/latest/rules/no-pageconfig-base-url/'
+    },
+    messages: {
+      noPageconfigBaseUrl:
+        'PageConfig.getBaseUrl() should not be called outside of makeSettings(). ' +
+        'Store ServerConnection.ISettings and access .baseUrl from it each time.'
+    },
+    schema: []
+  },
+  defaultOptions: [],
+  create(context) {
+    return {
+      CallExpression(node) {
+        const { callee } = node;
+        if (
+          callee.type === 'MemberExpression' &&
+          callee.object.type === 'Identifier' &&
+          callee.object.name === 'PageConfig' &&
+          callee.property.type === 'Identifier' &&
+          callee.property.name === 'getBaseUrl'
+        ) {
+          context.report({ node, messageId: 'noPageconfigBaseUrl' });
+        }
+      }
+    };
+  }
+});
+
+export = jupyterNoPageconfigBaseUrl;

--- a/tests/jupyter-no-pageconfig-base-url.test.ts
+++ b/tests/jupyter-no-pageconfig-base-url.test.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import noPageconfigBaseUrl from '../src/rules/no-pageconfig-base-url';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parser: require('@typescript-eslint/parser'),
+    parserOptions: {
+      ecmaVersion: 2020,
+      sourceType: 'module'
+    }
+  }
+});
+
+ruleTester.run('no-pageconfig-base-url', noPageconfigBaseUrl, {
+  valid: [
+    // Different method on PageConfig
+    { code: `PageConfig.getOption('someKey');` },
+    // Different object
+    { code: `someOther.getBaseUrl();` },
+    // Free function call
+    { code: `getBaseUrl();` },
+    // Property access (not a call)
+    { code: `const url = settings.baseUrl;` }
+  ],
+
+  invalid: [
+    {
+      code: `const url = PageConfig.getBaseUrl();`,
+      errors: [{ messageId: 'noPageconfigBaseUrl' }]
+    },
+    {
+      code: `PageConfig.getBaseUrl();`,
+      errors: [{ messageId: 'noPageconfigBaseUrl' }]
+    },
+    {
+      code: `const x = URLExt.join(PageConfig.getBaseUrl(), path);`,
+      errors: [{ messageId: 'noPageconfigBaseUrl' }]
+    },
+    {
+      code: `this._baseUrl = PageConfig.getBaseUrl();`,
+      errors: [{ messageId: 'noPageconfigBaseUrl' }]
+    }
+  ]
+});

--- a/website/docs/rules/index.md
+++ b/website/docs/rules/index.md
@@ -7,6 +7,7 @@ This section documents all rules currently provided by `eslint-plugin-jupyter`.
 - [command-described-by](./command-described-by)
 - [no-schema-enum](./no-schema-enum)
 - [no-translation-concatenation](./no-translation-concatenation)
+- [no-pageconfig-base-url](./no-pageconfig-base-url)
 - [no-untranslated-string](./no-untranslated-string)
 - [plugin-activation-args](./plugin-activation-args)
 - [plugin-description](./plugin-description)
@@ -29,6 +30,7 @@ The plugin ships with a recommended configuration that enables all current rules
 | [jupyter/token-format](./token-format) | `error` |
 | [jupyter/require-soft-assertions-before-snapshots](./require-soft-assertions-before-snapshots) | `warn` ¹ |
 | [jupyter/no-schema-enum](./no-schema-enum) | `warn` ² |
+| [jupyter/no-pageconfig-base-url](./no-pageconfig-base-url) | `warn` |
 
 ¹ Applied only to `**/*.spec.{ts,js}` and `**/*.test.{ts,js}` files.  
 ² Applied only to `**/schema/*.json` files

--- a/website/docs/rules/no-pageconfig-base-url.md
+++ b/website/docs/rules/no-pageconfig-base-url.md
@@ -6,7 +6,7 @@ Disallow calling `PageConfig.getBaseUrl()` outside of `makeSettings()`.
 
 JupyterLab supports swapping the backend URL at runtime via a custom `ServiceManagerPlugin<ServerConnection.ISettings>`. This only works when code retrieves `baseUrl` fresh from a stored `ServerConnection.ISettings` object each time it is needed, rather than capturing it once at construction time.
 
-Calling `PageConfig.getBaseUrl()` directly bypasses `ServerConnection.ISettings` entirely, or memoizes the URL in a field, making the backend URL effectively immutable for the lifetime of the object.
+Calling `PageConfig.getBaseUrl()` directly bypasses `ServerConnection.ISettings` entirely, making the backend URL effectively immutable for the lifetime of the object, especially when memoizing the URL in a field.
 
 ## Rule details
 

--- a/website/docs/rules/no-pageconfig-base-url.md
+++ b/website/docs/rules/no-pageconfig-base-url.md
@@ -1,0 +1,50 @@
+# `no-pageconfig-base-url`
+
+Disallow calling `PageConfig.getBaseUrl()` outside of `makeSettings()`.
+
+## Why
+
+JupyterLab supports swapping the backend URL at runtime via a custom `ServiceManagerPlugin<ServerConnection.ISettings>`. This only works when code retrieves `baseUrl` fresh from a stored `ServerConnection.ISettings` object each time it is needed, rather than capturing it once at construction time.
+
+Calling `PageConfig.getBaseUrl()` directly bypasses `ServerConnection.ISettings` entirely, or memoizes the URL in a field, making the backend URL effectively immutable for the lifetime of the object.
+
+## Rule details
+
+The rule reports every call expression of the form `PageConfig.getBaseUrl()`. The only legitimate call site is inside the `ServerConnection.makeSettings()` implementation itself, and in tests or examples.
+
+## Incorrect
+
+```ts
+// Stored on instance — URL can never change after construction
+constructor(options: IOptions) {
+  this._baseUrl = PageConfig.getBaseUrl();
+}
+
+// Captured in a closure at activation time
+activate: (app: JupyterFrontEnd, paths: JupyterFrontEnd.IPaths) => {
+  const url = URLExt.join(PageConfig.getBaseUrl(), paths.urls.themes);
+  return new ThemeManager({ url });
+};
+```
+
+## Correct
+
+```ts
+// Access baseUrl from stored settings each time it is needed
+private async _requestAPI<T>(): Promise<T> {
+  const settings = this._serverSettings;
+  const requestUrl = URLExt.join(settings.baseUrl, API_PATH);
+  const response = await ServerConnection.makeRequest(requestUrl, {}, settings);
+  ...
+}
+
+// Pass serverSettings through and read baseUrl when needed
+activate: (app: JupyterFrontEnd) => {
+  const serverSettings = app.serviceManager.serverSettings;
+  return new MyManager({ serverSettings });
+};
+```
+
+## Options
+
+This rule has no options.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -20,6 +20,7 @@ const sidebars: SidebarsConfig = {
       items: [
         'rules/index',
         'rules/command-described-by',
+        'rules/no-pageconfig-base-url',
         'rules/no-schema-enum',
         'rules/no-translation-concatenation',
         'rules/no-untranslated-string',


### PR DESCRIPTION
## Fixes #66 

### Description
Add new rule that disallows calling `PageConfig.getBaseUrl()`.