### PR TITLE
Add type definition for correct `oneOf` example

### DIFF
--- a/website/docs/rules/no-schema-enum.md
+++ b/website/docs/rules/no-schema-enum.md
@@ -31,6 +31,7 @@ Requires [`jsonc-eslint-parser`](https://github.com/ota-meshi/jsonc-eslint-parse
 {
   "properties": {
     "defaultZoom": {
+      "type": "string",
       "oneOf": [
         { "const": "fit-to-width",  "title": "Fit to width"  },
         { "const": "fit-to-height", "title": "Fit to height" },


### PR DESCRIPTION
Related to #69 