### PR TITLE
Add disposable ownership lint rules

### DIFF
--- a/eslint.downstream.config.mjs
+++ b/eslint.downstream.config.mjs
@@ -76,6 +76,21 @@ function makeExtensionAdoptionConfig(projectName) {
   };
 }
 
+function makeDisposableTestSeverityConfig(projectName) {
+  return {
+    basePath: __dirname,
+    files: [
+      `${projectName}/**/*.spec.ts`,
+      `${projectName}/**/*.test.ts`,
+      `${projectName}/packages/*/src/testutils.ts`
+    ],
+    rules: {
+      'jupyter/require-disposable-ownership': 'warn',
+      'jupyter/require-disposable-transfer': 'warn'
+    }
+  };
+}
+
 function makeTestConfig(projectName) {
   return [
     {
@@ -138,5 +153,6 @@ const projects = ['jupyterlab', 'notebook', 'jupyterlite'];
 export default [
   ...projects.map(makeProjectConfig),
   ...projects.map(makeExtensionAdoptionConfig),
+  ...projects.map(makeDisposableTestSeverityConfig),
   ...projects.flatMap(makeTestConfig)
 ]

--- a/eslint.downstream.config.mjs
+++ b/eslint.downstream.config.mjs
@@ -43,7 +43,9 @@ function makeProjectConfig(projectName) {
       'jupyter/plugin-description': 'error',
       'jupyter/no-translation-concatenation': 'error',
       'jupyter/token-format': 'error',
-      'jupyter/require-soft-assertions-before-snapshots': 'error'
+      'jupyter/require-soft-assertions-before-snapshots': 'error',
+      'jupyter/require-disposable-ownership': 'error',
+      'jupyter/require-disposable-transfer': 'error'
     },
     languageOptions: {
       parser: resolvedParser,

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,8 @@ import noUntranslatedString from './rules/no-untranslated-string';
 import noSchemaEnum from './rules/no-schema-enum';
 import requireSoftAssertionsBeforeSnapshots from './rules/require-soft-assertions-before-snapshots';
 import noPageconfigBaseUrl from './rules/no-pageconfig-base-url';
+import requireDisposableOwnership from './rules/require-disposable-ownership';
+import requireDisposableTransfer from './rules/require-disposable-transfer';
 
 const plugin = {
   rules: {
@@ -25,7 +27,9 @@ const plugin = {
     'no-schema-enum': noSchemaEnum,
     'require-soft-assertions-before-snapshots':
       requireSoftAssertionsBeforeSnapshots,
-    'no-pageconfig-base-url': noPageconfigBaseUrl
+    'no-pageconfig-base-url': noPageconfigBaseUrl,
+    'require-disposable-ownership': requireDisposableOwnership,
+    'require-disposable-transfer': requireDisposableTransfer
   },
   configs: {
     recommended: [
@@ -38,7 +42,9 @@ const plugin = {
           'jupyter/no-translation-concatenation': 'error',
           'jupyter/token-format': 'error',
           'jupyter/no-untranslated-string': 'warn',
-          'jupyter/no-pageconfig-base-url': 'warn'
+          'jupyter/no-pageconfig-base-url': 'warn',
+          'jupyter/require-disposable-ownership': 'warn',
+          'jupyter/require-disposable-transfer': 'warn'
         }
       },
       {
@@ -49,12 +55,7 @@ const plugin = {
         }
       },
       {
-        files: [
-          '**/*.spec.ts',
-          '**/*.spec.js',
-          '**/*.test.ts',
-          '**/*.test.js'
-        ],
+        files: ['**/*.spec.ts', '**/*.spec.js', '**/*.test.ts', '**/*.test.js'],
         rules: {
           'jupyter/require-soft-assertions-before-snapshots': 'warn'
         }
@@ -69,7 +70,9 @@ const plugin = {
         'jupyter/token-format': 'error',
         'jupyter/no-untranslated-string': 'warn',
         'jupyter/no-schema-enum': 'warn',
-        'jupyter/no-pageconfig-base-url': 'warn'
+        'jupyter/no-pageconfig-base-url': 'warn',
+        'jupyter/require-disposable-ownership': 'warn',
+        'jupyter/require-disposable-transfer': 'warn'
       },
       overrides: [
         {

--- a/src/rules/require-disposable-ownership.ts
+++ b/src/rules/require-disposable-ownership.ts
@@ -107,6 +107,8 @@ const requireDisposableOwnership = createRule({
       },
 
       NewExpression(node) {
+        markManagedDisposableUse(pending, node, ownership);
+
         if (!isDisposableCreation(node)) {
           return;
         }

--- a/src/rules/require-disposable-ownership.ts
+++ b/src/rules/require-disposable-ownership.ts
@@ -9,6 +9,7 @@ import * as ts from 'typescript';
 import { createRule } from '../utils/create-rule';
 import {
   addPendingDisposable,
+  DEFAULT_OWNERSHIP_FUNCTION_NAMES,
   DisposableOwnershipContext,
   getAssignedVariable,
   isDisposableConstructor,
@@ -44,9 +45,9 @@ const requireDisposableOwnership = createRule({
           ownershipFunctionNames: {
             type: 'array',
             items: { type: 'string' },
-            default: [],
+            default: DEFAULT_OWNERSHIP_FUNCTION_NAMES,
             description:
-              'Additional function or method names that take ownership of a disposable argument.'
+              'Function or method names that take ownership of a disposable argument.'
           }
         },
         additionalProperties: false
@@ -87,7 +88,8 @@ const requireDisposableOwnership = createRule({
       checker,
       services,
       ownershipFunctionNames: new Set(
-        (options as RuleOptions).ownershipFunctionNames ?? []
+        (options as RuleOptions).ownershipFunctionNames ??
+          DEFAULT_OWNERSHIP_FUNCTION_NAMES
       )
     };
 

--- a/src/rules/require-disposable-ownership.ts
+++ b/src/rules/require-disposable-ownership.ts
@@ -15,6 +15,7 @@ import {
   isDisposableConstructor,
   isDisposableExpressionManaged,
   isDisposableType,
+  isInJupyterPluginActivate,
   isOuterFunctionScopeVariable,
   markManagedDisposableUse,
   PendingDisposableMap
@@ -109,6 +110,10 @@ const requireDisposableOwnership = createRule({
 
       NewExpression(node) {
         markManagedDisposableUse(pending, node, ownership);
+
+        if (isInJupyterPluginActivate(node, ownership)) {
+          return;
+        }
 
         if (!isDisposableCreation(node)) {
           return;

--- a/src/rules/require-disposable-ownership.ts
+++ b/src/rules/require-disposable-ownership.ts
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import { TSESTree } from '@typescript-eslint/types';
+import { ESLintUtils, ParserServices } from '@typescript-eslint/utils';
+import * as ts from 'typescript';
+import { createRule } from '../utils/create-rule';
+import {
+  addPendingDisposable,
+  DisposableOwnershipContext,
+  getAssignedVariable,
+  isDisposableConstructor,
+  isDisposableExpressionManaged,
+  isDisposableType,
+  markManagedDisposableUse,
+  PendingDisposableMap
+} from '../utils/disposables';
+
+interface RuleOptions {
+  ownershipFunctionNames?: string[];
+}
+
+const requireDisposableOwnership = createRule({
+  name: 'require-disposable-ownership',
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Require newly created IDisposable objects to be owned, returned, assigned to a field, or disposed',
+      url: 'https://eslint-plugin.readthedocs.io/en/latest/rules/require-disposable-ownership/'
+    },
+    messages: {
+      unmanagedDisposable:
+        'Disposable created here must be owned, returned, assigned to a field, or disposed.',
+      unmanagedDisposableVariable:
+        'Disposable "{{ name }}" must be owned, returned, assigned to a field, or disposed.'
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          ownershipFunctionNames: {
+            type: 'array',
+            items: { type: 'string' },
+            default: [],
+            description:
+              'Additional function or method names that take ownership of a disposable argument.'
+          }
+        },
+        additionalProperties: false
+      }
+    ]
+  },
+  defaultOptions: [{}],
+
+  create(context, [options]) {
+    const pending: PendingDisposableMap = new Map();
+    let services: ParserServices | null = null;
+    let checker: ts.TypeChecker | null = null;
+
+    try {
+      services = ESLintUtils.getParserServices(context, true);
+      checker = services.program ? services.program.getTypeChecker() : null;
+    } catch {
+      services = null;
+    }
+
+    function isDisposableCreation(node: TSESTree.NewExpression): boolean {
+      if (checker && services) {
+        try {
+          const tsNode = services.esTreeNodeToTSNodeMap.get(node);
+          const type = checker.getTypeAtLocation(tsNode);
+          if (isDisposableType(type, checker)) {
+            return true;
+          }
+        } catch {
+          // Fall back to the known Lumino disposable constructors below.
+        }
+      }
+      return isDisposableConstructor(node);
+    }
+
+    const ownership: DisposableOwnershipContext = {
+      sourceCode: context.sourceCode,
+      checker,
+      services,
+      ownershipFunctionNames: new Set(
+        (options as RuleOptions).ownershipFunctionNames ?? []
+      )
+    };
+
+    return {
+      CallExpression(node) {
+        markManagedDisposableUse(pending, node, ownership);
+      },
+
+      ReturnStatement(node) {
+        markManagedDisposableUse(pending, node, ownership);
+      },
+
+      AssignmentExpression(node) {
+        markManagedDisposableUse(pending, node, ownership);
+      },
+
+      NewExpression(node) {
+        if (!isDisposableCreation(node)) {
+          return;
+        }
+
+        const assignedVariable = getAssignedVariable(node, context.sourceCode);
+        if (assignedVariable) {
+          addPendingDisposable(pending, assignedVariable, node);
+          return;
+        }
+
+        if (isDisposableExpressionManaged(node, ownership)) {
+          return;
+        }
+
+        context.report({ node, messageId: 'unmanagedDisposable' });
+      },
+
+      'Program:exit'() {
+        for (const [variable, records] of pending) {
+          for (const record of records) {
+            context.report({
+              node: record.node,
+              messageId: 'unmanagedDisposableVariable',
+              data: { name: variable.name }
+            });
+          }
+        }
+      }
+    };
+  }
+});
+
+export = requireDisposableOwnership;

--- a/src/rules/require-disposable-transfer.ts
+++ b/src/rules/require-disposable-transfer.ts
@@ -9,6 +9,7 @@ import * as ts from 'typescript';
 import { createRule } from '../utils/create-rule';
 import {
   addPendingDisposable,
+  DEFAULT_OWNERSHIP_FUNCTION_NAMES,
   DisposableOwnershipContext,
   getAssignedVariable,
   getCalleeName,
@@ -21,7 +22,27 @@ import {
 } from '../utils/disposables';
 
 interface RuleOptions {
+  ignoredReturnFunctionNames?: string[];
   ownershipFunctionNames?: string[];
+}
+
+const DEFAULT_IGNORED_RETURN_FUNCTION_NAMES = [
+  'add',
+  'addCommand',
+  'addGroup',
+  'addItem',
+  'addKeyBinding',
+  'contextMenuWidget',
+  'find',
+  'get',
+  'insertCell',
+  'register',
+  'registerStatusItem',
+  'transform'
+];
+
+function isDefaultIgnoredFactoryReturnFunctionName(name: string): boolean {
+  return /^add[A-Za-z0-9_$]*Factory$/.test(name);
 }
 
 const requireDisposableTransfer = createRule({
@@ -46,9 +67,16 @@ const requireDisposableTransfer = createRule({
           ownershipFunctionNames: {
             type: 'array',
             items: { type: 'string' },
-            default: [],
+            default: DEFAULT_OWNERSHIP_FUNCTION_NAMES,
             description:
-              'Additional function or method names that take ownership of a disposable argument.'
+              'Function or method names that take ownership of a disposable argument.'
+          },
+          ignoredReturnFunctionNames: {
+            type: 'array',
+            items: { type: 'string' },
+            default: DEFAULT_IGNORED_RETURN_FUNCTION_NAMES,
+            description:
+              'Function or method names whose disposable return value is intentionally ignored.'
           }
         },
         additionalProperties: false
@@ -87,12 +115,31 @@ const requireDisposableTransfer = createRule({
       }
     }
 
+    const ignoredReturnFunctionNamesOption = (options as RuleOptions)
+      .ignoredReturnFunctionNames;
+    const ignoredReturnFunctionNames = new Set(
+      ignoredReturnFunctionNamesOption ?? DEFAULT_IGNORED_RETURN_FUNCTION_NAMES
+    );
+
+    function isIgnoredReturn(node: TSESTree.CallExpression): boolean {
+      const name = getCalleeName(node.callee);
+      if (!name) {
+        return false;
+      }
+      return (
+        ignoredReturnFunctionNames.has(name) ||
+        (ignoredReturnFunctionNamesOption === undefined &&
+          isDefaultIgnoredFactoryReturnFunctionName(name))
+      );
+    }
+
     const ownership: DisposableOwnershipContext = {
       sourceCode: context.sourceCode,
       checker,
       services,
       ownershipFunctionNames: new Set(
-        (options as RuleOptions).ownershipFunctionNames ?? []
+        (options as RuleOptions).ownershipFunctionNames ??
+          DEFAULT_OWNERSHIP_FUNCTION_NAMES
       )
     };
 
@@ -101,6 +148,7 @@ const requireDisposableTransfer = createRule({
         markManagedDisposableUse(pending, node, ownership);
 
         if (
+          isIgnoredReturn(node) ||
           !shouldCheckReturnedDisposable(node) ||
           isDisposableExpressionManaged(node, ownership)
         ) {

--- a/src/rules/require-disposable-transfer.ts
+++ b/src/rules/require-disposable-transfer.ts
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import { TSESTree } from '@typescript-eslint/types';
+import { ESLintUtils, ParserServices } from '@typescript-eslint/utils';
+import * as ts from 'typescript';
+import { createRule } from '../utils/create-rule';
+import {
+  addPendingDisposable,
+  DisposableOwnershipContext,
+  getAssignedVariable,
+  getCalleeName,
+  isDisposableExpressionManaged,
+  isDisposableSetFactoryCall,
+  isDisposableType,
+  markManagedDisposableUse,
+  PendingDisposableMap,
+  shouldCheckReturnedDisposable
+} from '../utils/disposables';
+
+interface RuleOptions {
+  ownershipFunctionNames?: string[];
+}
+
+const requireDisposableTransfer = createRule({
+  name: 'require-disposable-transfer',
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Require calls returning IDisposable to be stored, returned, added to a DisposableSet, or disposed',
+      url: 'https://eslint-plugin.readthedocs.io/en/latest/rules/require-disposable-transfer/'
+    },
+    messages: {
+      unhandledDisposable:
+        'IDisposable returned from "{{ name }}" must be stored, returned, added to a DisposableSet, or disposed.',
+      unmanagedDisposableVariable:
+        'IDisposable "{{ name }}" must be returned, added to a DisposableSet, assigned to a field, or disposed.'
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          ownershipFunctionNames: {
+            type: 'array',
+            items: { type: 'string' },
+            default: [],
+            description:
+              'Additional function or method names that take ownership of a disposable argument.'
+          }
+        },
+        additionalProperties: false
+      }
+    ]
+  },
+  defaultOptions: [{}],
+
+  create(context, [options]) {
+    const pending: PendingDisposableMap = new Map();
+    let services: ParserServices | null = null;
+    let checker: ts.TypeChecker | null = null;
+
+    try {
+      services = ESLintUtils.getParserServices(context, true);
+      checker = services.program ? services.program.getTypeChecker() : null;
+    } catch {
+      services = null;
+    }
+
+    function returnsDisposable(node: TSESTree.CallExpression): boolean {
+      if (isDisposableSetFactoryCall(node)) {
+        return true;
+      }
+
+      if (!checker || !services) {
+        return false;
+      }
+
+      try {
+        const tsNode = services.esTreeNodeToTSNodeMap.get(node);
+        const type = checker.getTypeAtLocation(tsNode);
+        return isDisposableType(type, checker);
+      } catch {
+        return false;
+      }
+    }
+
+    const ownership: DisposableOwnershipContext = {
+      sourceCode: context.sourceCode,
+      checker,
+      services,
+      ownershipFunctionNames: new Set(
+        (options as RuleOptions).ownershipFunctionNames ?? []
+      )
+    };
+
+    return {
+      CallExpression(node) {
+        markManagedDisposableUse(pending, node, ownership);
+
+        if (
+          !shouldCheckReturnedDisposable(node) ||
+          isDisposableExpressionManaged(node, ownership)
+        ) {
+          return;
+        }
+
+        if (!returnsDisposable(node)) {
+          return;
+        }
+
+        const assignedVariable = getAssignedVariable(node, context.sourceCode);
+        if (assignedVariable) {
+          addPendingDisposable(pending, assignedVariable, node);
+          return;
+        }
+
+        context.report({
+          node,
+          messageId: 'unhandledDisposable',
+          data: { name: getCalleeName(node.callee) ?? 'call' }
+        });
+      },
+
+      ReturnStatement(node) {
+        markManagedDisposableUse(pending, node, ownership);
+      },
+
+      AssignmentExpression(node) {
+        markManagedDisposableUse(pending, node, ownership);
+      },
+
+      'Program:exit'() {
+        for (const [variable, records] of pending) {
+          for (const record of records) {
+            context.report({
+              node: record.node,
+              messageId: 'unmanagedDisposableVariable',
+              data: { name: variable.name }
+            });
+          }
+        }
+      }
+    };
+  }
+});
+
+export = requireDisposableTransfer;

--- a/src/rules/require-disposable-transfer.ts
+++ b/src/rules/require-disposable-transfer.ts
@@ -27,16 +27,28 @@ interface RuleOptions {
 }
 
 const DEFAULT_IGNORED_RETURN_FUNCTION_NAMES = [
+  '_adjacentBar',
+  '_currentTabBar',
   'add',
   'addCommand',
+  'addFileType',
   'addGroup',
   'addItem',
   'addKeyBinding',
+  'addWidgetExtension',
+  'contextForWidget',
   'contextMenuWidget',
   'find',
   'get',
+  'getCurrent',
+  'getLanguageServerManager',
+  'getLogger',
+  'getManager',
+  'initializeState',
   'insertCell',
+  'insertTab',
   'register',
+  'registerItem',
   'registerStatusItem',
   'transform'
 ];

--- a/src/rules/require-disposable-transfer.ts
+++ b/src/rules/require-disposable-transfer.ts
@@ -29,27 +29,45 @@ interface RuleOptions {
 const DEFAULT_IGNORED_RETURN_FUNCTION_NAMES = [
   '_adjacentBar',
   '_currentTabBar',
+  '_handleNewSession',
   'add',
   'addCommand',
+  'addCommandToolbarButtonClass',
   'addFileType',
   'addGroup',
   'addItem',
   'addKeyBinding',
+  'addToolbarButtonClass',
   'addWidgetExtension',
   'contextForWidget',
   'contextMenuWidget',
+  'defaultWidgetFactory',
   'find',
+  'findWidget',
   'get',
   'getCurrent',
   'getLanguageServerManager',
   'getLogger',
   'getManager',
+  'getModelFactory',
+  'getWidgetFactory',
   'initializeState',
   'insertCell',
+  'insertItem',
   'insertTab',
+  'openInspector',
+  'openOrReveal',
+  'pop',
+  'popLastModifiedCell',
   'register',
   'registerItem',
   'registerStatusItem',
+  'requestCreateSubshell',
+  'requestDebug',
+  'requestDeleteSubshell',
+  'shift',
+  'widgetAt',
+  'widgetRenderer',
   'transform'
 ];
 
@@ -189,6 +207,10 @@ const requireDisposableTransfer = createRule({
       },
 
       AssignmentExpression(node) {
+        markManagedDisposableUse(pending, node, ownership);
+      },
+
+      NewExpression(node) {
         markManagedDisposableUse(pending, node, ownership);
       },
 

--- a/src/rules/require-disposable-transfer.ts
+++ b/src/rules/require-disposable-transfer.ts
@@ -17,6 +17,7 @@ import {
   isDisposableExpressionManaged,
   isDisposableSetFactoryCall,
   isDisposableType,
+  isInJupyterPluginActivate,
   isOuterFunctionScopeVariable,
   markManagedDisposableUse,
   PendingDisposableMap,
@@ -46,6 +47,7 @@ const DEFAULT_IGNORED_RETURN_FUNCTION_NAMES = [
   'contextForWidget',
   'contextMenuWidget',
   'defaultWidgetFactory',
+  'delete',
   'find',
   'findWidget',
   'get',
@@ -70,6 +72,7 @@ const DEFAULT_IGNORED_RETURN_FUNCTION_NAMES = [
   'requestCreateSubshell',
   'requestDebug',
   'requestDeleteSubshell',
+  'set',
   'shift',
   'widgetAt',
   'widgetRenderer',
@@ -78,6 +81,15 @@ const DEFAULT_IGNORED_RETURN_FUNCTION_NAMES = [
 
 function isDefaultIgnoredFactoryReturnFunctionName(name: string): boolean {
   return /^add[A-Za-z0-9_$]*Factory$/.test(name);
+}
+
+function isLikelyDisposableFactoryCall(node: TSESTree.CallExpression): boolean {
+  if (isDisposableSetFactoryCall(node)) {
+    return true;
+  }
+
+  const name = getCalleeName(node.callee);
+  return name !== null && /^(build|create|make|new)[A-Z0-9_$]/.test(name);
 }
 
 const requireDisposableTransfer = createRule({
@@ -190,9 +202,17 @@ const requireDisposableTransfer = createRule({
         markManagedDisposableUse(pending, node, ownership);
 
         if (
+          isInJupyterPluginActivate(node, ownership) ||
           isIgnoredReturn(node) ||
           !shouldCheckReturnedDisposable(node) ||
           isDisposableExpressionManaged(node, ownership)
+        ) {
+          return;
+        }
+
+        if (
+          ignoredReturnFunctionNamesOption === undefined &&
+          !isLikelyDisposableFactoryCall(node)
         ) {
           return;
         }

--- a/src/utils/disposables.ts
+++ b/src/utils/disposables.ts
@@ -6,6 +6,7 @@
 import { TSESTree } from '@typescript-eslint/types';
 import { ParserServices, TSESLint } from '@typescript-eslint/utils';
 import * as ts from 'typescript';
+import { getJupyterPluginKind } from './plugin-utils';
 
 const DISPOSABLE_INTERFACE_NAMES = ['IDisposable', 'IObservableDisposable'];
 
@@ -362,12 +363,34 @@ export function getAssignedVariable(
   return null;
 }
 
-function isFunctionLike(node: TSESTree.Node): boolean {
+function isFunctionLike(
+  node: TSESTree.Node
+): node is
+  | TSESTree.ArrowFunctionExpression
+  | TSESTree.FunctionDeclaration
+  | TSESTree.FunctionExpression {
   return (
     node.type === 'ArrowFunctionExpression' ||
     node.type === 'FunctionDeclaration' ||
     node.type === 'FunctionExpression'
   );
+}
+
+function getEnclosingFunction(
+  node: TSESTree.Node
+):
+  | TSESTree.ArrowFunctionExpression
+  | TSESTree.FunctionDeclaration
+  | TSESTree.FunctionExpression
+  | null {
+  let parent = node.parent;
+  while (parent) {
+    if (isFunctionLike(parent)) {
+      return parent;
+    }
+    parent = parent.parent;
+  }
+  return null;
 }
 
 function isConditionalOrRepeated(node: TSESTree.Node): boolean {
@@ -451,6 +474,49 @@ export function isOuterFunctionScopeVariable(
   return (
     getFunctionScope(sourceCode.getScope(node)) !==
     getFunctionScope(variable.scope)
+  );
+}
+
+export function isInJupyterPluginActivate(
+  node: TSESTree.Node,
+  ownership: DisposableOwnershipContext
+): boolean {
+  const fn = getEnclosingFunction(node);
+  const property = fn?.parent;
+  if (
+    !fn ||
+    !property ||
+    property.type !== 'Property' ||
+    property.value !== fn ||
+    property.computed ||
+    !(
+      (property.key.type === 'Identifier' &&
+        property.key.name === 'activate') ||
+      (property.key.type === 'Literal' && property.key.value === 'activate')
+    )
+  ) {
+    return false;
+  }
+
+  const object = property.parent;
+  const variable = object?.parent;
+  if (
+    !object ||
+    object.type !== 'ObjectExpression' ||
+    !variable ||
+    variable.type !== 'VariableDeclarator'
+  ) {
+    return false;
+  }
+
+  return (
+    getJupyterPluginKind(
+      variable,
+      ownership.checker,
+      ownership.services
+        ? node => ownership.services!.esTreeNodeToTSNodeMap.get(node)
+        : null
+    ) !== null
   );
 }
 
@@ -750,15 +816,11 @@ function isDialogLaunchCall(
 function markManagedVariables(
   pending: PendingDisposableMap,
   node: TSESTree.Node,
-  ownership: DisposableOwnershipContext,
-  requireUnconditional = true
+  ownership: DisposableOwnershipContext
 ): void {
   const variables = getIdentifierVariables(ownership.sourceCode, node);
   for (const variable of variables) {
-    const shouldMark = requireUnconditional
-      ? isUnconditionalUse(node, variable)
-      : !isCatchClauseUse(node, variable);
-    if (shouldMark) {
+    if (isUnconditionalUse(node, variable)) {
       markDisposableManaged(pending, variable);
     }
   }
@@ -800,7 +862,7 @@ export function markManagedDisposableUse(
         property.type === 'Property' &&
         isOptionsObjectValueManaged(property.value, ownership)
       ) {
-        markManagedVariables(pending, property.value, ownership, false);
+        markManagedVariables(pending, property.value, ownership);
       }
     }
   }
@@ -812,7 +874,7 @@ export function markManagedDisposableUse(
   const ownershipArguments = getOwnershipArguments(node, ownership);
   if (ownershipArguments.length > 0) {
     for (const argument of ownershipArguments) {
-      markManagedVariables(pending, argument, ownership, false);
+      markManagedVariables(pending, argument, ownership);
     }
     return;
   }

--- a/src/utils/disposables.ts
+++ b/src/utils/disposables.ts
@@ -389,6 +389,14 @@ function isDisposableSetType(
   node: TSESTree.Node,
   ownership: DisposableOwnershipContext
 ): boolean {
+  return hasExpressionTypeName(node, ownership, DISPOSABLE_SET_NAMES);
+}
+
+function hasExpressionTypeName(
+  node: TSESTree.Node,
+  ownership: DisposableOwnershipContext,
+  names: readonly string[]
+): boolean {
   if (!ownership.checker || !ownership.services) {
     return false;
   }
@@ -396,7 +404,7 @@ function isDisposableSetType(
   try {
     const tsNode = ownership.services.esTreeNodeToTSNodeMap.get(node);
     const type = ownership.checker.getTypeAtLocation(tsNode);
-    return hasTypeName(type, ownership.checker, DISPOSABLE_SET_NAMES);
+    return hasTypeName(type, ownership.checker, names);
   } catch {
     return false;
   }
@@ -406,17 +414,14 @@ function isAttachedPropertyType(
   node: TSESTree.Node,
   ownership: DisposableOwnershipContext
 ): boolean {
-  if (!ownership.checker || !ownership.services) {
-    return false;
-  }
+  return hasExpressionTypeName(node, ownership, ['AttachedProperty']);
+}
 
-  try {
-    const tsNode = ownership.services.esTreeNodeToTSNodeMap.get(node);
-    const type = ownership.checker.getTypeAtLocation(tsNode);
-    return hasTypeName(type, ownership.checker, ['AttachedProperty']);
-  } catch {
-    return false;
-  }
+function isDialogType(
+  node: TSESTree.Node,
+  ownership: DisposableOwnershipContext
+): boolean {
+  return hasExpressionTypeName(node, ownership, ['Dialog']);
 }
 
 function isOwnershipAddCall(
@@ -486,6 +491,16 @@ function isArgumentOfCallOrNew(
   return node.type === 'CallExpression' || node.type === 'NewExpression';
 }
 
+function getPropertyName(node: TSESTree.Property): string | null {
+  if (!node.computed && node.key.type === 'Identifier') {
+    return node.key.name;
+  }
+  if (node.key.type === 'Literal' && typeof node.key.value === 'string') {
+    return node.key.value;
+  }
+  return null;
+}
+
 function isOptionsObjectValueManaged(
   expression: TSESTree.Node,
   ownership: DisposableOwnershipContext
@@ -505,6 +520,15 @@ function isOptionsObjectValueManaged(
   }
 
   const parent = object.parent;
+  const propertyName = getPropertyName(property);
+  if (
+    parent?.type === 'AssignmentPattern' &&
+    parent.right === object &&
+    propertyName === 'shell'
+  ) {
+    return true;
+  }
+
   if (!parent || !isArgumentOfCallOrNew(parent)) {
     return false;
   }
@@ -515,6 +539,10 @@ function isOptionsObjectValueManaged(
 
   if (parent.type === 'NewExpression') {
     return true;
+  }
+
+  if (getCalleeName(parent.callee) === 'showDialog') {
+    return propertyName === 'body';
   }
 
   return (
@@ -577,14 +605,33 @@ export function isDisposableExpressionManaged(
   if (
     parent.type === 'MemberExpression' &&
     parent.object === expression &&
-    getStaticMemberName(parent) === 'dispose' &&
     parent.parent?.type === 'CallExpression' &&
     parent.parent.callee === parent
   ) {
-    return true;
+    if (getStaticMemberName(parent) === 'dispose') {
+      return true;
+    }
+    if (
+      getStaticMemberName(parent) === 'launch' &&
+      isDialogType(expression, ownership)
+    ) {
+      return true;
+    }
   }
 
   return false;
+}
+
+function isDialogLaunchCall(
+  node: TSESTree.CallExpression,
+  ownership: DisposableOwnershipContext
+): node is TSESTree.CallExpression & { callee: TSESTree.MemberExpression } {
+  return (
+    isStaticMemberCall(node, 'launch') &&
+    node.callee.type === 'MemberExpression' &&
+    node.callee.object.type !== 'Super' &&
+    isDialogType(node.callee.object, ownership)
+  );
 }
 
 export function markManagedDisposableUse(
@@ -640,6 +687,16 @@ export function markManagedDisposableUse(
       if (isUnconditionalUse(node, variable)) {
         markDisposableManaged(pending, variable);
       }
+    }
+  }
+
+  if (isDialogLaunchCall(node, ownership)) {
+    const variable = getIdentifierVariable(
+      ownership.sourceCode,
+      node.callee.object
+    );
+    if (variable && isUnconditionalUse(node, variable)) {
+      markDisposableManaged(pending, variable);
     }
   }
 }

--- a/src/utils/disposables.ts
+++ b/src/utils/disposables.ts
@@ -20,23 +20,49 @@ const DISPOSABLE_CONSTRUCTOR_NAMES = [
 const DISPOSABLE_SET_NAMES = ['DisposableSet', 'ObservableDisposableSet'];
 
 const OWNED_CONSTRUCTOR_OPTION_NAMES = new Map([
+  ['CodeCell', ['model']],
+  ['CodeEditorWrapper', ['model']],
+  ['CodeViewerWidget', ['model']],
+  ['Collapser', ['widget']],
+  ['DocumentWidget', ['content']],
+  ['FileBrowser', ['model']],
+  ['FileEditorWidget', ['content']],
   ['Dialog', ['body']],
-  ['MainAreaWidget', ['content']]
+  ['Licenses', ['model']],
+  ['MainAreaWidget', ['content']],
+  ['MarkdownDocument', ['content']],
+  ['MarkdownViewer', ['renderer']],
+  ['MimeContent', ['renderer']],
+  ['MimeDocument', ['content']],
+  ['NotebookPanel', ['content']],
+  ['RawCell', ['model']]
 ]);
+
+const OWNED_FUNCTION_OPTION_NAMES = new Map([
+  ['createNew', ['sharedModel']],
+  ['createNotebook', ['kernelHistory']],
+  ['open', ['editorWrapper']],
+  ['showPopup', ['body']]
+]);
+
+const FLUENT_DISPOSABLE_METHOD_NAMES = ['initializeState'];
 
 export const DEFAULT_OWNERSHIP_FUNCTION_NAMES = [
   'add',
   'addCell',
   'addFactory',
+  'addGroup',
   'addItem',
   'addMenu',
   'addModelFactory',
   'addSibling',
   'addWidget',
   'addWidgetFactory',
+  'insertBefore',
   'insertItem',
   'insertWidget',
-  'registerStatusItem'
+  'registerStatusItem',
+  '_wrappedOutput'
 ];
 
 interface PendingDisposable {
@@ -91,16 +117,95 @@ function getTransparentChild(node: TSESTree.Node): TSESTree.Node | null {
   return null;
 }
 
+function reducerReturnsAccumulator(
+  callback: TSESTree.Node,
+  accumulatorName: string
+): boolean {
+  if (
+    callback.type !== 'ArrowFunctionExpression' &&
+    callback.type !== 'FunctionExpression'
+  ) {
+    return false;
+  }
+
+  if (
+    callback.body.type === 'Identifier' &&
+    callback.body.name === accumulatorName
+  ) {
+    return true;
+  }
+
+  return (
+    callback.body.type === 'BlockStatement' &&
+    callback.body.body.some(
+      statement =>
+        statement.type === 'ReturnStatement' &&
+        statement.argument?.type === 'Identifier' &&
+        statement.argument.name === accumulatorName
+    )
+  );
+}
+
+function isReduceAccumulatorInitialValue(
+  node: TSESTree.Node,
+  parent: TSESTree.Node
+): parent is TSESTree.CallExpression {
+  if (
+    parent.type !== 'CallExpression' ||
+    parent.callee.type !== 'MemberExpression' ||
+    getStaticMemberName(parent.callee) !== 'reduce' ||
+    parent.arguments.length < 2 ||
+    parent.arguments[1] !== node
+  ) {
+    return false;
+  }
+
+  const [callback] = parent.arguments;
+  if (
+    !callback ||
+    (callback.type !== 'ArrowFunctionExpression' &&
+      callback.type !== 'FunctionExpression')
+  ) {
+    return false;
+  }
+
+  const [accumulator] = callback.params;
+  return (
+    accumulator?.type === 'Identifier' &&
+    reducerReturnsAccumulator(callback, accumulator.name)
+  );
+}
+
 function getOuterExpression(node: TSESTree.Node): TSESTree.Node {
   let current = node;
   let parent = current.parent;
   while (parent) {
     const child = getTransparentChild(parent);
-    if (child !== current) {
-      break;
+    if (child === current) {
+      current = parent;
+      parent = current.parent;
+      continue;
     }
-    current = parent;
-    parent = current.parent;
+
+    if (isReduceAccumulatorInitialValue(current, parent)) {
+      current = parent;
+      parent = current.parent;
+      continue;
+    }
+
+    if (
+      parent.type === 'MemberExpression' &&
+      parent.object === current &&
+      parent.parent?.type === 'CallExpression' &&
+      parent.parent.callee === parent &&
+      FLUENT_DISPOSABLE_METHOD_NAMES.includes(getStaticMemberName(parent) ?? '')
+    ) {
+      current = parent.parent;
+      parent = current.parent;
+      continue;
+    }
+
+    break;
   }
   return current;
 }
@@ -116,22 +221,16 @@ function isThisMemberExpression(node: TSESTree.Node): boolean {
   return isThisMemberExpression(expression.object);
 }
 
-function isFallbackExpression(
-  node: TSESTree.Node
-): node is TSESTree.LogicalExpression {
-  return (
-    node.type === 'LogicalExpression' &&
-    (node.operator === '||' || node.operator === '??')
-  );
-}
-
 function getOuterFallbackExpression(node: TSESTree.Node): TSESTree.Node {
   let current = getOuterExpression(node);
   let parent = current.parent;
   while (
     parent &&
-    isFallbackExpression(parent) &&
-    (parent.left === current || parent.right === current)
+    ((parent.type === 'LogicalExpression' &&
+      (parent.operator === '||' || parent.operator === '??') &&
+      (parent.left === current || parent.right === current)) ||
+      (parent.type === 'ConditionalExpression' &&
+        (parent.consequent === current || parent.alternate === current)))
   ) {
     current = parent;
     parent = current.parent;
@@ -257,12 +356,39 @@ function getIdentifierVariable(
   return null;
 }
 
+function getVariableInitializer(
+  variable: TSESLint.Scope.Variable
+): TSESTree.Node | null {
+  for (const definition of variable.defs) {
+    const node = definition.node;
+    if (node.type === 'VariableDeclarator') {
+      return node.init ?? null;
+    }
+  }
+  return null;
+}
+
 function getIdentifierVariables(
   sourceCode: TSESLint.SourceCode,
-  node: TSESTree.Node | null | undefined
+  node: TSESTree.Node | null | undefined,
+  seen = new Set<TSESLint.Scope.Variable>()
 ): TSESLint.Scope.Variable[] {
   const variable = getIdentifierVariable(sourceCode, node);
   if (variable) {
+    if (seen.has(variable)) {
+      return [variable];
+    }
+    seen.add(variable);
+    const initializer = getVariableInitializer(variable);
+    if (
+      initializer?.type === 'ArrayExpression' ||
+      initializer?.type === 'ObjectExpression'
+    ) {
+      return [
+        variable,
+        ...getIdentifierVariables(sourceCode, initializer, seen)
+      ];
+    }
     return [variable];
   }
   if (!node) {
@@ -271,13 +397,13 @@ function getIdentifierVariables(
 
   const child = getTransparentChild(node);
   if (child) {
-    return getIdentifierVariables(sourceCode, child);
+    return getIdentifierVariables(sourceCode, child, seen);
   }
 
   if (node.type === 'ArrayExpression') {
     return node.elements.flatMap(element =>
       element && element.type !== 'SpreadElement'
-        ? getIdentifierVariables(sourceCode, element)
+        ? getIdentifierVariables(sourceCode, element, seen)
         : []
     );
   }
@@ -285,7 +411,7 @@ function getIdentifierVariables(
   if (node.type === 'ObjectExpression') {
     return node.properties.flatMap(property =>
       property.type === 'Property'
-        ? getIdentifierVariables(sourceCode, property.value)
+        ? getIdentifierVariables(sourceCode, property.value, seen)
         : []
     );
   }
@@ -305,13 +431,19 @@ export function addPendingDisposable(
 
 function markDisposableManaged(
   pending: PendingDisposableMap,
-  variable: TSESLint.Scope.Variable | null
+  variable: TSESLint.Scope.Variable | null,
+  useNode?: TSESTree.Node
 ): void {
   if (!variable) {
     return;
   }
   const records = pending.get(variable);
   if (!records) {
+    return;
+  }
+
+  if (useNode && shouldMarkAllBranchRecords(records, useNode)) {
+    pending.delete(variable);
     return;
   }
 
@@ -409,6 +541,67 @@ function isConditionalOrRepeated(node: TSESTree.Node): boolean {
   );
 }
 
+function isBeforeNode(first: TSESTree.Node, second: TSESTree.Node): boolean {
+  if (first.range && second.range) {
+    return first.range[1] <= second.range[0];
+  }
+  return first.loc.end.line <= second.loc.start.line;
+}
+
+function getExclusiveBranchAncestor(node: TSESTree.Node): TSESTree.Node | null {
+  let current = node;
+  let parent = current.parent;
+
+  while (parent) {
+    if (isFunctionLike(parent)) {
+      return null;
+    }
+
+    if (
+      parent.type === 'IfStatement' &&
+      (parent.consequent === current || parent.alternate === current)
+    ) {
+      return parent;
+    }
+
+    if (
+      parent.type === 'SwitchStatement' &&
+      current.type === 'SwitchCase' &&
+      parent.cases.includes(current)
+    ) {
+      return parent;
+    }
+
+    if (
+      parent.type === 'ConditionalExpression' &&
+      (parent.consequent === current || parent.alternate === current)
+    ) {
+      return parent;
+    }
+
+    current = parent;
+    parent = current.parent;
+  }
+
+  return null;
+}
+
+function shouldMarkAllBranchRecords(
+  records: PendingDisposable[],
+  useNode: TSESTree.Node
+): boolean {
+  if (records.length <= 1) {
+    return false;
+  }
+
+  const branch = getExclusiveBranchAncestor(records[0].node);
+  return (
+    branch !== null &&
+    isBeforeNode(branch, useNode) &&
+    records.every(record => getExclusiveBranchAncestor(record.node) === branch)
+  );
+}
+
 function isUnconditionalUse(
   node: TSESTree.Node,
   variable: TSESLint.Scope.Variable
@@ -427,6 +620,74 @@ function isUnconditionalUse(
   }
 
   return false;
+}
+
+function isTruthyIdentifierTest(
+  node: TSESTree.Node,
+  variable: TSESLint.Scope.Variable,
+  sourceCode: TSESLint.SourceCode
+): boolean {
+  const identifier = getIdentifierVariable(sourceCode, node);
+  if (identifier === variable) {
+    return true;
+  }
+
+  if (
+    node.type === 'UnaryExpression' &&
+    node.operator === '!' &&
+    node.argument.type === 'UnaryExpression' &&
+    node.argument.operator === '!'
+  ) {
+    return isTruthyIdentifierTest(node.argument.argument, variable, sourceCode);
+  }
+
+  if (node.type === 'LogicalExpression' && node.operator === '&&') {
+    return (
+      isTruthyIdentifierTest(node.left, variable, sourceCode) ||
+      isTruthyIdentifierTest(node.right, variable, sourceCode)
+    );
+  }
+
+  return false;
+}
+
+function isTruthyGuardedUse(
+  node: TSESTree.Node,
+  variable: TSESLint.Scope.Variable,
+  sourceCode: TSESLint.SourceCode
+): boolean {
+  let current = node;
+  let parent = current.parent;
+
+  while (parent) {
+    if (isFunctionLike(parent)) {
+      return false;
+    }
+
+    if (
+      parent.type === 'IfStatement' &&
+      parent.consequent === current &&
+      isTruthyIdentifierTest(parent.test, variable, sourceCode)
+    ) {
+      return true;
+    }
+
+    current = parent;
+    parent = current.parent;
+  }
+
+  return false;
+}
+
+function isManagedUse(
+  node: TSESTree.Node,
+  variable: TSESLint.Scope.Variable,
+  sourceCode: TSESLint.SourceCode
+): boolean {
+  return (
+    isUnconditionalUse(node, variable) ||
+    isTruthyGuardedUse(node, variable, sourceCode)
+  );
 }
 
 function isCatchClauseUse(
@@ -499,17 +760,13 @@ export function isInJupyterPluginActivate(
   }
 
   const object = property.parent;
-  const variable = object?.parent;
-  if (
-    !object ||
-    object.type !== 'ObjectExpression' ||
-    !variable ||
-    variable.type !== 'VariableDeclarator'
-  ) {
+  if (!object || object.type !== 'ObjectExpression') {
     return false;
   }
 
-  return (
+  const variable = object.parent;
+  if (
+    variable?.type === 'VariableDeclarator' &&
     getJupyterPluginKind(
       variable,
       ownership.checker,
@@ -517,6 +774,25 @@ export function isInJupyterPluginActivate(
         ? node => ownership.services!.esTreeNodeToTSNodeMap.get(node)
         : null
     ) !== null
+  ) {
+    return true;
+  }
+
+  const propertyNames = new Set(
+    object.properties.flatMap(property =>
+      property.type === 'Property'
+        ? [getPropertyName(property)].filter(
+            (name): name is string => name !== null
+          )
+        : []
+    )
+  );
+  return (
+    propertyNames.has('id') &&
+    propertyNames.has('activate') &&
+    ['autoStart', 'optional', 'provides', 'requires'].some(name =>
+      propertyNames.has(name)
+    )
   );
 }
 
@@ -566,6 +842,77 @@ function hasExpressionTypeName(
   }
 }
 
+function declarationHasHeritageName(
+  declaration: ts.Declaration,
+  names: readonly string[]
+): boolean {
+  if (
+    !(
+      ts.isClassDeclaration(declaration) ||
+      ts.isClassExpression(declaration) ||
+      ts.isInterfaceDeclaration(declaration)
+    )
+  ) {
+    return false;
+  }
+
+  return (
+    declaration.heritageClauses?.some(clause =>
+      clause.types.some(type => {
+        const text = type.expression.getText();
+        return names.some(name => text === name || text.endsWith(`.${name}`));
+      })
+    ) ?? false
+  );
+}
+
+function hasHeritageName(
+  type: ts.Type,
+  names: readonly string[],
+  seen = new Set<ts.Type>()
+): boolean {
+  if (seen.has(type)) {
+    return false;
+  }
+  seen.add(type);
+
+  if (type.isUnion()) {
+    return type.types.some(part => hasHeritageName(part, names, seen));
+  }
+
+  if (type.isIntersection()) {
+    return type.types.some(part => hasHeritageName(part, names, seen));
+  }
+
+  const symbol = type.getSymbol();
+  return (
+    symbol?.declarations?.some(declaration =>
+      declarationHasHeritageName(declaration, names)
+    ) ?? false
+  );
+}
+
+function hasExpressionTypeOrHeritageName(
+  node: TSESTree.Node,
+  ownership: DisposableOwnershipContext,
+  names: readonly string[]
+): boolean {
+  if (!ownership.checker || !ownership.services) {
+    return false;
+  }
+
+  try {
+    const tsNode = ownership.services.esTreeNodeToTSNodeMap.get(node);
+    const type = ownership.checker.getTypeAtLocation(tsNode);
+    return (
+      hasTypeName(type, ownership.checker, names) ||
+      hasHeritageName(type, names)
+    );
+  } catch {
+    return false;
+  }
+}
+
 function isAttachedPropertyType(
   node: TSESTree.Node,
   ownership: DisposableOwnershipContext
@@ -577,7 +924,14 @@ function isDialogType(
   node: TSESTree.Node,
   ownership: DisposableOwnershipContext
 ): boolean {
-  return hasExpressionTypeName(node, ownership, ['Dialog']);
+  return hasExpressionTypeOrHeritageName(node, ownership, ['Dialog']);
+}
+
+function isDocumentWidgetType(
+  node: TSESTree.Node,
+  ownership: DisposableOwnershipContext
+): boolean {
+  return hasExpressionTypeOrHeritageName(node, ownership, ['DocumentWidget']);
 }
 
 function isOwnershipAddCall(
@@ -625,6 +979,18 @@ export function isClassFieldCollectionMutationCall(
   );
 }
 
+function isArrayExtInsertCall(
+  node: TSESTree.CallExpression
+): node is TSESTree.CallExpression & { callee: TSESTree.MemberExpression } {
+  return (
+    isStaticMemberCall(node, 'insert') &&
+    node.callee.type === 'MemberExpression' &&
+    getCalleeName(node.callee.object) === 'ArrayExt' &&
+    node.arguments.length >= 3 &&
+    isThisMemberExpression(node.arguments[0])
+  );
+}
+
 function getOwnershipArguments(
   node: TSESTree.CallExpression,
   ownership: DisposableOwnershipContext
@@ -653,6 +1019,14 @@ function getOwnershipArguments(
     return node.arguments.slice(1);
   }
 
+  if (isClassFieldCollectionMutationCall(node, ['push', 'unshift'])) {
+    return node.arguments;
+  }
+
+  if (isArrayExtInsertCall(node)) {
+    return node.arguments.slice(2, 3);
+  }
+
   return [];
 }
 
@@ -670,6 +1044,84 @@ function getPropertyName(node: TSESTree.Property): string | null {
     return node.key.value;
   }
   return null;
+}
+
+function getObjectExpression(
+  sourceCode: TSESLint.SourceCode,
+  node: TSESTree.Node
+): TSESTree.ObjectExpression | null {
+  if (node.type === 'ObjectExpression') {
+    return node;
+  }
+
+  const child = getTransparentChild(node);
+  if (child) {
+    return getObjectExpression(sourceCode, child);
+  }
+
+  if (node.type === 'Identifier') {
+    const variable = resolveVariable(sourceCode, node);
+    const initializer = variable ? getVariableInitializer(variable) : null;
+    if (initializer?.type === 'ObjectExpression') {
+      return initializer;
+    }
+  }
+
+  return null;
+}
+
+function getManagedOptionNames(
+  node: TSESTree.CallExpression | TSESTree.NewExpression,
+  ownership: DisposableOwnershipContext
+): string[] {
+  if (node.type === 'NewExpression') {
+    const constructorName = getCalleeName(node.callee);
+    const names =
+      constructorName === null
+        ? []
+        : (OWNED_CONSTRUCTOR_OPTION_NAMES.get(constructorName) ?? []);
+    return [
+      ...names,
+      ...(isDialogType(node, ownership) ? ['body'] : []),
+      ...(isDocumentWidgetType(node, ownership) ? ['content'] : [])
+    ];
+  }
+
+  const calleeName = getCalleeName(node.callee);
+  return calleeName === null
+    ? []
+    : (OWNED_FUNCTION_OPTION_NAMES.get(calleeName) ?? []);
+}
+
+function markManagedKnownOptionVariables(
+  pending: PendingDisposableMap,
+  node: TSESTree.CallExpression | TSESTree.NewExpression,
+  ownership: DisposableOwnershipContext
+): void {
+  const optionNames = getManagedOptionNames(node, ownership);
+  if (optionNames.length === 0) {
+    return;
+  }
+
+  for (const argument of node.arguments) {
+    if (argument.type === 'ObjectExpression') {
+      continue;
+    }
+
+    const object = getObjectExpression(ownership.sourceCode, argument);
+    if (!object) {
+      continue;
+    }
+
+    for (const property of object.properties) {
+      if (
+        property.type === 'Property' &&
+        optionNames.includes(getPropertyName(property) ?? '')
+      ) {
+        markManagedVariables(pending, property.value, ownership);
+      }
+    }
+  }
 }
 
 function isOptionsObjectValueManaged(
@@ -711,17 +1163,29 @@ function isOptionsObjectValueManaged(
   if (parent.type === 'NewExpression') {
     const constructorName = getCalleeName(parent.callee);
     return (
-      constructorName !== null &&
       propertyName !== null &&
-      (OWNED_CONSTRUCTOR_OPTION_NAMES.get(constructorName)?.includes(
-        propertyName
-      ) ??
-        false)
+      ((constructorName !== null &&
+        (OWNED_CONSTRUCTOR_OPTION_NAMES.get(constructorName)?.includes(
+          propertyName
+        ) ??
+          false)) ||
+        (propertyName === 'body' && isDialogType(parent, ownership)) ||
+        (propertyName === 'content' && isDocumentWidgetType(parent, ownership)))
     );
   }
 
   if (getCalleeName(parent.callee) === 'showDialog') {
     return propertyName === 'body';
+  }
+
+  const calleeName = getCalleeName(parent.callee);
+  if (
+    calleeName !== null &&
+    propertyName !== null &&
+    (OWNED_FUNCTION_OPTION_NAMES.get(calleeName)?.includes(propertyName) ??
+      false)
+  ) {
+    return true;
   }
 
   return (
@@ -730,6 +1194,98 @@ function isOptionsObjectValueManaged(
       object as TSESTree.CallExpressionArgument
     )
   );
+}
+
+function getManagedAggregateExpression(
+  node: TSESTree.Node
+): TSESTree.Node | null {
+  let current = getOuterExpression(node);
+  let parent = current.parent;
+  let foundAggregate = false;
+
+  while (parent) {
+    if (parent.type === 'Property' && parent.value === current) {
+      current = parent;
+      parent = current.parent;
+      foundAggregate = true;
+      continue;
+    }
+
+    if (
+      parent.type === 'ArrayExpression' &&
+      parent.elements.includes(current as TSESTree.Expression)
+    ) {
+      current = parent;
+      parent = current.parent;
+      foundAggregate = true;
+      continue;
+    }
+
+    if (
+      parent.type === 'ObjectExpression' &&
+      parent.properties.includes(current as TSESTree.Property)
+    ) {
+      current = parent;
+      parent = current.parent;
+      foundAggregate = true;
+      continue;
+    }
+
+    break;
+  }
+
+  return foundAggregate ? current : null;
+}
+
+function isAggregateExpressionManaged(
+  expression: TSESTree.Node,
+  ownership: DisposableOwnershipContext
+): boolean {
+  const aggregate = getManagedAggregateExpression(expression);
+  if (!aggregate) {
+    return false;
+  }
+
+  const outerAggregate = getOuterFallbackExpression(aggregate);
+  const parent = outerAggregate.parent;
+  if (!parent) {
+    return false;
+  }
+
+  if (parent.type === 'ReturnStatement' && parent.argument === outerAggregate) {
+    return true;
+  }
+
+  if (
+    parent.type === 'ArrowFunctionExpression' &&
+    parent.body === outerAggregate
+  ) {
+    return true;
+  }
+
+  if (
+    parent.type === 'AssignmentExpression' &&
+    parent.right === outerAggregate &&
+    parent.left.type === 'MemberExpression'
+  ) {
+    return true;
+  }
+
+  if (parent.type === 'PropertyDefinition' && parent.value === outerAggregate) {
+    return true;
+  }
+
+  if (isOptionsObjectValueManaged(outerAggregate, ownership)) {
+    return true;
+  }
+
+  if (parent.type === 'CallExpression') {
+    return getOwnershipArguments(parent, ownership).includes(
+      outerAggregate as TSESTree.CallExpressionArgument
+    );
+  }
+
+  return false;
 }
 
 export function isDisposableExpressionManaged(
@@ -781,6 +1337,10 @@ export function isDisposableExpressionManaged(
     return true;
   }
 
+  if (isAggregateExpressionManaged(expression, ownership)) {
+    return true;
+  }
+
   if (
     parent.type === 'MemberExpression' &&
     parent.object === expression &&
@@ -820,9 +1380,200 @@ function markManagedVariables(
 ): void {
   const variables = getIdentifierVariables(ownership.sourceCode, node);
   for (const variable of variables) {
-    if (isUnconditionalUse(node, variable)) {
-      markDisposableManaged(pending, variable);
+    if (isManagedUse(node, variable, ownership.sourceCode)) {
+      markDisposableManaged(pending, variable, node);
     }
+  }
+}
+
+function markManagedVariablesWithoutScopeCheck(
+  pending: PendingDisposableMap,
+  node: TSESTree.Node | null | undefined,
+  ownership: DisposableOwnershipContext,
+  useNode?: TSESTree.Node
+): void {
+  const variables = getIdentifierVariables(ownership.sourceCode, node);
+  for (const variable of variables) {
+    markDisposableManaged(pending, variable, useNode);
+  }
+}
+
+function getDisposedSignalCallback(
+  node: TSESTree.CallExpression
+): TSESTree.ArrowFunctionExpression | TSESTree.FunctionExpression | null {
+  if (
+    !isStaticMemberCall(node, 'connect') ||
+    node.callee.type !== 'MemberExpression' ||
+    node.callee.object.type !== 'MemberExpression' ||
+    getStaticMemberName(node.callee.object) !== 'disposed'
+  ) {
+    return null;
+  }
+
+  const [callback] = node.arguments;
+  return callback &&
+    (callback.type === 'ArrowFunctionExpression' ||
+      callback.type === 'FunctionExpression')
+    ? callback
+    : null;
+}
+
+function getDisposeCallTarget(node: TSESTree.Node): TSESTree.Node | null {
+  if (
+    node.type === 'CallExpression' &&
+    isStaticMemberCall(node, 'dispose') &&
+    node.callee.type === 'MemberExpression' &&
+    node.callee.object.type !== 'Super'
+  ) {
+    return node.callee.object;
+  }
+  return null;
+}
+
+function getUnconditionalDisposeTargets(
+  callback: TSESTree.ArrowFunctionExpression | TSESTree.FunctionExpression
+): TSESTree.Node[] {
+  const body = callback.body;
+  const expressionTarget = getDisposeCallTarget(body);
+  if (expressionTarget) {
+    return [expressionTarget];
+  }
+
+  if (body.type !== 'BlockStatement') {
+    return [];
+  }
+
+  return body.body.flatMap(statement => {
+    if (statement.type !== 'ExpressionStatement') {
+      return [];
+    }
+    const target = getDisposeCallTarget(statement.expression);
+    return target ? [target] : [];
+  });
+}
+
+function expressionContainsIdentifierName(
+  node: TSESTree.Node | null | undefined,
+  name: string
+): boolean {
+  if (!node) {
+    return false;
+  }
+
+  if (node.type === 'Identifier' && node.name === name) {
+    return true;
+  }
+
+  const child = getTransparentChild(node);
+  if (child) {
+    return expressionContainsIdentifierName(child, name);
+  }
+
+  if (node.type === 'ArrayExpression') {
+    return node.elements.some(element =>
+      element && element.type !== 'SpreadElement'
+        ? expressionContainsIdentifierName(element, name)
+        : false
+    );
+  }
+
+  if (node.type === 'ObjectExpression') {
+    return node.properties.some(property =>
+      property.type === 'Property'
+        ? expressionContainsIdentifierName(property.value, name)
+        : false
+    );
+  }
+
+  return false;
+}
+
+function isOwnershipCallWithIdentifier(
+  node: TSESTree.Node,
+  name: string,
+  ownership: DisposableOwnershipContext
+): node is TSESTree.CallExpression {
+  return (
+    node.type === 'CallExpression' &&
+    getOwnershipArguments(node, ownership).some(argument =>
+      expressionContainsIdentifierName(argument, name)
+    )
+  );
+}
+
+function forEachCallbackOwnsParameter(
+  callback: TSESTree.ArrowFunctionExpression | TSESTree.FunctionExpression,
+  parameterName: string,
+  ownership: DisposableOwnershipContext
+): boolean {
+  if (isOwnershipCallWithIdentifier(callback.body, parameterName, ownership)) {
+    return true;
+  }
+
+  if (callback.body.type !== 'BlockStatement') {
+    return false;
+  }
+
+  return callback.body.body.some(
+    statement =>
+      statement.type === 'ExpressionStatement' &&
+      isOwnershipCallWithIdentifier(
+        statement.expression,
+        parameterName,
+        ownership
+      )
+  );
+}
+
+function markImmediateForEachOwnership(
+  pending: PendingDisposableMap,
+  node: TSESTree.CallExpression,
+  ownership: DisposableOwnershipContext
+): void {
+  if (
+    !isStaticMemberCall(node, 'forEach') ||
+    node.callee.type !== 'MemberExpression' ||
+    node.callee.object.type !== 'ArrayExpression'
+  ) {
+    return;
+  }
+
+  const [callback] = node.arguments;
+  if (
+    !callback ||
+    (callback.type !== 'ArrowFunctionExpression' &&
+      callback.type !== 'FunctionExpression')
+  ) {
+    return;
+  }
+
+  const [parameter] = callback.params;
+  if (
+    parameter?.type !== 'Identifier' ||
+    !forEachCallbackOwnsParameter(callback, parameter.name, ownership)
+  ) {
+    return;
+  }
+
+  for (const element of node.callee.object.elements) {
+    if (element && element.type !== 'SpreadElement') {
+      markManagedVariablesWithoutScopeCheck(pending, element, ownership, node);
+    }
+  }
+}
+
+function markDisposedSignalCallbackDisposals(
+  pending: PendingDisposableMap,
+  node: TSESTree.CallExpression,
+  ownership: DisposableOwnershipContext
+): void {
+  const callback = getDisposedSignalCallback(node);
+  if (!callback) {
+    return;
+  }
+
+  for (const target of getUnconditionalDisposeTargets(callback)) {
+    markManagedVariablesWithoutScopeCheck(pending, target, ownership, node);
   }
 }
 
@@ -832,18 +1583,38 @@ export function markManagedDisposableUse(
   ownership: DisposableOwnershipContext
 ): void {
   if (node.type === 'ReturnStatement') {
-    const variable = getIdentifierVariable(ownership.sourceCode, node.argument);
-    if (variable && isUnconditionalUse(node, variable)) {
-      markDisposableManaged(pending, variable);
+    if (isInJupyterPluginActivate(node, ownership)) {
+      markManagedVariablesWithoutScopeCheck(
+        pending,
+        node.argument,
+        ownership,
+        node
+      );
+      return;
+    }
+
+    const variables = getIdentifierVariables(
+      ownership.sourceCode,
+      node.argument
+    );
+    for (const variable of variables) {
+      if (isManagedUse(node, variable, ownership.sourceCode)) {
+        markDisposableManaged(pending, variable, node);
+      }
     }
     return;
   }
 
   if (node.type === 'AssignmentExpression') {
     if (node.left.type === 'MemberExpression') {
-      const variable = getIdentifierVariable(ownership.sourceCode, node.right);
-      if (variable && isUnconditionalUse(node, variable)) {
-        markDisposableManaged(pending, variable);
+      const variables = getIdentifierVariables(
+        ownership.sourceCode,
+        node.right
+      );
+      for (const variable of variables) {
+        if (isManagedUse(node, variable, ownership.sourceCode)) {
+          markDisposableManaged(pending, variable, node);
+        }
       }
     }
     return;
@@ -852,6 +1623,13 @@ export function markManagedDisposableUse(
   if (node.type !== 'CallExpression' && node.type !== 'NewExpression') {
     return;
   }
+
+  if (node.type === 'CallExpression') {
+    markDisposedSignalCallbackDisposals(pending, node, ownership);
+    markImmediateForEachOwnership(pending, node, ownership);
+  }
+
+  markManagedKnownOptionVariables(pending, node, ownership);
 
   for (const argument of node.arguments) {
     if (argument.type !== 'ObjectExpression') {
@@ -890,11 +1668,11 @@ export function markManagedDisposableUse(
     );
     if (variable) {
       if (
-        isUnconditionalUse(node, variable) ||
+        isManagedUse(node, variable, ownership.sourceCode) ||
         (hasPendingDisposableSet(pending, variable) &&
           !isCatchClauseUse(node, variable))
       ) {
-        markDisposableManaged(pending, variable);
+        markDisposableManaged(pending, variable, node);
       }
     }
   }
@@ -904,8 +1682,8 @@ export function markManagedDisposableUse(
       ownership.sourceCode,
       node.callee.object
     );
-    if (variable && isUnconditionalUse(node, variable)) {
-      markDisposableManaged(pending, variable);
+    if (variable && isManagedUse(node, variable, ownership.sourceCode)) {
+      markDisposableManaged(pending, variable, node);
     }
   }
 }
@@ -923,34 +1701,10 @@ function hasDisposableTypeName(
 function declarationHasDisposableHeritage(
   declaration: ts.Declaration
 ): boolean {
-  if (
-    !(
-      ts.isClassDeclaration(declaration) ||
-      ts.isClassExpression(declaration) ||
-      ts.isInterfaceDeclaration(declaration)
-    )
-  ) {
-    return false;
-  }
-
-  return (
-    declaration.heritageClauses?.some(clause =>
-      clause.types.some(type => {
-        const text = type.expression.getText();
-        for (const name of DISPOSABLE_INTERFACE_NAMES) {
-          if (text === name || text.endsWith(`.${name}`)) {
-            return true;
-          }
-        }
-        for (const name of DISPOSABLE_CONSTRUCTOR_NAMES) {
-          if (text === name || text.endsWith(`.${name}`)) {
-            return true;
-          }
-        }
-        return false;
-      })
-    ) ?? false
-  );
+  return declarationHasHeritageName(declaration, [
+    ...DISPOSABLE_INTERFACE_NAMES,
+    ...DISPOSABLE_CONSTRUCTOR_NAMES
+  ]);
 }
 
 function hasDisposableHeritage(type: ts.Type): boolean {

--- a/src/utils/disposables.ts
+++ b/src/utils/disposables.ts
@@ -1,0 +1,667 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import { TSESTree } from '@typescript-eslint/types';
+import { ParserServices, TSESLint } from '@typescript-eslint/utils';
+import * as ts from 'typescript';
+
+const DISPOSABLE_INTERFACE_NAMES = ['IDisposable', 'IObservableDisposable'];
+
+const DISPOSABLE_CONSTRUCTOR_NAMES = [
+  'DisposableDelegate',
+  'ObservableDisposableDelegate',
+  'DisposableSet',
+  'ObservableDisposableSet'
+];
+
+const DISPOSABLE_SET_NAMES = ['DisposableSet', 'ObservableDisposableSet'];
+
+interface PendingDisposable {
+  node: TSESTree.Node;
+}
+
+export interface DisposableOwnershipContext {
+  sourceCode: TSESLint.SourceCode;
+  checker: ts.TypeChecker | null;
+  services: ParserServices | null;
+  ownershipFunctionNames: Set<string>;
+}
+
+export type PendingDisposableMap = Map<
+  TSESLint.Scope.Variable,
+  PendingDisposable[]
+>;
+
+function getStaticMemberName(node: TSESTree.MemberExpression): string | null {
+  if (!node.computed && node.property.type === 'Identifier') {
+    return node.property.name;
+  }
+  if (
+    node.computed &&
+    node.property.type === 'Literal' &&
+    typeof node.property.value === 'string'
+  ) {
+    return node.property.value;
+  }
+  return null;
+}
+
+export function getCalleeName(node: TSESTree.Node): string | null {
+  if (node.type === 'Identifier') {
+    return node.name;
+  }
+  if (node.type === 'MemberExpression') {
+    return getStaticMemberName(node);
+  }
+  return null;
+}
+
+function getTransparentChild(node: TSESTree.Node): TSESTree.Node | null {
+  if (
+    node.type === 'ChainExpression' ||
+    node.type === 'TSAsExpression' ||
+    node.type === 'TSTypeAssertion' ||
+    node.type === 'TSNonNullExpression'
+  ) {
+    return node.expression;
+  }
+  return null;
+}
+
+function getOuterExpression(node: TSESTree.Node): TSESTree.Node {
+  let current = node;
+  let parent = current.parent;
+  while (parent) {
+    const child = getTransparentChild(parent);
+    if (child !== current) {
+      break;
+    }
+    current = parent;
+    parent = current.parent;
+  }
+  return current;
+}
+
+function isStaticMemberCall(
+  node: TSESTree.CallExpression,
+  name: string
+): boolean {
+  return (
+    node.callee.type === 'MemberExpression' &&
+    getStaticMemberName(node.callee) === name
+  );
+}
+
+function isOwnershipFunctionCall(
+  node: TSESTree.CallExpression,
+  ownership: DisposableOwnershipContext
+): boolean {
+  const name = getCalleeName(node.callee);
+  return name !== null && ownership.ownershipFunctionNames.has(name);
+}
+
+function getReceiverName(node: TSESTree.Node): string | null {
+  if (node.type === 'Identifier') {
+    return node.name;
+  }
+  if (
+    node.type === 'MemberExpression' &&
+    !node.computed &&
+    node.property.type === 'Identifier'
+  ) {
+    return node.property.name;
+  }
+  return null;
+}
+
+function isLikelyDisposableSet(node: TSESTree.Node): boolean {
+  const name = getReceiverName(node);
+  return name === 'disposables' || name === '_disposables';
+}
+
+function isLikelyDisposableProperty(node: TSESTree.Node): boolean {
+  const name = getReceiverName(node);
+  return name === 'disposablesProperty';
+}
+
+export function isDisposableConstructor(node: TSESTree.NewExpression): boolean {
+  const name = getCalleeName(node.callee);
+  return name !== null && DISPOSABLE_CONSTRUCTOR_NAMES.includes(name);
+}
+
+export function isDisposableSetFactoryCall(node: TSESTree.Node): boolean {
+  if (
+    node.type !== 'CallExpression' ||
+    node.callee.type !== 'MemberExpression' ||
+    getStaticMemberName(node.callee) !== 'from'
+  ) {
+    return false;
+  }
+
+  const name = getCalleeName(node.callee.object);
+  return name !== null && DISPOSABLE_SET_NAMES.includes(name);
+}
+
+function isDirectArrayArgument(
+  element: TSESTree.ArrayExpression['elements'][number]
+): element is TSESTree.Expression {
+  return element !== null && element.type !== 'SpreadElement';
+}
+
+function getDisposableSetFactoryArguments(
+  node: TSESTree.CallExpression
+): TSESTree.CallExpressionArgument[] {
+  if (!isDisposableSetFactoryCall(node)) {
+    return [];
+  }
+
+  const [items] = node.arguments;
+  if (!items || items.type !== 'ArrayExpression') {
+    return [];
+  }
+
+  return items.elements.filter(isDirectArrayArgument);
+}
+
+function resolveVariable(
+  sourceCode: TSESLint.SourceCode,
+  identifier: TSESTree.Identifier
+): TSESLint.Scope.Variable | null {
+  let scope: TSESLint.Scope.Scope | null = sourceCode.getScope(identifier);
+  while (scope) {
+    const variable = scope.set.get(identifier.name);
+    if (variable) {
+      return variable;
+    }
+    scope = scope.upper;
+  }
+  return null;
+}
+
+function getIdentifierVariable(
+  sourceCode: TSESLint.SourceCode,
+  node: TSESTree.Node | null | undefined
+): TSESLint.Scope.Variable | null {
+  if (!node) {
+    return null;
+  }
+  if (node.type === 'Identifier') {
+    return resolveVariable(sourceCode, node);
+  }
+  const child = getTransparentChild(node);
+  if (child) {
+    return getIdentifierVariable(sourceCode, child);
+  }
+  return null;
+}
+
+export function addPendingDisposable(
+  pending: PendingDisposableMap,
+  variable: TSESLint.Scope.Variable,
+  node: TSESTree.Node
+): void {
+  const records = pending.get(variable) ?? [];
+  records.push({ node });
+  pending.set(variable, records);
+}
+
+function markDisposableManaged(
+  pending: PendingDisposableMap,
+  variable: TSESLint.Scope.Variable | null
+): void {
+  if (!variable) {
+    return;
+  }
+  const records = pending.get(variable);
+  if (!records) {
+    return;
+  }
+
+  records.pop();
+  if (records.length === 0) {
+    pending.delete(variable);
+  }
+}
+
+export function getAssignedVariable(
+  node: TSESTree.Node,
+  sourceCode: TSESLint.SourceCode
+): TSESLint.Scope.Variable | null {
+  const expression = getOuterExpression(node);
+  const parent = expression.parent;
+  if (!parent) {
+    return null;
+  }
+  if (
+    parent.type === 'VariableDeclarator' &&
+    parent.init === expression &&
+    parent.id.type === 'Identifier'
+  ) {
+    const declaredVariables = sourceCode.getDeclaredVariables(parent);
+    return declaredVariables[0] ?? null;
+  }
+  if (
+    parent.type === 'AssignmentExpression' &&
+    parent.right === expression &&
+    parent.left.type === 'Identifier'
+  ) {
+    return resolveVariable(sourceCode, parent.left);
+  }
+  return null;
+}
+
+function isFunctionLike(node: TSESTree.Node): boolean {
+  return (
+    node.type === 'ArrowFunctionExpression' ||
+    node.type === 'FunctionDeclaration' ||
+    node.type === 'FunctionExpression'
+  );
+}
+
+function isConditionalOrRepeated(node: TSESTree.Node): boolean {
+  return (
+    node.type === 'CatchClause' ||
+    node.type === 'ConditionalExpression' ||
+    node.type === 'DoWhileStatement' ||
+    node.type === 'ForInStatement' ||
+    node.type === 'ForOfStatement' ||
+    node.type === 'ForStatement' ||
+    node.type === 'IfStatement' ||
+    node.type === 'SwitchCase' ||
+    node.type === 'SwitchStatement' ||
+    node.type === 'TryStatement' ||
+    node.type === 'WhileStatement'
+  );
+}
+
+function isUnconditionalUse(
+  node: TSESTree.Node,
+  variable: TSESLint.Scope.Variable
+): boolean {
+  const scopeBlock = variable.scope.block;
+  let parent = node.parent;
+
+  while (parent) {
+    if (parent === scopeBlock) {
+      return true;
+    }
+    if (isFunctionLike(parent) || isConditionalOrRepeated(parent)) {
+      return false;
+    }
+    parent = parent.parent;
+  }
+
+  return false;
+}
+
+function hasTypeName(
+  type: ts.Type,
+  checker: ts.TypeChecker,
+  names: readonly string[]
+): boolean {
+  const apparentType = checker.getApparentType(type);
+  const symbols = [
+    type.aliasSymbol,
+    type.getSymbol(),
+    apparentType.aliasSymbol,
+    apparentType.getSymbol()
+  ];
+
+  return symbols.some(symbol => {
+    if (!symbol) {
+      return false;
+    }
+    return names.includes(symbol.getName());
+  });
+}
+
+function isDisposableSetType(
+  node: TSESTree.Node,
+  ownership: DisposableOwnershipContext
+): boolean {
+  if (!ownership.checker || !ownership.services) {
+    return false;
+  }
+
+  try {
+    const tsNode = ownership.services.esTreeNodeToTSNodeMap.get(node);
+    const type = ownership.checker.getTypeAtLocation(tsNode);
+    return hasTypeName(type, ownership.checker, DISPOSABLE_SET_NAMES);
+  } catch {
+    return false;
+  }
+}
+
+function isAttachedPropertyType(
+  node: TSESTree.Node,
+  ownership: DisposableOwnershipContext
+): boolean {
+  if (!ownership.checker || !ownership.services) {
+    return false;
+  }
+
+  try {
+    const tsNode = ownership.services.esTreeNodeToTSNodeMap.get(node);
+    const type = ownership.checker.getTypeAtLocation(tsNode);
+    return hasTypeName(type, ownership.checker, ['AttachedProperty']);
+  } catch {
+    return false;
+  }
+}
+
+function isOwnershipAddCall(
+  node: TSESTree.CallExpression,
+  ownership: DisposableOwnershipContext
+): boolean {
+  if (
+    !isStaticMemberCall(node, 'add') ||
+    node.callee.type !== 'MemberExpression'
+  ) {
+    return false;
+  }
+
+  return (
+    isDisposableSetType(node.callee.object, ownership) ||
+    isLikelyDisposableSet(node.callee.object)
+  );
+}
+
+function isOwnershipSetCall(
+  node: TSESTree.CallExpression,
+  ownership: DisposableOwnershipContext
+): boolean {
+  if (
+    !isStaticMemberCall(node, 'set') ||
+    node.callee.type !== 'MemberExpression'
+  ) {
+    return false;
+  }
+
+  return (
+    isAttachedPropertyType(node.callee.object, ownership) ||
+    isLikelyDisposableProperty(node.callee.object)
+  );
+}
+
+function getOwnershipArguments(
+  node: TSESTree.CallExpression,
+  ownership: DisposableOwnershipContext
+): TSESTree.CallExpressionArgument[] {
+  if (isOwnershipAddCall(node, ownership)) {
+    return node.arguments;
+  }
+
+  if (isDisposableSetFactoryCall(node)) {
+    return getDisposableSetFactoryArguments(node);
+  }
+
+  if (isOwnershipFunctionCall(node, ownership)) {
+    return node.arguments;
+  }
+
+  if (isOwnershipSetCall(node, ownership)) {
+    return node.arguments.slice(1);
+  }
+
+  return [];
+}
+
+export function isDisposableExpressionManaged(
+  node: TSESTree.Node,
+  ownership: DisposableOwnershipContext
+): boolean {
+  const expression = getOuterExpression(node);
+  const parent = expression.parent;
+  if (!parent) {
+    return false;
+  }
+
+  if (parent.type === 'ReturnStatement' && parent.argument === expression) {
+    return true;
+  }
+
+  if (parent.type === 'ArrowFunctionExpression' && parent.body === expression) {
+    return true;
+  }
+
+  if (
+    parent.type === 'AssignmentExpression' &&
+    parent.right === expression &&
+    parent.left.type === 'MemberExpression'
+  ) {
+    return true;
+  }
+
+  if (parent.type === 'PropertyDefinition' && parent.value === expression) {
+    return true;
+  }
+
+  if (parent.type === 'CallExpression') {
+    return getOwnershipArguments(parent, ownership).includes(
+      expression as TSESTree.CallExpressionArgument
+    );
+  }
+
+  if (
+    parent.type === 'ArrayExpression' &&
+    parent.parent?.type === 'CallExpression'
+  ) {
+    return getOwnershipArguments(parent.parent, ownership).includes(
+      expression as TSESTree.CallExpressionArgument
+    );
+  }
+
+  if (
+    parent.type === 'MemberExpression' &&
+    parent.object === expression &&
+    getStaticMemberName(parent) === 'dispose' &&
+    parent.parent?.type === 'CallExpression' &&
+    parent.parent.callee === parent
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+export function markManagedDisposableUse(
+  pending: PendingDisposableMap,
+  node: TSESTree.Node,
+  ownership: DisposableOwnershipContext
+): void {
+  if (node.type === 'ReturnStatement') {
+    const variable = getIdentifierVariable(ownership.sourceCode, node.argument);
+    if (variable && isUnconditionalUse(node, variable)) {
+      markDisposableManaged(pending, variable);
+    }
+    return;
+  }
+
+  if (node.type === 'AssignmentExpression') {
+    if (node.left.type === 'MemberExpression') {
+      const variable = getIdentifierVariable(ownership.sourceCode, node.right);
+      if (variable && isUnconditionalUse(node, variable)) {
+        markDisposableManaged(pending, variable);
+      }
+    }
+    return;
+  }
+
+  if (node.type !== 'CallExpression') {
+    return;
+  }
+
+  const ownershipArguments = getOwnershipArguments(node, ownership);
+  if (ownershipArguments.length > 0) {
+    for (const argument of ownershipArguments) {
+      const variable = getIdentifierVariable(ownership.sourceCode, argument);
+      if (variable && isUnconditionalUse(node, variable)) {
+        markDisposableManaged(pending, variable);
+      }
+    }
+    return;
+  }
+
+  if (
+    isStaticMemberCall(node, 'dispose') &&
+    node.callee.type === 'MemberExpression' &&
+    node.callee.object.type !== 'Super'
+  ) {
+    const variable = getIdentifierVariable(
+      ownership.sourceCode,
+      node.callee.object
+    );
+    if (variable) {
+      if (isUnconditionalUse(node, variable)) {
+        markDisposableManaged(pending, variable);
+      }
+    }
+  }
+}
+
+function hasDisposableTypeName(
+  type: ts.Type,
+  checker: ts.TypeChecker
+): boolean {
+  return (
+    hasTypeName(type, checker, DISPOSABLE_INTERFACE_NAMES) ||
+    hasTypeName(type, checker, DISPOSABLE_CONSTRUCTOR_NAMES)
+  );
+}
+
+function declarationHasDisposableHeritage(
+  declaration: ts.Declaration
+): boolean {
+  if (
+    !(
+      ts.isClassDeclaration(declaration) ||
+      ts.isClassExpression(declaration) ||
+      ts.isInterfaceDeclaration(declaration)
+    )
+  ) {
+    return false;
+  }
+
+  return (
+    declaration.heritageClauses?.some(clause =>
+      clause.types.some(type => {
+        const text = type.expression.getText();
+        for (const name of DISPOSABLE_INTERFACE_NAMES) {
+          if (text === name || text.endsWith(`.${name}`)) {
+            return true;
+          }
+        }
+        for (const name of DISPOSABLE_CONSTRUCTOR_NAMES) {
+          if (text === name || text.endsWith(`.${name}`)) {
+            return true;
+          }
+        }
+        return false;
+      })
+    ) ?? false
+  );
+}
+
+function hasDisposableHeritage(type: ts.Type): boolean {
+  const symbol = type.getSymbol();
+  return symbol?.declarations?.some(declarationHasDisposableHeritage) ?? false;
+}
+
+function hasDisposableShape(type: ts.Type, checker: ts.TypeChecker): boolean {
+  const dispose = type.getProperty('dispose');
+  const isDisposed = type.getProperty('isDisposed');
+  if (!dispose || !isDisposed) {
+    return false;
+  }
+
+  const declaration = dispose.valueDeclaration ?? dispose.declarations?.[0];
+  if (!declaration) {
+    return false;
+  }
+
+  const disposeType = checker.getTypeOfSymbolAtLocation(dispose, declaration);
+  return disposeType.getCallSignatures().length > 0;
+}
+
+export function isDisposableType(
+  type: ts.Type,
+  checker: ts.TypeChecker,
+  seen = new Set<ts.Type>()
+): boolean {
+  if (seen.has(type)) {
+    return false;
+  }
+  seen.add(type);
+
+  if (type.isUnion()) {
+    return type.types.some(part => isDisposableType(part, checker, seen));
+  }
+
+  if (type.isIntersection()) {
+    return type.types.some(part => isDisposableType(part, checker, seen));
+  }
+
+  const apparentType = checker.getApparentType(type);
+
+  return (
+    hasDisposableTypeName(type, checker) ||
+    hasDisposableHeritage(type) ||
+    hasDisposableShape(apparentType, checker)
+  );
+}
+
+export function shouldCheckReturnedDisposable(
+  node: TSESTree.CallExpression
+): boolean {
+  const expression = getOuterExpression(node);
+  const parent = expression.parent;
+  if (!parent) {
+    return false;
+  }
+
+  if (
+    parent.type === 'ExpressionStatement' ||
+    parent.type === 'ReturnStatement'
+  ) {
+    return true;
+  }
+
+  if (parent.type === 'VariableDeclarator' && parent.init === expression) {
+    return true;
+  }
+
+  if (parent.type === 'AssignmentExpression' && parent.right === expression) {
+    return true;
+  }
+
+  if (parent.type === 'PropertyDefinition' && parent.value === expression) {
+    return true;
+  }
+
+  if (
+    parent.type === 'UnaryExpression' &&
+    parent.operator === 'void' &&
+    parent.argument === expression
+  ) {
+    return true;
+  }
+
+  if (parent.type === 'CallExpression' || parent.type === 'NewExpression') {
+    return parent.arguments.includes(
+      expression as TSESTree.CallExpressionArgument
+    );
+  }
+
+  if (
+    parent.type === 'ArrayExpression' &&
+    (parent.parent?.type === 'CallExpression' ||
+      parent.parent?.type === 'NewExpression') &&
+    parent.parent.arguments.includes(parent as TSESTree.CallExpressionArgument)
+  ) {
+    return true;
+  }
+
+  return parent.type === 'MemberExpression' && parent.object === expression;
+}

--- a/src/utils/disposables.ts
+++ b/src/utils/disposables.ts
@@ -18,6 +18,15 @@ const DISPOSABLE_CONSTRUCTOR_NAMES = [
 
 const DISPOSABLE_SET_NAMES = ['DisposableSet', 'ObservableDisposableSet'];
 
+export const DEFAULT_OWNERSHIP_FUNCTION_NAMES = [
+  'add',
+  'addFactory',
+  'addItem',
+  'addModelFactory',
+  'addWidget',
+  'addWidgetFactory'
+];
+
 interface PendingDisposable {
   node: TSESTree.Node;
 }
@@ -78,6 +87,29 @@ function getOuterExpression(node: TSESTree.Node): TSESTree.Node {
     if (child !== current) {
       break;
     }
+    current = parent;
+    parent = current.parent;
+  }
+  return current;
+}
+
+function isFallbackExpression(
+  node: TSESTree.Node
+): node is TSESTree.LogicalExpression {
+  return (
+    node.type === 'LogicalExpression' &&
+    (node.operator === '||' || node.operator === '??')
+  );
+}
+
+function getOuterFallbackExpression(node: TSESTree.Node): TSESTree.Node {
+  let current = getOuterExpression(node);
+  let parent = current.parent;
+  while (
+    parent &&
+    isFallbackExpression(parent) &&
+    (parent.left === current || parent.right === current)
+  ) {
     current = parent;
     parent = current.parent;
   }
@@ -197,6 +229,42 @@ function getIdentifierVariable(
   return null;
 }
 
+function getIdentifierVariables(
+  sourceCode: TSESLint.SourceCode,
+  node: TSESTree.Node | null | undefined
+): TSESLint.Scope.Variable[] {
+  const variable = getIdentifierVariable(sourceCode, node);
+  if (variable) {
+    return [variable];
+  }
+  if (!node) {
+    return [];
+  }
+
+  const child = getTransparentChild(node);
+  if (child) {
+    return getIdentifierVariables(sourceCode, child);
+  }
+
+  if (node.type === 'ArrayExpression') {
+    return node.elements.flatMap(element =>
+      element && element.type !== 'SpreadElement'
+        ? getIdentifierVariables(sourceCode, element)
+        : []
+    );
+  }
+
+  if (node.type === 'ObjectExpression') {
+    return node.properties.flatMap(property =>
+      property.type === 'Property'
+        ? getIdentifierVariables(sourceCode, property.value)
+        : []
+    );
+  }
+
+  return [];
+}
+
 export function addPendingDisposable(
   pending: PendingDisposableMap,
   variable: TSESLint.Scope.Variable,
@@ -229,7 +297,7 @@ export function getAssignedVariable(
   node: TSESTree.Node,
   sourceCode: TSESLint.SourceCode
 ): TSESLint.Scope.Variable | null {
-  const expression = getOuterExpression(node);
+  const expression = getOuterFallbackExpression(node);
   const parent = expression.parent;
   if (!parent) {
     return null;
@@ -389,6 +457,10 @@ function getOwnershipArguments(
   node: TSESTree.CallExpression,
   ownership: DisposableOwnershipContext
 ): TSESTree.CallExpressionArgument[] {
+  if (node.callee.type === 'Super') {
+    return node.arguments;
+  }
+
   if (isOwnershipAddCall(node, ownership)) {
     return node.arguments;
   }
@@ -408,11 +480,56 @@ function getOwnershipArguments(
   return [];
 }
 
+function isArgumentOfCallOrNew(
+  node: TSESTree.Node
+): node is TSESTree.CallExpression | TSESTree.NewExpression {
+  return node.type === 'CallExpression' || node.type === 'NewExpression';
+}
+
+function isOptionsObjectValueManaged(
+  expression: TSESTree.Node,
+  ownership: DisposableOwnershipContext
+): boolean {
+  const property = expression.parent;
+  if (
+    !property ||
+    property.type !== 'Property' ||
+    property.value !== expression
+  ) {
+    return false;
+  }
+
+  const object = property.parent;
+  if (!object || object.type !== 'ObjectExpression') {
+    return false;
+  }
+
+  const parent = object.parent;
+  if (!parent || !isArgumentOfCallOrNew(parent)) {
+    return false;
+  }
+
+  if (!parent.arguments.includes(object as TSESTree.CallExpressionArgument)) {
+    return false;
+  }
+
+  if (parent.type === 'NewExpression') {
+    return true;
+  }
+
+  return (
+    parent.callee.type === 'Super' ||
+    getOwnershipArguments(parent, ownership).includes(
+      object as TSESTree.CallExpressionArgument
+    )
+  );
+}
+
 export function isDisposableExpressionManaged(
   node: TSESTree.Node,
   ownership: DisposableOwnershipContext
 ): boolean {
-  const expression = getOuterExpression(node);
+  const expression = getOuterFallbackExpression(node);
   const parent = expression.parent;
   if (!parent) {
     return false;
@@ -451,6 +568,10 @@ export function isDisposableExpressionManaged(
     return getOwnershipArguments(parent.parent, ownership).includes(
       expression as TSESTree.CallExpressionArgument
     );
+  }
+
+  if (isOptionsObjectValueManaged(expression, ownership)) {
+    return true;
   }
 
   if (
@@ -496,9 +617,11 @@ export function markManagedDisposableUse(
   const ownershipArguments = getOwnershipArguments(node, ownership);
   if (ownershipArguments.length > 0) {
     for (const argument of ownershipArguments) {
-      const variable = getIdentifierVariable(ownership.sourceCode, argument);
-      if (variable && isUnconditionalUse(node, variable)) {
-        markDisposableManaged(pending, variable);
+      const variables = getIdentifierVariables(ownership.sourceCode, argument);
+      for (const variable of variables) {
+        if (isUnconditionalUse(node, variable)) {
+          markDisposableManaged(pending, variable);
+        }
       }
     }
     return;
@@ -615,7 +738,7 @@ export function isDisposableType(
 export function shouldCheckReturnedDisposable(
   node: TSESTree.CallExpression
 ): boolean {
-  const expression = getOuterExpression(node);
+  const expression = getOuterFallbackExpression(node);
   const parent = expression.parent;
   if (!parent) {
     return false;

--- a/src/utils/disposables.ts
+++ b/src/utils/disposables.ts
@@ -20,11 +20,16 @@ const DISPOSABLE_SET_NAMES = ['DisposableSet', 'ObservableDisposableSet'];
 
 export const DEFAULT_OWNERSHIP_FUNCTION_NAMES = [
   'add',
+  'addCell',
   'addFactory',
   'addItem',
   'addModelFactory',
+  'addSibling',
   'addWidget',
-  'addWidgetFactory'
+  'addWidgetFactory',
+  'insertItem',
+  'insertWidget',
+  'registerStatusItem'
 ];
 
 interface PendingDisposable {
@@ -634,6 +639,19 @@ function isDialogLaunchCall(
   );
 }
 
+function markManagedVariables(
+  pending: PendingDisposableMap,
+  node: TSESTree.Node,
+  ownership: DisposableOwnershipContext
+): void {
+  const variables = getIdentifierVariables(ownership.sourceCode, node);
+  for (const variable of variables) {
+    if (isUnconditionalUse(node, variable)) {
+      markDisposableManaged(pending, variable);
+    }
+  }
+}
+
 export function markManagedDisposableUse(
   pending: PendingDisposableMap,
   node: TSESTree.Node,
@@ -657,19 +675,32 @@ export function markManagedDisposableUse(
     return;
   }
 
-  if (node.type !== 'CallExpression') {
+  if (node.type !== 'CallExpression' && node.type !== 'NewExpression') {
+    return;
+  }
+
+  for (const argument of node.arguments) {
+    if (argument.type !== 'ObjectExpression') {
+      continue;
+    }
+    for (const property of argument.properties) {
+      if (
+        property.type === 'Property' &&
+        isOptionsObjectValueManaged(property.value, ownership)
+      ) {
+        markManagedVariables(pending, property.value, ownership);
+      }
+    }
+  }
+
+  if (node.type === 'NewExpression') {
     return;
   }
 
   const ownershipArguments = getOwnershipArguments(node, ownership);
   if (ownershipArguments.length > 0) {
     for (const argument of ownershipArguments) {
-      const variables = getIdentifierVariables(ownership.sourceCode, argument);
-      for (const variable of variables) {
-        if (isUnconditionalUse(node, variable)) {
-          markDisposableManaged(pending, variable);
-        }
-      }
+      markManagedVariables(pending, argument, ownership);
     }
     return;
   }

--- a/tests/jupyter-require-disposable-ownership.test.ts
+++ b/tests/jupyter-require-disposable-ownership.test.ts
@@ -275,6 +275,23 @@ ruleTester.run('require-disposable-ownership', requireDisposableOwnership, {
     {
       filename: typeAwareFilename,
       code: `
+        class StatusItem {
+          readonly isDisposed = false;
+          dispose(): void {}
+        }
+        declare const statusBar: {
+          registerStatusItem(id: string, options: { item: StatusItem }): void;
+        } | null;
+
+        const item = statusBar ? new StatusItem() : null;
+        if (statusBar && item) {
+          statusBar.registerStatusItem('status', { item });
+        }
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
         class Widget {
           readonly isDisposed = false;
           dispose(): void {}
@@ -306,6 +323,21 @@ ruleTester.run('require-disposable-ownership', requireDisposableOwnership, {
     {
       filename: typeAwareFilename,
       code: `
+        class Menu {
+          readonly isDisposed = false;
+          dispose(): void {}
+        }
+        declare const menuBar: {
+          addGroup(items: Array<{ type: 'submenu'; submenu: Menu }>, rank: number): void;
+        };
+
+        const menu = new Menu();
+        menuBar.addGroup([{ type: 'submenu', submenu: menu }], 40);
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
         import type { JupyterFrontEndPlugin } from './fixtures/types';
 
         class WidgetTracker<T> {
@@ -323,6 +355,35 @@ ruleTester.run('require-disposable-ownership', requireDisposableOwnership, {
             console.log(tracker);
           }
         };
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        class WidgetTracker<T> {
+          readonly isDisposed = false;
+          constructor(options: { namespace: string }) {}
+          dispose(): void {}
+        }
+        declare const token: unknown;
+
+        function createPlugins(): unknown[] {
+          const plugins: unknown[] = [];
+          const tracker = new WidgetTracker<object>({
+            namespace: 'example'
+          });
+
+          plugins.push({
+            id: 'example:tracker',
+            provides: token,
+            autoStart: true,
+            activate: () => {
+              return tracker;
+            }
+          });
+
+          return plugins;
+        }
       `
     },
     {
@@ -358,6 +419,253 @@ ruleTester.run('require-disposable-ownership', requireDisposableOwnership, {
             const widget = new Widget();
             this._widgets.set('widget', widget);
           }
+        }
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        class Widget {
+          readonly isDisposed = false;
+          dispose(): void {}
+        }
+
+        function createToolbarItems(): Array<{ name: string; widget: Widget }> {
+          return [
+            {
+              name: 'refresh',
+              widget: new Widget()
+            }
+          ];
+        }
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        class Widget {
+          readonly isDisposed = false;
+          dispose(): void {}
+        }
+
+        class Owner {
+          private _state: { widget: Widget } | null = null;
+
+          initialize(): void {
+            this._state = {
+              widget: new Widget()
+            };
+          }
+        }
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        class Widget {
+          readonly isDisposed = false;
+          dispose(): void {}
+        }
+
+        class Owner {
+          private _items: Array<{ widget: Widget }> = [];
+
+          addWidget(): void {
+            const widget = new Widget();
+            this._items.push({ widget });
+          }
+        }
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        class WidgetFactory {
+          readonly isDisposed = false;
+          dispose(): void {}
+        }
+        declare const docRegistry: {
+          addWidgetFactory(factory: WidgetFactory): void;
+        };
+
+        const factory = new WidgetFactory();
+        const textFactory = new WidgetFactory();
+        [factory, textFactory].forEach(factory => {
+          docRegistry.addWidgetFactory(factory);
+        });
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        declare const id: string;
+        class Widget {
+          readonly isDisposed = false;
+          dispose(): void {}
+        }
+
+        function createWidget(): Widget {
+          let widget: Widget;
+          switch (id) {
+            case 'left':
+              widget = new Widget();
+              break;
+            case 'right':
+              widget = new Widget();
+              break;
+            default:
+              widget = new Widget();
+          }
+
+          return widget;
+        }
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        class Widget {
+          readonly isDisposed = false;
+          dispose(): void {}
+          initializeState(): this {
+            return this;
+          }
+        }
+
+        function createWidget(): Widget {
+          return new Widget().initializeState();
+        }
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        class Widget {
+          readonly isDisposed = false;
+          dispose(): void {}
+        }
+        class Model {
+          readonly isDisposed = false;
+          dispose(): void {}
+        }
+        class CodeEditorWrapper {
+          readonly isDisposed = false;
+          constructor(options: { model: Model }) {}
+          dispose(): void {}
+        }
+
+        function createEditor(): CodeEditorWrapper {
+          const model = new Model();
+          return new CodeEditorWrapper({ model });
+        }
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        class Model {
+          readonly isDisposed = false;
+          dispose(): void {}
+        }
+        class Licenses {
+          readonly isDisposed = false;
+          constructor(options: { model: Model }) {}
+          dispose(): void {}
+        }
+
+        function createLicenses(): Licenses {
+          const model = new Model();
+          return new Licenses({ model });
+        }
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        class Widget {
+          readonly isDisposed = false;
+          dispose(): void {}
+        }
+        class Dialog<T> {
+          readonly isDisposed = false;
+          constructor(options: { body: Widget }) {}
+          dispose(): void {}
+          launch(): Promise<T> {
+            return Promise.resolve(undefined as T);
+          }
+        }
+        class PromptDialog extends Dialog<string> {}
+
+        function prompt(): Promise<string> {
+          const dialog = new PromptDialog({ body: new Widget() });
+          return dialog.launch();
+        }
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        class Widget {
+          readonly isDisposed = false;
+          dispose(): void {}
+        }
+        declare function showPopup(options: { body: Widget }): Widget;
+
+        class Owner {
+          private _popup: Widget | null = null;
+
+          open(): void {
+            const body = new Widget();
+            this._popup = showPopup({ body });
+          }
+        }
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        class Widget {
+          readonly isDisposed = false;
+          dispose(): void {}
+        }
+        class DocumentWidget<T extends Widget> {
+          readonly isDisposed = false;
+          constructor(options: { content: T }) {}
+          dispose(): void {}
+        }
+        class MarkdownDocument extends DocumentWidget<Widget> {}
+
+        function createDocument(): MarkdownDocument {
+          const content = new Widget();
+          return new MarkdownDocument({ content });
+        }
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        class NotebookHistory {
+          readonly isDisposed = false;
+          dispose(): void {}
+        }
+        class Notebook {
+          readonly isDisposed = false;
+          dispose(): void {}
+        }
+        class NotebookPanel {
+          readonly isDisposed = false;
+          constructor(options: { content: Notebook }) {}
+          dispose(): void {}
+        }
+        declare const contentFactory: {
+          createNotebook(options: { kernelHistory: NotebookHistory }): Notebook;
+        };
+
+        function createPanel(): NotebookPanel {
+          const kernelHistory = new NotebookHistory();
+          const nbOptions = { kernelHistory };
+          const content = contentFactory.createNotebook(nbOptions);
+          return new NotebookPanel({ content });
         }
       `
     },
@@ -539,6 +847,67 @@ ruleTester.run('require-disposable-ownership', requireDisposableOwnership, {
         new DisposableDelegate(() => {
           cleanup();
         }).dispose();
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        declare function cleanup(): void;
+        class DisposableDelegate {
+          constructor(callback: () => void) {}
+          dispose(): void {}
+        }
+        declare const widget: {
+          readonly disposed: {
+            connect(callback: () => void): void;
+          };
+        };
+
+        const disposable = new DisposableDelegate(() => {
+          cleanup();
+        });
+        widget.disposed.connect(() => {
+          disposable.dispose();
+        });
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        class DisposableSet {
+          add(disposable: object): void {}
+          dispose(): void {}
+        }
+        declare const shortcuts: object[];
+        let disposables: DisposableSet | null = null;
+
+        function loadShortcuts(): void {
+          disposables = shortcuts.reduce((acc): DisposableSet => {
+            acc.add({});
+            return acc;
+          }, new DisposableSet());
+        }
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        class Widget {
+          readonly isDisposed = false;
+          dispose(): void {}
+        }
+        class Panel extends Widget {}
+
+        class OutputArea {
+          addWarning(): Panel {
+            const warning = new Widget();
+            return this._wrappedOutput(warning);
+          }
+
+          private _wrappedOutput(output: Widget): Panel {
+            return new Panel();
+          }
+        }
       `
     },
     {
@@ -815,6 +1184,32 @@ ruleTester.run('require-disposable-ownership', requireDisposableOwnership, {
       filename: typeAwareFilename,
       code: `
         declare const condition: boolean;
+        class WidgetFactory {
+          readonly isDisposed = false;
+          dispose(): void {}
+        }
+        declare const docRegistry: {
+          addWidgetFactory(factory: WidgetFactory): void;
+        };
+
+        const factory = new WidgetFactory();
+        [factory].forEach(factory => {
+          if (condition) {
+            docRegistry.addWidgetFactory(factory);
+          }
+        });
+      `,
+      errors: [
+        {
+          messageId: 'unmanagedDisposableVariable',
+          data: { name: 'factory' }
+        }
+      ]
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        declare const condition: boolean;
         class Widget {
           readonly isDisposed = false;
           dispose(): void {}
@@ -856,6 +1251,51 @@ ruleTester.run('require-disposable-ownership', requireDisposableOwnership, {
           data: { name: 'disposable' }
         }
       ]
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        declare function cleanup(): void;
+        declare const condition: boolean;
+        class DisposableDelegate {
+          constructor(callback: () => void) {}
+          dispose(): void {}
+        }
+        declare const widget: {
+          readonly disposed: {
+            connect(callback: () => void): void;
+          };
+        };
+
+        const disposable = new DisposableDelegate(() => {
+          cleanup();
+        });
+        widget.disposed.connect(() => {
+          if (condition) {
+            disposable.dispose();
+          }
+        });
+      `,
+      errors: [
+        {
+          messageId: 'unmanagedDisposableVariable',
+          data: { name: 'disposable' }
+        }
+      ]
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        class DisposableSet {
+          dispose(): void {}
+        }
+        declare const shortcuts: object[];
+
+        shortcuts.reduce((): DisposableSet => {
+          return new DisposableSet();
+        }, new DisposableSet());
+      `,
+      errors: [{ messageId: 'unmanagedDisposable' }]
     },
     {
       filename: typeAwareFilename,

--- a/tests/jupyter-require-disposable-ownership.test.ts
+++ b/tests/jupyter-require-disposable-ownership.test.ts
@@ -129,6 +129,23 @@ ruleTester.run('require-disposable-ownership', requireDisposableOwnership, {
     {
       filename: typeAwareFilename,
       code: `
+        declare function cleanup(): void;
+        class DisposableDelegate {
+          constructor(callback: () => void) {}
+          dispose(): void {}
+        }
+        declare const shell: {
+          add(disposable: DisposableDelegate): void;
+        };
+
+        shell.add(new DisposableDelegate(() => {
+          cleanup();
+        }));
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
         class DisposableSet {
           dispose(): void {}
         }
@@ -171,6 +188,69 @@ ruleTester.run('require-disposable-ownership', requireDisposableOwnership, {
           return new DisposableDelegate(() => {
             cleanup();
           });
+        }
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        declare function cleanup(): void;
+        class DisposableDelegate {
+          constructor(callback: () => void) {}
+          dispose(): void {}
+        }
+        class Widget {
+          constructor(options: { disposable: DisposableDelegate }) {}
+        }
+
+        new Widget({
+          disposable: new DisposableDelegate(() => {
+            cleanup();
+          })
+        });
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        declare function cleanup(): void;
+        class DisposableDelegate {
+          constructor(callback: () => void) {}
+          dispose(): void {}
+        }
+
+        class Owner {
+          private _disposable: DisposableDelegate | null = null;
+
+          initialize(): void {
+            this._disposable =
+              this._disposable ??
+              new DisposableDelegate(() => {
+                cleanup();
+              });
+          }
+        }
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        declare function cleanup(): void;
+        class DisposableDelegate {
+          constructor(callback: () => void) {}
+          dispose(): void {}
+        }
+        class Base {
+          constructor(options: { disposable: DisposableDelegate }) {}
+        }
+        class Owner extends Base {
+          constructor() {
+            super({
+              disposable: new DisposableDelegate(() => {
+                cleanup();
+              })
+            });
+          }
         }
       `
     },
@@ -508,6 +588,7 @@ ruleTester.run('require-disposable-ownership', requireDisposableOwnership, {
     },
     {
       filename: typeAwareFilename,
+      options: [{ ownershipFunctionNames: [] }],
       code: `
         declare function cleanup(): void;
         class DisposableDelegate {

--- a/tests/jupyter-require-disposable-ownership.test.ts
+++ b/tests/jupyter-require-disposable-ownership.test.ts
@@ -213,6 +213,56 @@ ruleTester.run('require-disposable-ownership', requireDisposableOwnership, {
     {
       filename: typeAwareFilename,
       code: `
+        class Widget {
+          readonly isDisposed = false;
+          dispose(): void {}
+        }
+        declare function showDialog(options: { body: Widget }): void;
+
+        showDialog({ body: new Widget() });
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        class Widget {
+          readonly isDisposed = false;
+          dispose(): void {}
+        }
+        class Dialog {
+          readonly isDisposed = false;
+          constructor(options: { body: Widget }) {}
+          dispose(): void {}
+          launch(): Promise<void> {
+            return Promise.resolve();
+          }
+        }
+
+        async function prompt(): Promise<void> {
+          const dialog = new Dialog({ body: new Widget() });
+          await dialog.launch();
+        }
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        class LabShell {
+          readonly isDisposed = false;
+          dispose(): void {}
+        }
+        interface IOptions {
+          shell: LabShell;
+        }
+
+        class Application {
+          constructor(options: IOptions = { shell: new LabShell() }) {}
+        }
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
         declare function cleanup(): void;
         class DisposableDelegate {
           constructor(callback: () => void) {}

--- a/tests/jupyter-require-disposable-ownership.test.ts
+++ b/tests/jupyter-require-disposable-ownership.test.ts
@@ -306,6 +306,28 @@ ruleTester.run('require-disposable-ownership', requireDisposableOwnership, {
     {
       filename: typeAwareFilename,
       code: `
+        import type { JupyterFrontEndPlugin } from './fixtures/types';
+
+        class WidgetTracker<T> {
+          readonly isDisposed = false;
+          constructor(options: { namespace: string }) {}
+          dispose(): void {}
+        }
+
+        export const plugin: JupyterFrontEndPlugin<void> = {
+          id: 'example:tracker',
+          activate: () => {
+            const tracker = new WidgetTracker<object>({
+              namespace: 'example'
+            });
+            console.log(tracker);
+          }
+        };
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
         declare const condition: boolean;
         class Widget {
           readonly isDisposed = false;
@@ -315,8 +337,8 @@ ruleTester.run('require-disposable-ownership', requireDisposableOwnership, {
           add(widget: Widget): void;
         };
 
-        const widget = new Widget();
         if (condition) {
+          const widget = new Widget();
           shell.add(widget);
         }
       `
@@ -762,6 +784,52 @@ ruleTester.run('require-disposable-ownership', requireDisposableOwnership, {
         {
           messageId: 'unmanagedDisposableVariable',
           data: { name: 'disposable' }
+        }
+      ]
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        declare const condition: boolean;
+        class Widget {
+          readonly isDisposed = false;
+          dispose(): void {}
+        }
+        declare const shell: {
+          add(widget: Widget): void;
+        };
+
+        const widget = new Widget();
+        if (condition) {
+          shell.add(widget);
+        }
+      `,
+      errors: [
+        {
+          messageId: 'unmanagedDisposableVariable',
+          data: { name: 'widget' }
+        }
+      ]
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        declare const condition: boolean;
+        class Widget {
+          readonly isDisposed = false;
+          dispose(): void {}
+        }
+        declare function showDialog(options: { body: Widget }): void;
+
+        const body = new Widget();
+        if (condition) {
+          showDialog({ body });
+        }
+      `,
+      errors: [
+        {
+          messageId: 'unmanagedDisposableVariable',
+          data: { name: 'body' }
         }
       ]
     },

--- a/tests/jupyter-require-disposable-ownership.test.ts
+++ b/tests/jupyter-require-disposable-ownership.test.ts
@@ -1,0 +1,548 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import * as path from 'path';
+import requireDisposableOwnership from '../src/rules/require-disposable-ownership';
+
+const typeAwareFilename = 'tests/type-aware-fixture.ts';
+
+const nonTypeAwareTester = new RuleTester({
+  languageOptions: {
+    parser: require('@typescript-eslint/parser'),
+    parserOptions: {
+      ecmaVersion: 2020,
+      sourceType: 'module',
+      tsconfigRootDir: path.resolve(__dirname, '..')
+    }
+  }
+});
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parser: require('@typescript-eslint/parser'),
+    parserOptions: {
+      ecmaVersion: 2020,
+      sourceType: 'module',
+      projectService: {
+        allowDefaultProject: ['tests/*.ts'],
+        defaultProject: 'tsconfig.json'
+      },
+      tsconfigRootDir: path.resolve(__dirname, '..')
+    }
+  }
+});
+
+nonTypeAwareTester.run(
+  'require-disposable-ownership (non-type-aware)',
+  requireDisposableOwnership,
+  {
+    valid: [
+      {
+        code: `
+          declare function cleanup(): void;
+          declare const _disposables: { add(disposable: DisposableDelegate): void };
+          class DisposableDelegate {
+            constructor(callback: () => void) {}
+          }
+
+          _disposables.add(new DisposableDelegate(() => {
+            cleanup();
+          }));
+        `
+      },
+      {
+        code: `
+          declare function cleanup(): void;
+          declare const _disposables: { add(disposable: ObservableDisposableDelegate): void };
+          class ObservableDisposableDelegate {
+            constructor(callback: () => void) {}
+          }
+
+          _disposables.add(new ObservableDisposableDelegate(() => {
+            cleanup();
+          }));
+        `
+      }
+    ],
+    invalid: [
+      {
+        code: `
+          declare function cleanup(): void;
+          class DisposableDelegate {
+            constructor(callback: () => void) {}
+          }
+
+          new DisposableDelegate(() => {
+            cleanup();
+          });
+        `,
+        errors: [{ messageId: 'unmanagedDisposable' }]
+      },
+      {
+        code: `
+          declare function cleanup(): void;
+          class ObservableDisposableDelegate {
+            constructor(callback: () => void) {}
+          }
+
+          new ObservableDisposableDelegate(() => {
+            cleanup();
+          });
+        `,
+        errors: [{ messageId: 'unmanagedDisposable' }]
+      },
+      {
+        code: `
+          class ObservableDisposableSet {}
+
+          new ObservableDisposableSet();
+        `,
+        errors: [{ messageId: 'unmanagedDisposable' }]
+      }
+    ]
+  }
+);
+
+ruleTester.run('require-disposable-ownership', requireDisposableOwnership, {
+  valid: [
+    {
+      filename: typeAwareFilename,
+      code: `
+        declare function cleanup(): void;
+        class DisposableDelegate {
+          constructor(callback: () => void) {}
+          dispose(): void {}
+        }
+        class DisposableSet {
+          add(disposable: DisposableDelegate): void {}
+        }
+        declare const disposables: DisposableSet;
+
+        disposables.add(new DisposableDelegate(() => {
+          cleanup();
+        }));
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        class DisposableSet {
+          dispose(): void {}
+        }
+        class AttachedProperty<T, U> {
+          set(owner: T, value: U): void {}
+        }
+        declare const widget: object;
+        declare const disposablesProperty: AttachedProperty<object, DisposableSet>;
+
+        const disposables = new DisposableSet();
+        disposablesProperty.set(widget, disposables);
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        class DisposableSet {
+          dispose(): void {}
+        }
+        declare const widget: object;
+        declare const Private: {
+          disposablesProperty: {
+            set(owner: object, value: DisposableSet): void;
+          };
+        };
+
+        Private.disposablesProperty.set(widget, new DisposableSet());
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        declare function cleanup(): void;
+        class DisposableDelegate {
+          constructor(callback: () => void) {}
+          dispose(): void {}
+        }
+
+        function createDisposable(): DisposableDelegate {
+          return new DisposableDelegate(() => {
+            cleanup();
+          });
+        }
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        declare function cleanup(): void;
+        class DisposableDelegate {
+          constructor(callback: () => void) {}
+          dispose(): void {}
+        }
+
+        const createDisposable = () => new DisposableDelegate(() => {
+          cleanup();
+        });
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        declare function cleanup(): void;
+        class DisposableDelegate {
+          constructor(callback: () => void) {}
+          dispose(): void {}
+        }
+
+        class Owner {
+          private _disposable: DisposableDelegate | null = null;
+
+          initialize(): void {
+            this._disposable = new DisposableDelegate(() => {
+              cleanup();
+            });
+          }
+        }
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        class DisposableSet {
+          dispose(): void {}
+        }
+
+        class Owner {
+          private _disposables = new DisposableSet();
+        }
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        declare function cleanup(): void;
+        class DisposableDelegate {
+          constructor(callback: () => void) {}
+          dispose(): void {}
+        }
+        class DisposableSet {
+          static from(items: Iterable<DisposableDelegate>): DisposableSet {
+            return new DisposableSet();
+          }
+          dispose(): void {}
+        }
+
+        DisposableSet.from([
+          new DisposableDelegate(() => {
+            cleanup();
+          })
+        ]).dispose();
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        declare function cleanup(): void;
+        class DisposableDelegate {
+          constructor(callback: () => void) {}
+          dispose(): void {}
+        }
+
+        new DisposableDelegate(() => {
+          cleanup();
+        }).dispose();
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        declare function cleanup(): void;
+        class DisposableDelegate {
+          constructor(callback: () => void) {}
+          dispose(): void {}
+        }
+
+        const disposable = new DisposableDelegate(() => {
+          cleanup();
+        });
+        disposable.dispose();
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      options: [{ ownershipFunctionNames: ['ownDisposable'] }],
+      code: `
+        declare function cleanup(): void;
+        declare function ownDisposable(disposable: DisposableDelegate): void;
+        class DisposableDelegate {
+          constructor(callback: () => void) {}
+          dispose(): void {}
+        }
+
+        const disposable = new DisposableDelegate(() => {
+          cleanup();
+        });
+        ownDisposable(disposable);
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+        class CustomDisposable implements IDisposable {
+          readonly isDisposed = false;
+          dispose(): void {}
+        }
+
+        function createDisposable(): IDisposable {
+          return new CustomDisposable();
+        }
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `new Date();`
+    }
+  ],
+
+  invalid: [
+    {
+      filename: typeAwareFilename,
+      code: `
+        declare function cleanup(): void;
+        class DisposableDelegate {
+          constructor(callback: () => void) {}
+          dispose(): void {}
+        }
+
+        new DisposableDelegate(() => {
+          cleanup();
+        });
+      `,
+      errors: [{ messageId: 'unmanagedDisposable' }]
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        class DisposableSet {
+          dispose(): void {}
+        }
+        declare const widget: object;
+        declare const values: {
+          set(owner: object, value: DisposableSet): void;
+        };
+
+        const disposables = new DisposableSet();
+        values.set(widget, disposables);
+      `,
+      errors: [
+        {
+          messageId: 'unmanagedDisposableVariable',
+          data: { name: 'disposables' }
+        }
+      ]
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        class DisposableSet {
+          dispose(): void {}
+        }
+
+        let disposables = new DisposableSet();
+        disposables.dispose();
+        disposables = new DisposableSet();
+      `,
+      errors: [
+        {
+          messageId: 'unmanagedDisposableVariable',
+          data: { name: 'disposables' }
+        }
+      ]
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        declare function cleanup(): void;
+        class DisposableDelegate {
+          constructor(callback: () => void) {}
+          dispose(): void {}
+        }
+
+        const disposable = new DisposableDelegate(() => {
+          cleanup();
+        });
+        console.log(disposable);
+      `,
+      errors: [
+        {
+          messageId: 'unmanagedDisposableVariable',
+          data: { name: 'disposable' }
+        }
+      ]
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        declare function cleanup(): void;
+        class DisposableDelegate {
+          constructor(callback: () => void) {}
+          dispose(): void {}
+        }
+
+        let disposable: DisposableDelegate;
+        disposable = new DisposableDelegate(() => {
+          cleanup();
+        });
+      `,
+      errors: [
+        {
+          messageId: 'unmanagedDisposableVariable',
+          data: { name: 'disposable' }
+        }
+      ]
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        declare function cleanup(): void;
+        class DisposableDelegate {
+          constructor(callback: () => void) {}
+          dispose(): void {}
+        }
+
+        let disposable = new DisposableDelegate(() => {
+          cleanup();
+        });
+        disposable = new DisposableDelegate(() => {
+          cleanup();
+        });
+        disposable.dispose();
+      `,
+      errors: [
+        {
+          messageId: 'unmanagedDisposableVariable',
+          data: { name: 'disposable' }
+        }
+      ]
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        declare function cleanup(): void;
+        class DisposableDelegate {
+          constructor(callback: () => void) {}
+          dispose(): void {}
+        }
+
+        function createLeak(): void {
+          const disposable = new DisposableDelegate(() => {
+            cleanup();
+          });
+        }
+
+        function disposeOther(disposable: DisposableDelegate): void {
+          disposable.dispose();
+        }
+      `,
+      errors: [
+        {
+          messageId: 'unmanagedDisposableVariable',
+          data: { name: 'disposable' }
+        }
+      ]
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        declare function cleanup(): void;
+        declare const condition: boolean;
+        class DisposableDelegate {
+          constructor(callback: () => void) {}
+          dispose(): void {}
+        }
+
+        const disposable = new DisposableDelegate(() => {
+          cleanup();
+        });
+        if (condition) {
+          disposable.dispose();
+        }
+      `,
+      errors: [
+        {
+          messageId: 'unmanagedDisposableVariable',
+          data: { name: 'disposable' }
+        }
+      ]
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        declare function cleanup(): void;
+        declare function defer(callback: () => void): void;
+        class DisposableDelegate {
+          constructor(callback: () => void) {}
+          dispose(): void {}
+        }
+
+        const disposable = new DisposableDelegate(() => {
+          cleanup();
+        });
+        defer(() => {
+          disposable.dispose();
+        });
+      `,
+      errors: [
+        {
+          messageId: 'unmanagedDisposableVariable',
+          data: { name: 'disposable' }
+        }
+      ]
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        declare function cleanup(): void;
+        class DisposableDelegate {
+          constructor(callback: () => void) {}
+          dispose(): void {}
+        }
+        declare const items: { add(disposable: DisposableDelegate): void };
+
+        const disposable = new DisposableDelegate(() => {
+          cleanup();
+        });
+        items.add(disposable);
+      `,
+      errors: [
+        {
+          messageId: 'unmanagedDisposableVariable',
+          data: { name: 'disposable' }
+        }
+      ]
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+        class CustomDisposable implements IDisposable {
+          readonly isDisposed = false;
+          dispose(): void {}
+        }
+
+        new CustomDisposable();
+      `,
+      errors: [{ messageId: 'unmanagedDisposable' }]
+    }
+  ]
+});

--- a/tests/jupyter-require-disposable-ownership.test.ts
+++ b/tests/jupyter-require-disposable-ownership.test.ts
@@ -217,9 +217,41 @@ ruleTester.run('require-disposable-ownership', requireDisposableOwnership, {
           readonly isDisposed = false;
           dispose(): void {}
         }
+        class MainAreaWidget {
+          readonly isDisposed = false;
+          constructor(options: { content: Widget }) {}
+          dispose(): void {}
+        }
+
+        function createMainAreaWidget(): MainAreaWidget {
+          const content = new Widget();
+          return new MainAreaWidget({ content });
+        }
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        class Widget {
+          readonly isDisposed = false;
+          dispose(): void {}
+        }
         declare function showDialog(options: { body: Widget }): void;
 
         showDialog({ body: new Widget() });
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        class Widget {
+          readonly isDisposed = false;
+          dispose(): void {}
+        }
+        declare function showDialog(options: { body: Widget }): void;
+
+        const body = new Widget();
+        showDialog({ body });
       `
     },
     {
@@ -242,6 +274,36 @@ ruleTester.run('require-disposable-ownership', requireDisposableOwnership, {
           const dialog = new Dialog({ body: new Widget() });
           await dialog.launch();
         }
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        class StatusItem {
+          readonly isDisposed = false;
+          dispose(): void {}
+        }
+        declare const statusBar: {
+          registerStatusItem(id: string, options: { item: StatusItem }): void;
+        };
+
+        const item = new StatusItem();
+        statusBar.registerStatusItem('status', { item });
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        class Widget {
+          readonly isDisposed = false;
+          dispose(): void {}
+        }
+        declare const layout: {
+          insertWidget(index: number, widget: Widget): void;
+        };
+
+        const widget = new Widget();
+        layout.insertWidget(0, widget);
       `
     },
     {

--- a/tests/jupyter-require-disposable-transfer.test.ts
+++ b/tests/jupyter-require-disposable-transfer.test.ts
@@ -318,6 +318,90 @@ ruleTester.run('require-disposable-transfer', requireDisposableTransfer, {
           readonly isDisposed: boolean;
           dispose(): void;
         }
+        declare function getCurrent(): IDisposable | null;
+        declare function getManager(): IDisposable;
+        declare function contextForWidget(widget: object): IDisposable | undefined;
+        declare const widget: object;
+
+        const current = getCurrent();
+        getManager();
+        contextForWidget(widget);
+        console.log(current);
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+
+        class Shell {
+          private _currentTabBar(): IDisposable | null {
+            return null;
+          }
+
+          private _adjacentBar(): IDisposable | null {
+            return null;
+          }
+
+          run(): void {
+            const current = this._currentTabBar();
+            const next = this._adjacentBar();
+            console.log(current, next);
+          }
+        }
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+        declare const registry: {
+          addFileType(options: object): IDisposable;
+          addWidgetExtension(name: string): IDisposable;
+          registerItem(name: string): IDisposable;
+        };
+        declare const tabs: {
+          insertTab(index: number): IDisposable;
+        };
+
+        registry.addFileType({});
+        registry.addWidgetExtension('cell');
+        registry.registerItem('status');
+        tabs.insertTab(0);
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+        class Cell implements IDisposable {
+          readonly isDisposed = false;
+          dispose(): void {}
+          initializeState(): this {
+            return this;
+          }
+        }
+
+        const cell = new Cell();
+        cell.initializeState();
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
         declare const toolbarRegistry: {
           addToolbarFactory(name: string): IDisposable;
         };
@@ -405,6 +489,27 @@ ruleTester.run('require-disposable-transfer', requireDisposableTransfer, {
         {
           messageId: 'unhandledDisposable',
           data: { name: 'add' }
+        }
+      ]
+    },
+    {
+      filename: typeAwareFilename,
+      options: [{ ignoredReturnFunctionNames: [] }],
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+        declare const registry: {
+          addFileType(options: object): IDisposable;
+        };
+
+        registry.addFileType({});
+      `,
+      errors: [
+        {
+          messageId: 'unhandledDisposable',
+          data: { name: 'addFileType' }
         }
       ]
     },

--- a/tests/jupyter-require-disposable-transfer.test.ts
+++ b/tests/jupyter-require-disposable-transfer.test.ts
@@ -119,6 +119,26 @@ ruleTester.run('require-disposable-transfer', requireDisposableTransfer, {
     {
       filename: typeAwareFilename,
       code: `
+        import type { JupyterFrontEndPlugin } from './fixtures/types';
+
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+        declare function createDisposable(): IDisposable;
+
+        export const plugin: JupyterFrontEndPlugin<void> = {
+          id: 'example:disposable',
+          activate: () => {
+            const disposable = createDisposable();
+            console.log(disposable);
+          }
+        };
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
         interface IDisposable {
           readonly isDisposed: boolean;
           dispose(): void;
@@ -305,6 +325,38 @@ ruleTester.run('require-disposable-transfer', requireDisposableTransfer, {
 
         const widget = _findWidgetByID('main');
         console.log(widget);
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+
+        class PanelHandler {
+          private _findWidgetByID(id: string): IDisposable | undefined {
+            return undefined;
+          }
+
+          find(id: string): void {
+            const widget = this._findWidgetByID(id);
+            console.log(widget);
+          }
+        }
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+        declare function dataToMenu(data: object): IDisposable;
+
+        dataToMenu({});
       `
     },
     {
@@ -513,6 +565,23 @@ ruleTester.run('require-disposable-transfer', requireDisposableTransfer, {
           readonly isDisposed: boolean;
           dispose(): void;
         }
+        declare const item: IDisposable;
+        declare const values: {
+          set(id: string, item: IDisposable): IDisposable | undefined;
+          delete(id: string): IDisposable | undefined;
+        };
+
+        values.set('item', item);
+        values.delete('item');
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
         declare function createDisposable(): IDisposable;
         declare function createMap(): {
           set(id: string, disposable: IDisposable): IDisposable;
@@ -649,17 +718,44 @@ ruleTester.run('require-disposable-transfer', requireDisposableTransfer, {
           readonly isDisposed: boolean;
           dispose(): void;
         }
-        declare const item: IDisposable;
-        declare const values: {
-          set(id: string, item: IDisposable): IDisposable;
+        declare const condition: boolean;
+        declare function createDisposable(): IDisposable;
+        declare const owner: {
+          addWidget(widget: IDisposable): void;
         };
 
-        values.set('item', item);
+        const widget = createDisposable();
+        if (condition) {
+          owner.addWidget(widget);
+        }
       `,
       errors: [
         {
-          messageId: 'unhandledDisposable',
-          data: { name: 'set' }
+          messageId: 'unmanagedDisposableVariable',
+          data: { name: 'widget' }
+        }
+      ]
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+        declare const condition: boolean;
+        declare function createDisposable(): IDisposable;
+        declare function showDialog(options: { body: IDisposable }): void;
+
+        const body = createDisposable();
+        if (condition) {
+          showDialog({ body });
+        }
+      `,
+      errors: [
+        {
+          messageId: 'unmanagedDisposableVariable',
+          data: { name: 'body' }
         }
       ]
     },

--- a/tests/jupyter-require-disposable-transfer.test.ts
+++ b/tests/jupyter-require-disposable-transfer.test.ts
@@ -203,6 +203,105 @@ ruleTester.run('require-disposable-transfer', requireDisposableTransfer, {
           dispose(): void;
         }
         declare function createDisposable(): IDisposable;
+        class MainAreaWidget {
+          constructor(options: { content: IDisposable }) {}
+          dispose(): void {}
+        }
+
+        const content = createDisposable();
+        new MainAreaWidget({ content }).dispose();
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+        declare function createDisposable(): IDisposable;
+        declare function showDialog(options: { body: IDisposable }): void;
+
+        const body = createDisposable();
+        showDialog({ body });
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+        declare function createDisposable(): IDisposable;
+        declare const statusBar: {
+          registerStatusItem(
+            id: string,
+            options: { item: IDisposable }
+          ): IDisposable;
+        };
+
+        const item = createDisposable();
+        statusBar.registerStatusItem('status', { item });
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+        declare function createDisposable(): IDisposable;
+        declare const layout: {
+          insertWidget(index: number, widget: IDisposable): void;
+        };
+
+        const widget = createDisposable();
+        layout.insertWidget(0, widget);
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+        declare const widgets: IDisposable[];
+        declare const owner: {
+          addWidget(widget: IDisposable): void;
+        };
+
+        const widget = widgets.pop();
+        if (widget) {
+          owner.addWidget(widget);
+        }
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+        declare const manager: {
+          findWidget(path: string): IDisposable | undefined;
+        };
+
+        const widget = manager.findWidget('path');
+        console.log(widget);
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+        declare function createDisposable(): IDisposable;
         declare const shell: {
           add(disposable: IDisposable): void;
         };

--- a/tests/jupyter-require-disposable-transfer.test.ts
+++ b/tests/jupyter-require-disposable-transfer.test.ts
@@ -139,6 +139,24 @@ ruleTester.run('require-disposable-transfer', requireDisposableTransfer, {
         }
         declare function createDisposable(): IDisposable;
 
+        class Owner {
+          private _disposable: IDisposable | null = null;
+
+          initialize(): void {
+            this._disposable = this._disposable || createDisposable();
+          }
+        }
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+        declare function createDisposable(): IDisposable;
+
         createDisposable().dispose();
       `
     },
@@ -175,6 +193,22 @@ ruleTester.run('require-disposable-transfer', requireDisposableTransfer, {
 
         const disposable = createDisposable();
         disposables.add(disposable);
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+        declare function createDisposable(): IDisposable;
+        declare const shell: {
+          add(disposable: IDisposable): void;
+        };
+
+        const disposable = createDisposable();
+        shell.add(disposable);
       `
     },
     {
@@ -236,6 +270,82 @@ ruleTester.run('require-disposable-transfer', requireDisposableTransfer, {
     },
     {
       filename: typeAwareFilename,
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+        declare const store: {
+          get(key: string): IDisposable;
+        };
+
+        const current = store.get('current');
+        console.log(current);
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+        declare const commands: {
+          addCommand(id: string, options: object): IDisposable;
+        };
+
+        commands.addCommand('example:command', {});
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+        declare const registry: {
+          add(id: string): IDisposable;
+        };
+
+        registry.add('example');
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+        declare const toolbarRegistry: {
+          addToolbarFactory(name: string): IDisposable;
+        };
+
+        toolbarRegistry.addToolbarFactory('example');
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+        declare function createDisposable(): IDisposable;
+        class Base {
+          constructor(options: { disposable: IDisposable }) {}
+        }
+        class Owner extends Base {
+          constructor() {
+            const disposable = createDisposable();
+            super({ disposable });
+          }
+        }
+      `
+    },
+    {
+      filename: typeAwareFilename,
       options: [{ ownershipFunctionNames: ['ownDisposable'] }],
       code: `
         interface IDisposable {
@@ -274,6 +384,69 @@ ruleTester.run('require-disposable-transfer', requireDisposableTransfer, {
         {
           messageId: 'unhandledDisposable',
           data: { name: 'createDisposable' }
+        }
+      ]
+    },
+    {
+      filename: typeAwareFilename,
+      options: [{ ignoredReturnFunctionNames: [] }],
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+        declare const registry: {
+          add(id: string): IDisposable;
+        };
+
+        registry.add('example');
+      `,
+      errors: [
+        {
+          messageId: 'unhandledDisposable',
+          data: { name: 'add' }
+        }
+      ]
+    },
+    {
+      filename: typeAwareFilename,
+      options: [{ ignoredReturnFunctionNames: [] }],
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+        declare const commands: {
+          addCommand(id: string, options: object): IDisposable;
+        };
+
+        commands.addCommand('example:command', {});
+      `,
+      errors: [
+        {
+          messageId: 'unhandledDisposable',
+          data: { name: 'addCommand' }
+        }
+      ]
+    },
+    {
+      filename: typeAwareFilename,
+      options: [{ ignoredReturnFunctionNames: [] }],
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+        declare const toolbarRegistry: {
+          addToolbarFactory(name: string): IDisposable;
+        };
+
+        toolbarRegistry.addToolbarFactory('example');
+      `,
+      errors: [
+        {
+          messageId: 'unhandledDisposable',
+          data: { name: 'addToolbarFactory' }
         }
       ]
     },
@@ -405,6 +578,7 @@ ruleTester.run('require-disposable-transfer', requireDisposableTransfer, {
     },
     {
       filename: typeAwareFilename,
+      options: [{ ownershipFunctionNames: [] }],
       code: `
         interface IDisposable {
           readonly isDisposed: boolean;

--- a/tests/jupyter-require-disposable-transfer.test.ts
+++ b/tests/jupyter-require-disposable-transfer.test.ts
@@ -1,0 +1,487 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import * as path from 'path';
+import requireDisposableTransfer from '../src/rules/require-disposable-transfer';
+
+const typeAwareFilename = 'tests/type-aware-fixture.ts';
+
+const nonTypeAwareTester = new RuleTester({
+  languageOptions: {
+    parser: require('@typescript-eslint/parser'),
+    parserOptions: {
+      ecmaVersion: 2020,
+      sourceType: 'module',
+      tsconfigRootDir: path.resolve(__dirname, '..')
+    }
+  }
+});
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parser: require('@typescript-eslint/parser'),
+    parserOptions: {
+      ecmaVersion: 2020,
+      sourceType: 'module',
+      projectService: {
+        allowDefaultProject: ['tests/*.ts'],
+        defaultProject: 'tsconfig.json'
+      },
+      tsconfigRootDir: path.resolve(__dirname, '..')
+    }
+  }
+});
+
+nonTypeAwareTester.run(
+  'require-disposable-transfer (non-type-aware)',
+  requireDisposableTransfer,
+  {
+    valid: [
+      {
+        code: `
+          declare function createDisposable(): IDisposable;
+          createDisposable();
+        `
+      },
+      {
+        code: `
+          const disposables = DisposableSet.from([]);
+          disposables.dispose();
+        `
+      },
+      {
+        code: `
+          ObservableDisposableSet.from([]).dispose();
+        `
+      }
+    ],
+    invalid: [
+      {
+        code: `
+          DisposableSet.from([]);
+        `,
+        errors: [
+          {
+            messageId: 'unhandledDisposable',
+            data: { name: 'from' }
+          }
+        ]
+      },
+      {
+        code: `
+          ObservableDisposableSet.from([]);
+        `,
+        errors: [
+          {
+            messageId: 'unhandledDisposable',
+            data: { name: 'from' }
+          }
+        ]
+      }
+    ]
+  }
+);
+
+ruleTester.run('require-disposable-transfer', requireDisposableTransfer, {
+  valid: [
+    {
+      filename: typeAwareFilename,
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+        declare function createDisposable(): IDisposable;
+        class DisposableSet {
+          add(disposable: IDisposable): void {}
+        }
+        declare const disposables: DisposableSet;
+
+        disposables.add(createDisposable());
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+        declare function createDisposable(): IDisposable;
+
+        const disposable = createDisposable();
+        disposable.dispose();
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+        declare function createDisposable(): IDisposable;
+
+        function forwardDisposable(): IDisposable {
+          return createDisposable();
+        }
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+        declare function createDisposable(): IDisposable;
+
+        createDisposable().dispose();
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+        declare function createDisposable(): IDisposable;
+
+        class Owner {
+          private _disposable: IDisposable | null = null;
+
+          initialize(): void {
+            this._disposable = createDisposable();
+          }
+        }
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+        declare function createDisposable(): IDisposable;
+        class DisposableSet {
+          add(disposable: IDisposable): void {}
+        }
+        declare const disposables: DisposableSet;
+
+        const disposable = createDisposable();
+        disposables.add(disposable);
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+        class DisposableSet {
+          static from(items: Iterable<IDisposable>): DisposableSet {
+            return new DisposableSet();
+          }
+          dispose(): void {}
+        }
+
+        const disposables = DisposableSet.from([]);
+        disposables.dispose();
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+        declare function createDisposable(): IDisposable;
+        class DisposableSet {
+          static from(items: Iterable<IDisposable>): DisposableSet {
+            return new DisposableSet();
+          }
+          dispose(): void {}
+        }
+
+        const disposables = DisposableSet.from([createDisposable()]);
+        disposables.dispose();
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+        declare function createDisposable(): IDisposable;
+        class DisposableSet {
+          static from(items: Iterable<IDisposable>): DisposableSet {
+            return new DisposableSet();
+          }
+          dispose(): void {}
+        }
+
+        const disposable = createDisposable();
+        const disposables = DisposableSet.from([disposable]);
+        disposables.dispose();
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      options: [{ ownershipFunctionNames: ['ownDisposable'] }],
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+        declare function createDisposable(): IDisposable;
+        declare function ownDisposable(disposable: IDisposable): void;
+
+        const disposable = createDisposable();
+        ownDisposable(disposable);
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        declare function createValue(): string;
+        createValue();
+      `
+    }
+  ],
+
+  invalid: [
+    {
+      filename: typeAwareFilename,
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+        declare function createDisposable(): IDisposable;
+
+        createDisposable();
+      `,
+      errors: [
+        {
+          messageId: 'unhandledDisposable',
+          data: { name: 'createDisposable' }
+        }
+      ]
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+        interface IObservableDisposable extends IDisposable {
+          readonly disposed: unknown;
+        }
+        declare function createObservableDisposable(): IObservableDisposable;
+
+        createObservableDisposable();
+      `,
+      errors: [
+        {
+          messageId: 'unhandledDisposable',
+          data: { name: 'createObservableDisposable' }
+        }
+      ]
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+        declare function createDisposable(): IDisposable;
+
+        void createDisposable();
+      `,
+      errors: [
+        {
+          messageId: 'unhandledDisposable',
+          data: { name: 'createDisposable' }
+        }
+      ]
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+        declare function createDisposable(): IDisposable;
+
+        const disposable = createDisposable();
+        console.log(disposable);
+      `,
+      errors: [
+        {
+          messageId: 'unmanagedDisposableVariable',
+          data: { name: 'disposable' }
+        }
+      ]
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+        declare function createDisposable(): IDisposable;
+
+        function createLeak(): void {
+          const disposable = createDisposable();
+        }
+
+        function disposeOther(disposable: IDisposable): void {
+          disposable.dispose();
+        }
+      `,
+      errors: [
+        {
+          messageId: 'unmanagedDisposableVariable',
+          data: { name: 'disposable' }
+        }
+      ]
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+        declare const condition: boolean;
+        declare function createDisposable(): IDisposable;
+
+        const disposable = createDisposable();
+        if (condition) {
+          disposable.dispose();
+        }
+      `,
+      errors: [
+        {
+          messageId: 'unmanagedDisposableVariable',
+          data: { name: 'disposable' }
+        }
+      ]
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+        declare function createDisposable(): IDisposable;
+        declare function defer(callback: () => void): void;
+
+        const disposable = createDisposable();
+        defer(() => {
+          disposable.dispose();
+        });
+      `,
+      errors: [
+        {
+          messageId: 'unmanagedDisposableVariable',
+          data: { name: 'disposable' }
+        }
+      ]
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+        declare function createDisposable(): IDisposable;
+        declare const items: { add(disposable: IDisposable): void };
+
+        const disposable = createDisposable();
+        items.add(disposable);
+      `,
+      errors: [
+        {
+          messageId: 'unmanagedDisposableVariable',
+          data: { name: 'disposable' }
+        }
+      ]
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+        declare function createDisposable(): IDisposable;
+
+        let disposable = createDisposable();
+        disposable = createDisposable();
+        disposable.dispose();
+      `,
+      errors: [
+        {
+          messageId: 'unmanagedDisposableVariable',
+          data: { name: 'disposable' }
+        }
+      ]
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+        declare function createDisposable(): IDisposable;
+
+        let disposable: IDisposable;
+        disposable = createDisposable();
+      `,
+      errors: [
+        {
+          messageId: 'unmanagedDisposableVariable',
+          data: { name: 'disposable' }
+        }
+      ]
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+        declare function createDisposable(): IDisposable;
+        class Owner {
+          constructor(disposable: IDisposable) {}
+        }
+
+        new Owner(createDisposable());
+      `,
+      errors: [
+        {
+          messageId: 'unhandledDisposable',
+          data: { name: 'createDisposable' }
+        }
+      ]
+    }
+  ]
+});

--- a/tests/jupyter-require-disposable-transfer.test.ts
+++ b/tests/jupyter-require-disposable-transfer.test.ts
@@ -158,6 +158,60 @@ ruleTester.run('require-disposable-transfer', requireDisposableTransfer, {
           dispose(): void;
         }
         declare function createDisposable(): IDisposable;
+        declare const widget: {
+          readonly disposed: {
+            connect(callback: () => void): void;
+          };
+        };
+
+        const disposable = createDisposable();
+        widget.disposed.connect(() => {
+          disposable.dispose();
+        });
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+        declare function createEditor(): IDisposable;
+        declare const sourceViewer: {
+          open(options: { editorWrapper: IDisposable }): void;
+        };
+
+        const editorWrapper = createEditor();
+        sourceViewer.open({ editorWrapper });
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+        declare function createOutput(): IDisposable;
+        declare const outputArea: {
+          _wrappedOutput(output: IDisposable, executionCount?: number | null): IDisposable;
+        };
+
+        function createWrappedOutput(): IDisposable {
+          const output = createOutput();
+          return outputArea._wrappedOutput(output, null);
+        }
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+        declare function createDisposable(): IDisposable;
 
         class Owner {
           private _disposable: IDisposable | null = null;
@@ -430,6 +484,147 @@ ruleTester.run('require-disposable-transfer', requireDisposableTransfer, {
         const disposable = createDisposable();
         const disposables = DisposableSet.from([disposable]);
         disposables.dispose();
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+        declare function createDisposable(): IDisposable | undefined;
+        class DisposableSet {
+          add(disposable: IDisposable): void {}
+        }
+        declare const disposables: DisposableSet;
+
+        const disposable = createDisposable();
+        if (disposable) {
+          disposables.add(disposable);
+        }
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+        declare function createDisposable(): IDisposable;
+
+        function createOptions(): { disposable: IDisposable } {
+          return {
+            disposable: createDisposable()
+          };
+        }
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+        declare function createDisposable(): IDisposable;
+
+        class Owner {
+          private _state: { disposable: IDisposable } | null = null;
+
+          initialize(): void {
+            this._state = {
+              disposable: createDisposable()
+            };
+          }
+        }
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+        declare const ArrayExt: {
+          insert<T>(array: T[], index: number, value: T): void;
+        };
+        declare function createDisposable(): IDisposable;
+
+        class Owner {
+          private _items: IDisposable[] = [];
+
+          addItem(): void {
+            const item = createDisposable();
+            ArrayExt.insert(this._items, 0, item);
+          }
+        }
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+        declare function createDisposable(): IDisposable;
+        declare const toolbar: {
+          insertBefore(before: string, name: string, item: IDisposable): void;
+        };
+
+        const item = createDisposable();
+        toolbar.insertBefore('kernelName', 'read-only-indicator', item);
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+        declare function createRenderer(): IDisposable;
+        class MimeContent {
+          readonly isDisposed = false;
+          constructor(options: { renderer: IDisposable }) {}
+          dispose(): void {}
+        }
+        class MimeDocument {
+          readonly isDisposed = false;
+          constructor(options: { content: MimeContent }) {}
+          dispose(): void {}
+        }
+
+        function createDocument(): MimeDocument {
+          const renderer = createRenderer();
+          const content = new MimeContent({ renderer });
+          return new MimeDocument({ content });
+        }
+      `
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+        declare function createSharedModel(): IDisposable;
+        declare const factory: {
+          createNew(options: { sharedModel: IDisposable }): IDisposable;
+        };
+
+        class Owner {
+          private _model: IDisposable | null = null;
+
+          initialize(): void {
+            const sharedModel = createSharedModel();
+            this._model = factory.createNew({ sharedModel });
+          }
+        }
       `
     },
     {
@@ -988,6 +1183,35 @@ ruleTester.run('require-disposable-transfer', requireDisposableTransfer, {
         const disposable = createDisposable();
         defer(() => {
           disposable.dispose();
+        });
+      `,
+      errors: [
+        {
+          messageId: 'unmanagedDisposableVariable',
+          data: { name: 'disposable' }
+        }
+      ]
+    },
+    {
+      filename: typeAwareFilename,
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+        declare const condition: boolean;
+        declare function createDisposable(): IDisposable;
+        declare const widget: {
+          readonly disposed: {
+            connect(callback: () => void): void;
+          };
+        };
+
+        const disposable = createDisposable();
+        widget.disposed.connect(() => {
+          if (condition) {
+            disposable.dispose();
+          }
         });
       `,
       errors: [

--- a/website/docs/rules/index.md
+++ b/website/docs/rules/index.md
@@ -11,6 +11,8 @@ This section documents all rules currently provided by `eslint-plugin-jupyter`.
 - [no-untranslated-string](./no-untranslated-string)
 - [plugin-activation-args](./plugin-activation-args)
 - [plugin-description](./plugin-description)
+- [require-disposable-ownership](./require-disposable-ownership)
+- [require-disposable-transfer](./require-disposable-transfer)
 - [require-soft-assertions-before-snapshots](./require-soft-assertions-before-snapshots)
 - [token-format](./token-format)
 
@@ -20,17 +22,19 @@ Each page includes intent, examples, configuration, and when to apply the rule.
 
 The plugin ships with a recommended configuration that enables all current rules with the following defaults:
 
-| Rule | Level |
-| --- | --- |
-| [jupyter/plugin-activation-args](./plugin-activation-args) | `error` |
-| [jupyter/command-described-by](./command-described-by) | `warn` |
-| [jupyter/no-untranslated-string](./no-untranslated-string) | `warn` |
-| [jupyter/plugin-description](./plugin-description) | `warn` |
-| [jupyter/no-translation-concatenation](./no-translation-concatenation) | `error` |
-| [jupyter/token-format](./token-format) | `error` |
+| Rule                                                                                           | Level    |
+| ---------------------------------------------------------------------------------------------- | -------- |
+| [jupyter/plugin-activation-args](./plugin-activation-args)                                     | `error`  |
+| [jupyter/command-described-by](./command-described-by)                                         | `warn`   |
+| [jupyter/no-untranslated-string](./no-untranslated-string)                                     | `warn`   |
+| [jupyter/plugin-description](./plugin-description)                                             | `warn`   |
+| [jupyter/no-translation-concatenation](./no-translation-concatenation)                         | `error`  |
+| [jupyter/token-format](./token-format)                                                         | `error`  |
+| [jupyter/require-disposable-ownership](./require-disposable-ownership)                         | `warn`   |
+| [jupyter/require-disposable-transfer](./require-disposable-transfer)                           | `warn`   |
 | [jupyter/require-soft-assertions-before-snapshots](./require-soft-assertions-before-snapshots) | `warn` ¹ |
-| [jupyter/no-schema-enum](./no-schema-enum) | `warn` ² |
-| [jupyter/no-pageconfig-base-url](./no-pageconfig-base-url) | `warn` |
+| [jupyter/no-schema-enum](./no-schema-enum)                                                     | `warn` ² |
+| [jupyter/no-pageconfig-base-url](./no-pageconfig-base-url)                                     | `warn`   |
 
 ¹ Applied only to `**/*.spec.{ts,js}` and `**/*.test.{ts,js}` files.  
 ² Applied only to `**/schema/*.json` files

--- a/website/docs/rules/require-disposable-ownership.md
+++ b/website/docs/rules/require-disposable-ownership.md
@@ -15,6 +15,8 @@ The rule checks `new` expressions that create known disposable classes such as
 `DisposableDelegate`, `ObservableDisposableDelegate`, `DisposableSet`, and
 `ObservableDisposableSet`. When TypeScript type information is available, it
 also detects objects typed as `IDisposable` or `IObservableDisposable`.
+It ignores disposable objects created directly inside a typed Jupyter plugin
+`activate` function, where services commonly live for the application lifetime.
 
 It accepts common ownership patterns:
 

--- a/website/docs/rules/require-disposable-ownership.md
+++ b/website/docs/rules/require-disposable-ownership.md
@@ -28,7 +28,10 @@ It accepts common ownership patterns:
 - Storing it in a variable that is later added, returned, assigned to a field,
   or disposed
 - Passing it to a configured ownership helper function or default ownership
-  sink such as `add`, `addItem`, or `addWidget`
+  sink such as `add`, `addCell`, `addItem`, `addWidget`, `insertWidget`,
+  or `registerStatusItem`
+- Passing it through an owned constructor options object, such as
+  `new MainAreaWidget({ content })`
 - Passing it as a `showDialog({ body: ... })` body or launching a typed
   `Dialog` with `.launch()`
 
@@ -81,8 +84,9 @@ class Owner {
 ### `ownershipFunctionNames`
 
 Function or method names that take ownership of disposable arguments. The
-default list is `add`, `addFactory`, `addItem`, `addModelFactory`, `addWidget`,
-and `addWidgetFactory`. If provided, this list replaces the default. Set this
+default list is `add`, `addCell`, `addFactory`, `addItem`, `addModelFactory`,
+`addSibling`, `addWidget`, `addWidgetFactory`, `insertItem`, `insertWidget`,
+and `registerStatusItem`. If provided, this list replaces the default. Set this
 option to `[]` to require stricter typed ownership checks.
 
 ```json

--- a/website/docs/rules/require-disposable-ownership.md
+++ b/website/docs/rules/require-disposable-ownership.md
@@ -1,0 +1,91 @@
+# `require-disposable-ownership`
+
+Require newly created disposable objects to be owned, returned, assigned to a
+field, or disposed.
+
+## Why
+
+Lumino `IDisposable` objects represent lifecycle cleanup. Creating a disposable
+and then dropping it usually leaks resources or callbacks that should have been
+released later.
+
+## Rule details
+
+The rule checks `new` expressions that create known disposable classes such as
+`DisposableDelegate`, `ObservableDisposableDelegate`, `DisposableSet`, and
+`ObservableDisposableSet`. When TypeScript type information is available, it
+also detects objects typed as `IDisposable` or `IObservableDisposable`.
+
+It accepts common ownership patterns:
+
+- Adding the object to a typed `DisposableSet` or a conventionally named
+  disposable collection such as `this._disposables.add(...)`
+- Passing the object as a direct array item to `DisposableSet.from(...)` or
+  `ObservableDisposableSet.from(...)`
+- Returning it
+- Assigning it to an object field or class field initializer
+- Calling `.dispose()` immediately
+- Storing it in a variable that is later added, returned, assigned to a field,
+  or disposed
+- Passing it to a configured ownership helper function
+
+## Incorrect
+
+```ts
+new DisposableDelegate(() => {
+  cleanup();
+});
+```
+
+```ts
+const disposable = new DisposableDelegate(() => {
+  cleanup();
+});
+console.log(disposable);
+```
+
+## Correct
+
+```ts
+this._disposables.add(
+  new DisposableDelegate(() => {
+    cleanup();
+  })
+);
+```
+
+```ts
+return new DisposableDelegate(() => {
+  cleanup();
+});
+```
+
+```ts
+const disposable = new DisposableDelegate(() => {
+  cleanup();
+});
+disposable.dispose();
+```
+
+```ts
+class Owner {
+  private _disposables = new DisposableSet();
+}
+```
+
+## Options
+
+### `ownershipFunctionNames`
+
+Additional function or method names that take ownership of disposable arguments.
+
+```json
+{
+  "jupyter/require-disposable-ownership": [
+    "warn",
+    {
+      "ownershipFunctionNames": ["ownDisposable", "registerDisposable"]
+    }
+  ]
+}
+```

--- a/website/docs/rules/require-disposable-ownership.md
+++ b/website/docs/rules/require-disposable-ownership.md
@@ -27,7 +27,8 @@ It accepts common ownership patterns:
 - Calling `.dispose()` immediately
 - Storing it in a variable that is later added, returned, assigned to a field,
   or disposed
-- Passing it to a configured ownership helper function
+- Passing it to a configured ownership helper function or default ownership
+  sink such as `add`, `addItem`, or `addWidget`
 
 ## Incorrect
 
@@ -77,7 +78,10 @@ class Owner {
 
 ### `ownershipFunctionNames`
 
-Additional function or method names that take ownership of disposable arguments.
+Function or method names that take ownership of disposable arguments. The
+default list is `add`, `addFactory`, `addItem`, `addModelFactory`, `addWidget`,
+and `addWidgetFactory`. If provided, this list replaces the default. Set this
+option to `[]` to require stricter typed ownership checks.
 
 ```json
 {

--- a/website/docs/rules/require-disposable-ownership.md
+++ b/website/docs/rules/require-disposable-ownership.md
@@ -29,6 +29,8 @@ It accepts common ownership patterns:
   or disposed
 - Passing it to a configured ownership helper function or default ownership
   sink such as `add`, `addItem`, or `addWidget`
+- Passing it as a `showDialog({ body: ... })` body or launching a typed
+  `Dialog` with `.launch()`
 
 ## Incorrect
 

--- a/website/docs/rules/require-disposable-transfer.md
+++ b/website/docs/rules/require-disposable-transfer.md
@@ -26,7 +26,13 @@ It accepts common ownership patterns:
 - Calling `.dispose()` immediately
 - Storing it in a variable that is later added, returned, assigned to a field,
   or disposed
-- Passing it to a configured ownership helper function
+- Passing it to a configured ownership helper function or default ownership
+  sink such as `add`, `addItem`, or `addWidget`
+
+By default, the rule does not report common borrowed-reference or
+registration-return calls such as `get`, `find`, `insertCell`,
+`contextMenuWidget`, `add`, `addCommand`, `addItem`, `registerStatusItem`,
+`addKeyBinding`, `addGroup`, `register`, `transform`, and `add*Factory`.
 
 ## Incorrect
 
@@ -63,14 +69,25 @@ disposables.dispose();
 
 ### `ownershipFunctionNames`
 
-Additional function or method names that take ownership of disposable arguments.
+Function or method names that take ownership of disposable arguments. The
+default list is `add`, `addFactory`, `addItem`, `addModelFactory`, `addWidget`,
+and `addWidgetFactory`. If provided, this list replaces the default. Set this
+option to `[]` to require stricter typed ownership checks.
+
+### `ignoredReturnFunctionNames`
+
+Function or method names whose disposable return value should be treated as
+borrowed or owned by a registration/session API. If provided, this list
+replaces the default. Set this option to `[]` to report ignored registration
+return values.
 
 ```json
 {
   "jupyter/require-disposable-transfer": [
     "warn",
     {
-      "ownershipFunctionNames": ["ownDisposable", "registerDisposable"]
+      "ownershipFunctionNames": ["ownDisposable", "registerDisposable"],
+      "ignoredReturnFunctionNames": ["addCommand", "get", "find"]
     }
   ]
 }

--- a/website/docs/rules/require-disposable-transfer.md
+++ b/website/docs/rules/require-disposable-transfer.md
@@ -10,10 +10,13 @@ Ignoring the returned value usually means the cleanup path has been lost.
 
 ## Rule details
 
-This rule checks call expressions whose return type is compatible with
-`IDisposable` or `IObservableDisposable` when TypeScript type information is
-available. It also recognizes the known Lumino factories
-`DisposableSet.from(...)` and `ObservableDisposableSet.from(...)`.
+This rule checks factory-like call expressions such as `create*`, `make*`,
+`build*`, and `new*` whose return type is compatible with `IDisposable` or
+`IObservableDisposable` when TypeScript type information is available. It also
+recognizes the known Lumino factories `DisposableSet.from(...)` and
+`ObservableDisposableSet.from(...)`. It ignores disposable values created
+directly inside a typed Jupyter plugin `activate` function, where services
+commonly live for the application lifetime.
 
 It accepts common ownership patterns:
 
@@ -38,10 +41,11 @@ fluent-initializer, or registration-return calls such as `get`, `find`,
 `getCurrent`, `contextForWidget`, `insertCell`, `insertTab`,
 `initializeState`, `contextMenuWidget`, `add`, `addCommand`, `addFileType`,
 `addItem`, `addWidgetExtension`, `addToolbarButtonClass`,
-`addCommandToolbarButtonClass`, `addTab`, `open`, `openInspector`,
+`addCommandToolbarButtonClass`, `addTab`, `delete`, `open`, `openInspector`,
 `openOrReveal`, `findWidget`, `_findWidgetByID`, `widgetAt`,
 `widgetRenderer`, `pop`, `shift`, `registerItem`, `registerStatusItem`,
-`addKeyBinding`, `addGroup`, `register`, `transform`, and `add*Factory`.
+`addKeyBinding`, `addGroup`, `register`, `set`, `transform`, and
+`add*Factory`.
 
 ## Incorrect
 
@@ -88,8 +92,8 @@ default. Set this option to `[]` to require stricter typed ownership checks.
 
 Function or method names whose disposable return value should be treated as
 borrowed or owned by a registration/session API. If provided, this list
-replaces the default. Set this option to `[]` to report ignored registration
-return values.
+replaces the default and opts into stricter return checking for non-factory
+calls. Set this option to `[]` to report ignored registration return values.
 
 ```json
 {

--- a/website/docs/rules/require-disposable-transfer.md
+++ b/website/docs/rules/require-disposable-transfer.md
@@ -1,0 +1,77 @@
+# `require-disposable-transfer`
+
+Require calls returning `IDisposable` to transfer ownership to a caller, field,
+or disposable collection.
+
+## Why
+
+Functions that return `IDisposable` hand cleanup responsibility to the caller.
+Ignoring the returned value usually means the cleanup path has been lost.
+
+## Rule details
+
+This rule checks call expressions whose return type is compatible with
+`IDisposable` or `IObservableDisposable` when TypeScript type information is
+available. It also recognizes the known Lumino factories
+`DisposableSet.from(...)` and `ObservableDisposableSet.from(...)`.
+
+It accepts common ownership patterns:
+
+- Adding the result to a typed `DisposableSet` or a conventionally named
+  disposable collection such as `this._disposables.add(...)`
+- Passing the result as a direct array item to `DisposableSet.from(...)` or
+  `ObservableDisposableSet.from(...)`
+- Returning the result
+- Assigning it to an object field
+- Calling `.dispose()` immediately
+- Storing it in a variable that is later added, returned, assigned to a field,
+  or disposed
+- Passing it to a configured ownership helper function
+
+## Incorrect
+
+```ts
+createDisposable();
+```
+
+```ts
+const disposable = createDisposable();
+console.log(disposable);
+```
+
+## Correct
+
+```ts
+this._disposables.add(createDisposable());
+```
+
+```ts
+const disposable = createDisposable();
+disposable.dispose();
+```
+
+```ts
+return createDisposable();
+```
+
+```ts
+const disposables = DisposableSet.from([createDisposable()]);
+disposables.dispose();
+```
+
+## Options
+
+### `ownershipFunctionNames`
+
+Additional function or method names that take ownership of disposable arguments.
+
+```json
+{
+  "jupyter/require-disposable-transfer": [
+    "warn",
+    {
+      "ownershipFunctionNames": ["ownDisposable", "registerDisposable"]
+    }
+  ]
+}
+```

--- a/website/docs/rules/require-disposable-transfer.md
+++ b/website/docs/rules/require-disposable-transfer.md
@@ -29,9 +29,11 @@ It accepts common ownership patterns:
 - Passing it to a configured ownership helper function or default ownership
   sink such as `add`, `addItem`, or `addWidget`
 
-By default, the rule does not report common borrowed-reference or
-registration-return calls such as `get`, `find`, `insertCell`,
-`contextMenuWidget`, `add`, `addCommand`, `addItem`, `registerStatusItem`,
+By default, the rule does not report common borrowed-reference,
+fluent-initializer, or registration-return calls such as `get`, `find`,
+`getCurrent`, `contextForWidget`, `insertCell`, `insertTab`,
+`initializeState`, `contextMenuWidget`, `add`, `addCommand`, `addFileType`,
+`addItem`, `addWidgetExtension`, `registerItem`, `registerStatusItem`,
 `addKeyBinding`, `addGroup`, `register`, `transform`, and `add*Factory`.
 
 ## Incorrect

--- a/website/docs/rules/require-disposable-transfer.md
+++ b/website/docs/rules/require-disposable-transfer.md
@@ -27,14 +27,20 @@ It accepts common ownership patterns:
 - Storing it in a variable that is later added, returned, assigned to a field,
   or disposed
 - Passing it to a configured ownership helper function or default ownership
-  sink such as `add`, `addItem`, or `addWidget`
+  sink such as `add`, `addCell`, `addItem`, `addWidget`, `insertWidget`,
+  or `registerStatusItem`
+- Passing it through an owned constructor options object, such as
+  `new MainAreaWidget({ content })`
 
 By default, the rule does not report common borrowed-reference,
 fluent-initializer, or registration-return calls such as `get`, `find`,
 `getCurrent`, `contextForWidget`, `insertCell`, `insertTab`,
 `initializeState`, `contextMenuWidget`, `add`, `addCommand`, `addFileType`,
-`addItem`, `addWidgetExtension`, `registerItem`, `registerStatusItem`,
-`addKeyBinding`, `addGroup`, `register`, `transform`, and `add*Factory`.
+`addItem`, `addWidgetExtension`, `addToolbarButtonClass`,
+`addCommandToolbarButtonClass`, `openInspector`, `openOrReveal`,
+`findWidget`, `widgetAt`, `widgetRenderer`, `pop`, `shift`, `registerItem`,
+`registerStatusItem`, `addKeyBinding`, `addGroup`, `register`, `transform`,
+and `add*Factory`.
 
 ## Incorrect
 
@@ -72,8 +78,9 @@ disposables.dispose();
 ### `ownershipFunctionNames`
 
 Function or method names that take ownership of disposable arguments. The
-default list is `add`, `addFactory`, `addItem`, `addModelFactory`, `addWidget`,
-and `addWidgetFactory`. If provided, this list replaces the default. Set this
+default list is `add`, `addCell`, `addFactory`, `addItem`, `addModelFactory`,
+`addSibling`, `addWidget`, `addWidgetFactory`, `insertItem`, `insertWidget`,
+and `registerStatusItem`. If provided, this list replaces the default. Set this
 option to `[]` to require stricter typed ownership checks.
 
 ### `ignoredReturnFunctionNames`

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -26,6 +26,8 @@ const sidebars: SidebarsConfig = {
         'rules/no-untranslated-string',
         'rules/plugin-activation-args',
         'rules/plugin-description',
+        'rules/require-disposable-ownership',
+        'rules/require-disposable-transfer',
         'rules/require-soft-assertions-before-snapshots',
         'rules/token-format'
       ]


### PR DESCRIPTION
Implements Rule 1 + Rule 2 from #74 


Adds `require-disposable-ownership` and `require-disposable-transfer` to catch newly created or returned `IDisposable` values whose ownership is dropped. The implementation recognizes Lumino disposable constructors, disposable-returning calls, `DisposableSet` / `ObservableDisposableSet`, direct `DisposableSet.from([...])` items, typed or known disposable collections, `AttachedProperty.set(...)`, returns, field assignments, class field initializers, immediate `.dispose()`, and configured ownership helper names. It also adds focused behavioral tests and docs for both rules.


Some of the known Limitations
`.set(...)` is treated as ownership only when the receiver is typed as `AttachedProperty` or matches the known `disposablesProperty` pattern; generic map-like calls such as `values.set(widget, disposables)` is not assumed safe. The rules verify that ownership is not immediately lost, but they do not prove that the owning object later disposes of stored fields. `AttachedProperty.set(...)` is accepted as ownership transfer, but later lifecycle cleanup is not verified. Control-flow analysis is conservative: cleanup in finally, exhaustive branches where all paths dispose, and alias disposal like `const alias = disposable; alias.dispose()` are not fully modeled. Catch-only disposal remains unsafe because it only runs on error paths.