### PR TITLE
Fix false positives in disposable ownership rules, improve API

### DIFF
--- a/src/rules/require-disposable-ownership.ts
+++ b/src/rules/require-disposable-ownership.ts
@@ -15,13 +15,17 @@ import {
   isDisposableConstructor,
   isDisposableExpressionManaged,
   isDisposableType,
+  isDisposedByNestedFunction,
+  isExportedVariable,
   isInJupyterPluginActivate,
   isOuterFunctionScopeVariable,
   markManagedDisposableUse,
-  PendingDisposableMap
+  PendingDisposableMap,
+  resolveNameListOption
 } from '../utils/disposables';
 
 interface RuleOptions {
+  extendDefaultOwnershipFunctionNames?: boolean;
   ownershipFunctionNames?: string[];
 }
 
@@ -47,9 +51,14 @@ const requireDisposableOwnership = createRule({
           ownershipFunctionNames: {
             type: 'array',
             items: { type: 'string' },
-            default: DEFAULT_OWNERSHIP_FUNCTION_NAMES,
             description:
-              'Function or method names that take ownership of a disposable argument.'
+              'Function or method names that take ownership of a disposable argument. Added to the built-in defaults unless extendDefaultOwnershipFunctionNames is false.'
+          },
+          extendDefaultOwnershipFunctionNames: {
+            type: 'boolean',
+            default: true,
+            description:
+              'Whether ownershipFunctionNames extends the built-in defaults. Set to false to replace them, or to drop them entirely when no list is given.'
           }
         },
         additionalProperties: false
@@ -89,9 +98,10 @@ const requireDisposableOwnership = createRule({
       sourceCode: context.sourceCode,
       checker,
       services,
-      ownershipFunctionNames: new Set(
-        (options as RuleOptions).ownershipFunctionNames ??
-          DEFAULT_OWNERSHIP_FUNCTION_NAMES
+      ownershipFunctionNames: resolveNameListOption(
+        (options as RuleOptions).ownershipFunctionNames,
+        DEFAULT_OWNERSHIP_FUNCTION_NAMES,
+        (options as RuleOptions).extendDefaultOwnershipFunctionNames !== false
       )
     };
 
@@ -126,7 +136,9 @@ const requireDisposableOwnership = createRule({
               node,
               assignedVariable,
               context.sourceCode
-            )
+            ) ||
+            isExportedVariable(assignedVariable) ||
+            isDisposedByNestedFunction(assignedVariable, ownership)
           ) {
             return;
           }

--- a/src/rules/require-disposable-transfer.ts
+++ b/src/rules/require-disposable-transfer.ts
@@ -17,14 +17,20 @@ import {
   isDisposableExpressionManaged,
   isDisposableSetFactoryCall,
   isDisposableType,
+  isDisposedByNestedFunction,
+  isExportedVariable,
   isInJupyterPluginActivate,
   isOuterFunctionScopeVariable,
   markManagedDisposableUse,
   PendingDisposableMap,
+  resolveNameListOption,
   shouldCheckReturnedDisposable
 } from '../utils/disposables';
 
 interface RuleOptions {
+  checkAllDisposableReturns?: boolean;
+  extendDefaultIgnoredReturnFunctionNames?: boolean;
+  extendDefaultOwnershipFunctionNames?: boolean;
   ignoredReturnFunctionNames?: string[];
   ownershipFunctionNames?: string[];
 }
@@ -114,16 +120,32 @@ const requireDisposableTransfer = createRule({
           ownershipFunctionNames: {
             type: 'array',
             items: { type: 'string' },
-            default: DEFAULT_OWNERSHIP_FUNCTION_NAMES,
             description:
-              'Function or method names that take ownership of a disposable argument.'
+              'Function or method names that take ownership of a disposable argument. Added to the built-in defaults unless extendDefaultOwnershipFunctionNames is false.'
+          },
+          extendDefaultOwnershipFunctionNames: {
+            type: 'boolean',
+            default: true,
+            description:
+              'Whether ownershipFunctionNames extends the built-in defaults. Set to false to replace them, or to drop them entirely when no list is given.'
           },
           ignoredReturnFunctionNames: {
             type: 'array',
             items: { type: 'string' },
-            default: DEFAULT_IGNORED_RETURN_FUNCTION_NAMES,
             description:
-              'Function or method names whose disposable return value is intentionally ignored.'
+              'Function or method names whose disposable return value is intentionally ignored. Added to the built-in defaults unless extendDefaultIgnoredReturnFunctionNames is false.'
+          },
+          extendDefaultIgnoredReturnFunctionNames: {
+            type: 'boolean',
+            default: true,
+            description:
+              'Whether ignoredReturnFunctionNames extends the built-in defaults, including the add*Factory and this._map.set()/delete() exemptions. Set to false to replace them, or to drop them entirely when no list is given.'
+          },
+          checkAllDisposableReturns: {
+            type: 'boolean',
+            default: false,
+            description:
+              'Check every call whose return type is disposable, not only factory-named calls (create*, build*, make*, new*).'
           }
         },
         additionalProperties: false
@@ -162,15 +184,22 @@ const requireDisposableTransfer = createRule({
       }
     }
 
-    const ignoredReturnFunctionNamesOption = (options as RuleOptions)
-      .ignoredReturnFunctionNames;
-    const ignoredReturnFunctionNames = new Set(
-      ignoredReturnFunctionNamesOption ?? DEFAULT_IGNORED_RETURN_FUNCTION_NAMES
+    // The two pattern-based exemptions below (`add*Factory`, and mutating a
+    // map-like field of `this`) are part of the built-in defaults, so the same
+    // flag that governs the default name list governs them too.
+    const extendDefaultIgnoredReturnFunctionNames =
+      (options as RuleOptions).extendDefaultIgnoredReturnFunctionNames !==
+      false;
+
+    const ignoredReturnFunctionNames = resolveNameListOption(
+      (options as RuleOptions).ignoredReturnFunctionNames,
+      DEFAULT_IGNORED_RETURN_FUNCTION_NAMES,
+      extendDefaultIgnoredReturnFunctionNames
     );
 
     function isIgnoredReturn(node: TSESTree.CallExpression): boolean {
       if (
-        ignoredReturnFunctionNamesOption === undefined &&
+        extendDefaultIgnoredReturnFunctionNames &&
         isClassFieldCollectionMutationCall(node, ['delete', 'set'])
       ) {
         return true;
@@ -182,18 +211,22 @@ const requireDisposableTransfer = createRule({
       }
       return (
         ignoredReturnFunctionNames.has(name) ||
-        (ignoredReturnFunctionNamesOption === undefined &&
+        (extendDefaultIgnoredReturnFunctionNames &&
           isDefaultIgnoredFactoryReturnFunctionName(name))
       );
     }
+
+    const checkAllDisposableReturns =
+      (options as RuleOptions).checkAllDisposableReturns === true;
 
     const ownership: DisposableOwnershipContext = {
       sourceCode: context.sourceCode,
       checker,
       services,
-      ownershipFunctionNames: new Set(
-        (options as RuleOptions).ownershipFunctionNames ??
-          DEFAULT_OWNERSHIP_FUNCTION_NAMES
+      ownershipFunctionNames: resolveNameListOption(
+        (options as RuleOptions).ownershipFunctionNames,
+        DEFAULT_OWNERSHIP_FUNCTION_NAMES,
+        (options as RuleOptions).extendDefaultOwnershipFunctionNames !== false
       )
     };
 
@@ -211,7 +244,7 @@ const requireDisposableTransfer = createRule({
         }
 
         if (
-          ignoredReturnFunctionNamesOption === undefined &&
+          !checkAllDisposableReturns &&
           !isLikelyDisposableFactoryCall(node)
         ) {
           return;
@@ -228,7 +261,9 @@ const requireDisposableTransfer = createRule({
               node,
               assignedVariable,
               context.sourceCode
-            )
+            ) ||
+            isExportedVariable(assignedVariable) ||
+            isDisposedByNestedFunction(assignedVariable, ownership)
           ) {
             return;
           }

--- a/src/utils/disposables.ts
+++ b/src/utils/disposables.ts
@@ -760,15 +760,10 @@ export function isOuterFunctionScopeVariable(
 }
 
 /**
- * Checks whether a variable is an exported binding, including inside an
- * exported `namespace` (`export const tracker = new WidgetTracker(...)`).
- *
- * Ownership of an exported singleton passes to the importers of the module, so
- * this file cannot see - and is not responsible for - its disposal. Such
- * declarations are also created exactly once and live for the lifetime of the
- * program, so there is nothing to leak.
+ * Checks whether the `export` keyword sits on a variable's own declaration, as
+ * in `export const tracker = ...`, including inside an exported `namespace`.
  */
-export function isExportedVariable(variable: TSESLint.Scope.Variable): boolean {
+function isExportedAtDeclaration(variable: TSESLint.Scope.Variable): boolean {
   return variable.defs.some(definition => {
     let current: TSESTree.Node | undefined = definition.node;
     while (current) {
@@ -793,6 +788,80 @@ export function isExportedVariable(variable: TSESLint.Scope.Variable): boolean {
 }
 
 /**
+ * Checks whether a variable is exported by a later statement rather than at its
+ * declaration: `export { tracker }`, `export { tracker as t }`, or
+ * `export default tracker`. The scope manager records each of these as a
+ * reference to the local binding, so they are matched by resolution rather than
+ * by name.
+ */
+function isExportedByExportStatement(
+  variable: TSESLint.Scope.Variable
+): boolean {
+  return variable.references.some(reference => {
+    const parent = reference.identifier.parent;
+    return (
+      parent?.type === 'ExportSpecifier' ||
+      parent?.type === 'ExportDefaultDeclaration'
+    );
+  });
+}
+
+/**
+ * Checks whether a variable is an exported binding, in any of the forms the
+ * `export` keyword can take.
+ *
+ * Ownership of an exported singleton passes to the importers of the module, so
+ * this file cannot see - and is not responsible for - its disposal. Such
+ * declarations are also created exactly once and live for the lifetime of the
+ * program, so there is nothing to leak.
+ */
+export function isExportedVariable(variable: TSESLint.Scope.Variable): boolean {
+  return (
+    isExportedAtDeclaration(variable) || isExportedByExportStatement(variable)
+  );
+}
+
+/**
+ * Checks whether this exact reference is handed to an ownership call, following
+ * only value-preserving positions on the way out: `set.add(item)`,
+ * `set.add([item])`, `set.add({ item })`, `set.add(item as IDisposable)`.
+ *
+ * Anchored on the resolved reference rather than on its name, so a same-named
+ * binding elsewhere in the callback cannot be mistaken for this variable.
+ */
+function isReferenceHandedToOwnershipCall(
+  identifier: TSESTree.Node,
+  ownership: DisposableOwnershipContext
+): boolean {
+  let current: TSESTree.Node = identifier;
+  let parent = current.parent;
+
+  while (parent && !isFunctionLike(parent)) {
+    if (parent.type === 'CallExpression') {
+      return getOwnershipArguments(parent, ownership).includes(
+        current as TSESTree.CallExpressionArgument
+      );
+    }
+
+    const preservesValue =
+      getTransparentChild(parent) === current ||
+      (parent.type === 'ArrayExpression' &&
+        parent.elements.includes(current as TSESTree.Expression)) ||
+      (parent.type === 'Property' && parent.value === current) ||
+      (parent.type === 'ObjectExpression' &&
+        parent.properties.includes(current as TSESTree.Property));
+    if (!preservesValue) {
+      return false;
+    }
+
+    current = parent;
+    parent = current.parent;
+  }
+
+  return false;
+}
+
+/**
  * Checks whether a variable escapes into a nested function that unconditionally
  * disposes it or hands off its ownership - the
  * `requestAnimationFrame(() => splash.dispose())`,
@@ -801,7 +870,9 @@ export function isExportedVariable(variable: TSESLint.Scope.Variable): boolean {
  *
  * This generalises the existing `disposed.connect(...)` special case to any
  * callback. Disposal that is itself conditional inside the callback still does
- * not count, so "cleanup only on some paths" stays reportable.
+ * not count, so "cleanup only on some paths" stays reportable. Both branches
+ * resolve identifiers to this variable rather than comparing names, so a
+ * shadowing binding inside the callback cannot silence the outer one.
  */
 export function isDisposedByNestedFunction(
   variable: TSESLint.Scope.Variable,
@@ -812,6 +883,10 @@ export function isDisposedByNestedFunction(
   for (const reference of variable.references) {
     if (getFunctionScope(reference.from) === declaringScope) {
       continue;
+    }
+
+    if (isReferenceHandedToOwnershipCall(reference.identifier, ownership)) {
+      return true;
     }
 
     const fn = getEnclosingFunction(reference.identifier);
@@ -826,10 +901,7 @@ export function isDisposedByNestedFunction(
     const disposesVariable = getUnconditionalDisposeTargets(fn).some(
       target => getIdentifierVariable(ownership.sourceCode, target) === variable
     );
-    if (
-      disposesVariable ||
-      callbackBodyTransfersOwnership(fn, variable.name, ownership)
-    ) {
+    if (disposesVariable) {
       return true;
     }
   }
@@ -1666,7 +1738,7 @@ function isOwnershipCallWithIdentifier(
   );
 }
 
-function callbackBodyTransfersOwnership(
+function forEachCallbackOwnsParameter(
   callback: TSESTree.ArrowFunctionExpression | TSESTree.FunctionExpression,
   parameterName: string,
   ownership: DisposableOwnershipContext
@@ -1715,7 +1787,7 @@ function markImmediateForEachOwnership(
   const [parameter] = callback.params;
   if (
     parameter?.type !== 'Identifier' ||
-    !callbackBodyTransfersOwnership(callback, parameter.name, ownership)
+    !forEachCallbackOwnsParameter(callback, parameter.name, ownership)
   ) {
     return;
   }

--- a/src/utils/disposables.ts
+++ b/src/utils/disposables.ts
@@ -900,6 +900,63 @@ function isEscapingUse(node: TSESTree.Node): boolean {
 }
 
 /**
+ * Checks whether a reference sits inside a closure that the declaring function
+ * unconditionally returns, the factory pattern:
+ *
+ * ```ts
+ * function createToolbarFactory() {
+ *   const items = new ObservableList(...);
+ *   return (widget: Widget) => { ...uses items... };
+ * }
+ * ```
+ *
+ * The closure is the function's product, so the captured state's lifetime is
+ * bound to it and belongs to whoever holds the factory. Walks outwards through
+ * enclosing functions, because the reference is often nested deeper than the
+ * returned closure itself (in a handler declared inside it).
+ *
+ * Only an unconditional `return` counts, matching how ownership transfer is
+ * treated elsewhere in this file. A closure that merely escapes as a call
+ * argument does not count: that is `defer(() => console.log(d))`, which hands
+ * off nothing.
+ */
+function isCapturedByReturnedClosure(
+  identifier: TSESTree.Node,
+  variable: TSESLint.Scope.Variable
+): boolean {
+  const declaringFunction = getFunctionScope(variable.scope)?.block;
+  if (!declaringFunction) {
+    return false;
+  }
+
+  let fn = getEnclosingFunction(identifier);
+  while (fn && fn !== declaringFunction) {
+    const expression = getOuterExpression(fn);
+    const parent = expression.parent;
+
+    const returnedFromDeclaringFunction =
+      parent?.type === 'ReturnStatement' &&
+      parent.argument === expression &&
+      getEnclosingFunction(parent) === declaringFunction &&
+      isUnconditionalWithinFunction(parent);
+
+    // `const make = () => () => items.use()` returns implicitly.
+    const isImplicitReturnBody =
+      parent?.type === 'ArrowFunctionExpression' &&
+      parent.body === expression &&
+      parent === declaringFunction;
+
+    if (returnedFromDeclaringFunction || isImplicitReturnBody) {
+      return true;
+    }
+
+    fn = getEnclosingFunction(fn);
+  }
+
+  return false;
+}
+
+/**
  * Checks whether this exact reference is handed to an ownership call, following
  * only value-preserving positions on the way out: `set.add(item)`,
  * `set.add([item])`, `set.add({ item })`, `set.add(item as IDisposable)`.
@@ -944,16 +1001,19 @@ function isReferenceHandedToOwnershipCall(
 }
 
 /**
- * Checks whether a variable escapes into a nested function that unconditionally
- * disposes it or hands off its ownership - the
- * `requestAnimationFrame(() => splash.dispose())`,
- * `void load().then(() => splash.dispose()).catch(() => splash.dispose())` and
- * `return () => items.dispose()` idioms.
+ * Checks whether a variable's lifetime is taken over by a nested function, in
+ * any of three ways:
  *
- * This generalises the existing `disposed.connect(...)` special case to any
- * callback. Disposal that is itself conditional inside the callback still does
- * not count, so "cleanup only on some paths" stays reportable. Both branches
- * resolve identifiers to this variable rather than comparing names, so a
+ * - it is captured by a closure the declaring function returns, so the closure
+ *   owns it (`createToolbarFactory`);
+ * - an escaping callback unconditionally disposes it
+ *   (`requestAnimationFrame(() => splash.dispose())`, promise chains);
+ * - an escaping callback unconditionally hands its ownership to something else.
+ *
+ * The last two generalise the existing `disposed.connect(...)` special case to
+ * any callback. Cleanup that is itself conditional inside the callback does not
+ * count, so "cleanup only on some paths" stays reportable, and every branch
+ * resolves identifiers to this variable rather than comparing names, so a
  * shadowing binding inside the callback cannot silence the outer one.
  */
 export function isDisposedByNestedFunction(
@@ -965,6 +1025,10 @@ export function isDisposedByNestedFunction(
   for (const reference of variable.references) {
     if (getFunctionScope(reference.from) === declaringScope) {
       continue;
+    }
+
+    if (isCapturedByReturnedClosure(reference.identifier, variable)) {
+      return true;
     }
 
     const fn = getEnclosingFunction(reference.identifier);

--- a/src/utils/disposables.ts
+++ b/src/utils/disposables.ts
@@ -47,6 +47,27 @@ const OWNED_FUNCTION_OPTION_NAMES = new Map([
 
 const FLUENT_DISPOSABLE_METHOD_NAMES = ['initializeState'];
 
+/**
+ * Resolves a configurable name list option.
+ *
+ * A user-supplied list is *added* to the built-in defaults, so a project only
+ * has to name its own helpers rather than restate this plugin's list. Passing
+ * the matching `extendDefault...` option as `false` drops the defaults, whether
+ * or not a replacement list is given, which is also how to ask for the
+ * strictest possible checking.
+ */
+export function resolveNameListOption(
+  provided: readonly string[] | undefined,
+  defaults: readonly string[],
+  extendDefaults: boolean
+): Set<string> {
+  const names = extendDefaults ? [...defaults] : [];
+  if (provided) {
+    names.push(...provided);
+  }
+  return new Set(names);
+}
+
 export const DEFAULT_OWNERSHIP_FUNCTION_NAMES = [
   'add',
   'addCell',
@@ -738,37 +759,97 @@ export function isOuterFunctionScopeVariable(
   );
 }
 
-export function isInJupyterPluginActivate(
-  node: TSESTree.Node,
+/**
+ * Checks whether a variable is an exported binding, including inside an
+ * exported `namespace` (`export const tracker = new WidgetTracker(...)`).
+ *
+ * Ownership of an exported singleton passes to the importers of the module, so
+ * this file cannot see - and is not responsible for - its disposal. Such
+ * declarations are also created exactly once and live for the lifetime of the
+ * program, so there is nothing to leak.
+ */
+export function isExportedVariable(variable: TSESLint.Scope.Variable): boolean {
+  return variable.defs.some(definition => {
+    let current: TSESTree.Node | undefined = definition.node;
+    while (current) {
+      if (
+        current.type === 'ExportNamedDeclaration' ||
+        current.type === 'ExportDefaultDeclaration'
+      ) {
+        return true;
+      }
+      // Stop at the declaration boundary: only the declaration itself and its
+      // enclosing statement can carry the `export` keyword.
+      if (
+        current.type === 'VariableDeclaration' &&
+        current.parent?.type !== 'ExportNamedDeclaration'
+      ) {
+        return false;
+      }
+      current = current.parent;
+    }
+    return false;
+  });
+}
+
+/**
+ * Checks whether a variable escapes into a nested function that unconditionally
+ * disposes it or hands off its ownership - the
+ * `requestAnimationFrame(() => splash.dispose())`,
+ * `void load().then(() => splash.dispose()).catch(() => splash.dispose())` and
+ * `return () => items.dispose()` idioms.
+ *
+ * This generalises the existing `disposed.connect(...)` special case to any
+ * callback. Disposal that is itself conditional inside the callback still does
+ * not count, so "cleanup only on some paths" stays reportable.
+ */
+export function isDisposedByNestedFunction(
+  variable: TSESLint.Scope.Variable,
   ownership: DisposableOwnershipContext
 ): boolean {
-  const fn = getEnclosingFunction(node);
-  const property = fn?.parent;
-  if (
-    !fn ||
-    !property ||
-    property.type !== 'Property' ||
-    property.value !== fn ||
-    property.computed ||
-    !(
-      (property.key.type === 'Identifier' &&
-        property.key.name === 'activate') ||
-      (property.key.type === 'Literal' && property.key.value === 'activate')
-    )
-  ) {
-    return false;
+  const declaringScope = getFunctionScope(variable.scope);
+
+  for (const reference of variable.references) {
+    if (getFunctionScope(reference.from) === declaringScope) {
+      continue;
+    }
+
+    const fn = getEnclosingFunction(reference.identifier);
+    if (
+      !fn ||
+      (fn.type !== 'ArrowFunctionExpression' &&
+        fn.type !== 'FunctionExpression')
+    ) {
+      continue;
+    }
+
+    const disposesVariable = getUnconditionalDisposeTargets(fn).some(
+      target => getIdentifierVariable(ownership.sourceCode, target) === variable
+    );
+    if (
+      disposesVariable ||
+      callbackBodyTransfersOwnership(fn, variable.name, ownership)
+    ) {
+      return true;
+    }
   }
 
-  const object = property.parent;
-  if (!object || object.type !== 'ObjectExpression') {
-    return false;
-  }
+  return false;
+}
 
-  const variable = object.parent;
+/**
+ * Checks whether an object literal is shaped like a Jupyter plugin descriptor,
+ * either by its declared type or by its property names.
+ */
+function isPluginDescriptorObject(
+  object: TSESTree.ObjectExpression,
+  ownership: DisposableOwnershipContext
+): boolean {
+  const declarator = object.parent;
   if (
-    variable?.type === 'VariableDeclarator' &&
+    declarator?.type === 'VariableDeclarator' &&
     getJupyterPluginKind(
-      variable,
+      declarator,
       ownership.checker,
       ownership.services
         ? node => ownership.services!.esTreeNodeToTSNodeMap.get(node)
@@ -793,6 +874,90 @@ export function isInJupyterPluginActivate(
     ['autoStart', 'optional', 'provides', 'requires'].some(name =>
       propertyNames.has(name)
     )
+  );
+}
+
+/**
+ * Resolves the variable a function is named by, so its references can be
+ * inspected: `function activateCsv() {}` or `const activateCsv = () => {}`.
+ */
+function getFunctionNameVariable(
+  fn: TSESTree.Node,
+  sourceCode: TSESLint.SourceCode
+): TSESLint.Scope.Variable | null {
+  if (fn.type === 'FunctionDeclaration' && fn.id) {
+    const name = fn.id.name;
+    return (
+      sourceCode.getDeclaredVariables(fn).find(entry => entry.name === name) ??
+      null
+    );
+  }
+
+  const declarator = fn.parent;
+  if (
+    declarator?.type === 'VariableDeclarator' &&
+    declarator.init === fn &&
+    declarator.id.type === 'Identifier'
+  ) {
+    return sourceCode.getDeclaredVariables(declarator)[0] ?? null;
+  }
+
+  return null;
+}
+
+/**
+ * Checks whether a function is wired up as the `activate` of a plugin
+ * descriptor elsewhere in the file, e.g. `activate: activateCsv`.
+ */
+function isReferencedAsPluginActivate(
+  variable: TSESLint.Scope.Variable,
+  ownership: DisposableOwnershipContext
+): boolean {
+  return variable.references.some(reference => {
+    const property = reference.identifier.parent;
+    return (
+      property?.type === 'Property' &&
+      property.value === reference.identifier &&
+      getPropertyName(property) === 'activate' &&
+      property.parent?.type === 'ObjectExpression' &&
+      isPluginDescriptorObject(property.parent, ownership)
+    );
+  });
+}
+
+export function isInJupyterPluginActivate(
+  node: TSESTree.Node,
+  ownership: DisposableOwnershipContext
+): boolean {
+  const fn = getEnclosingFunction(node);
+  if (!fn) {
+    return false;
+  }
+
+  // Inline form: `const plugin = { id, autoStart, activate: () => { ... } }`.
+  const property = fn.parent;
+  if (
+    property?.type === 'Property' &&
+    property.value === fn &&
+    getPropertyName(property) === 'activate' &&
+    property.parent?.type === 'ObjectExpression' &&
+    isPluginDescriptorObject(property.parent, ownership)
+  ) {
+    return true;
+  }
+
+  // Named form: `function activate() { ... }`, the convention for plugins whose
+  // activation lives in a separate function (often in a `Private` namespace).
+  if (fn.type === 'FunctionDeclaration' && fn.id?.name === 'activate') {
+    return true;
+  }
+
+  // Referenced form: `function activateCsv() { ... }` used as
+  // `{ id, autoStart, activate: activateCsv }`.
+  const nameVariable = getFunctionNameVariable(fn, ownership.sourceCode);
+  return (
+    nameVariable !== null &&
+    isReferencedAsPluginActivate(nameVariable, ownership)
   );
 }
 
@@ -1501,7 +1666,7 @@ function isOwnershipCallWithIdentifier(
   );
 }
 
-function forEachCallbackOwnsParameter(
+function callbackBodyTransfersOwnership(
   callback: TSESTree.ArrowFunctionExpression | TSESTree.FunctionExpression,
   parameterName: string,
   ownership: DisposableOwnershipContext
@@ -1550,7 +1715,7 @@ function markImmediateForEachOwnership(
   const [parameter] = callback.params;
   if (
     parameter?.type !== 'Identifier' ||
-    !forEachCallbackOwnsParameter(callback, parameter.name, ownership)
+    !callbackBodyTransfersOwnership(callback, parameter.name, ownership)
   ) {
     return;
   }

--- a/src/utils/disposables.ts
+++ b/src/utils/disposables.ts
@@ -816,8 +816,86 @@ function isExportedByExportStatement(
  * program, so there is nothing to leak.
  */
 export function isExportedVariable(variable: TSESLint.Scope.Variable): boolean {
+  if (
+    !isExportedAtDeclaration(variable) &&
+    !isExportedByExportStatement(variable)
+  ) {
+    return false;
+  }
+
+  // A reassigned export is not a single module-lifetime singleton: every value
+  // but the last one is replaced, and only the last one can still be disposed.
   return (
-    isExportedAtDeclaration(variable) || isExportedByExportStatement(variable)
+    variable.references.filter(reference => reference.isWrite()).length <= 1
+  );
+}
+
+/**
+ * Checks whether a node is reached on every run of its enclosing function, that
+ * is, whether nothing conditional or repeated sits between it and the function
+ * body. This is the same standard `isUnconditionalUse` applies within a scope.
+ */
+function isUnconditionalWithinFunction(node: TSESTree.Node): boolean {
+  let parent = node.parent;
+  while (parent && !isFunctionLike(parent)) {
+    if (isConditionalOrRepeated(parent)) {
+      return false;
+    }
+    parent = parent.parent;
+  }
+  return true;
+}
+
+/**
+ * Checks whether a function expression ends up somewhere that can run it later:
+ * passed to a call, returned, stored on a field or in an object literal, or
+ * assigned to a variable that itself escapes.
+ *
+ * A callback that is only declared and never used is not a cleanup path, so
+ * `const cleanupLater = () => d.dispose();` on its own leaves `d` unmanaged.
+ */
+function isEscapingCallback(
+  fn: TSESTree.Node,
+  sourceCode: TSESLint.SourceCode
+): boolean {
+  const expression = getOuterExpression(fn);
+  const parent = expression.parent;
+  if (!parent) {
+    return false;
+  }
+
+  if (parent.type === 'VariableDeclarator' && parent.init === expression) {
+    const [variable] = sourceCode.getDeclaredVariables(parent);
+    return (
+      variable !== undefined &&
+      variable.references.some(
+        reference => !reference.init && isEscapingUse(reference.identifier)
+      )
+    );
+  }
+
+  return isEscapingUse(expression);
+}
+
+/**
+ * Positions in which a value is handed to something else: an argument or callee
+ * of a call, a return value, a field or object literal entry, an array element.
+ */
+function isEscapingUse(node: TSESTree.Node): boolean {
+  const parent = getOuterExpression(node).parent;
+  if (!parent) {
+    return false;
+  }
+  return (
+    parent.type === 'CallExpression' ||
+    parent.type === 'NewExpression' ||
+    parent.type === 'ReturnStatement' ||
+    parent.type === 'PropertyDefinition' ||
+    parent.type === 'Property' ||
+    parent.type === 'ArrayExpression' ||
+    (parent.type === 'ArrowFunctionExpression' && parent.body === node) ||
+    (parent.type === 'AssignmentExpression' &&
+      parent.left.type === 'MemberExpression')
   );
 }
 
@@ -827,7 +905,9 @@ export function isExportedVariable(variable: TSESLint.Scope.Variable): boolean {
  * `set.add([item])`, `set.add({ item })`, `set.add(item as IDisposable)`.
  *
  * Anchored on the resolved reference rather than on its name, so a same-named
- * binding elsewhere in the callback cannot be mistaken for this variable.
+ * binding elsewhere in the callback cannot be mistaken for this variable. The
+ * transfer must also be unconditional, matching how same-scope transfers are
+ * treated: a transfer that only happens on some paths is not a transfer.
  */
 function isReferenceHandedToOwnershipCall(
   identifier: TSESTree.Node,
@@ -838,8 +918,10 @@ function isReferenceHandedToOwnershipCall(
 
   while (parent && !isFunctionLike(parent)) {
     if (parent.type === 'CallExpression') {
-      return getOwnershipArguments(parent, ownership).includes(
-        current as TSESTree.CallExpressionArgument
+      return (
+        getOwnershipArguments(parent, ownership).includes(
+          current as TSESTree.CallExpressionArgument
+        ) && isUnconditionalWithinFunction(parent)
       );
     }
 
@@ -885,10 +967,6 @@ export function isDisposedByNestedFunction(
       continue;
     }
 
-    if (isReferenceHandedToOwnershipCall(reference.identifier, ownership)) {
-      return true;
-    }
-
     const fn = getEnclosingFunction(reference.identifier);
     if (
       !fn ||
@@ -896,6 +974,15 @@ export function isDisposedByNestedFunction(
         fn.type !== 'FunctionExpression')
     ) {
       continue;
+    }
+
+    // A callback nobody can run is not a cleanup path.
+    if (!isEscapingCallback(fn, ownership.sourceCode)) {
+      continue;
+    }
+
+    if (isReferenceHandedToOwnershipCall(reference.identifier, ownership)) {
+      return true;
     }
 
     const disposesVariable = getUnconditionalDisposeTargets(fn).some(

--- a/tests/jupyter-require-disposable-ownership.test.ts
+++ b/tests/jupyter-require-disposable-ownership.test.ts
@@ -109,6 +109,42 @@ nonTypeAwareTester.run(
 ruleTester.run('require-disposable-ownership', requireDisposableOwnership, {
   valid: [
     {
+      // Ownership transfer at the top level of an escaping callback.
+      filename: typeAwareFilename,
+      code: `
+        declare function defer(cb: () => void): void;
+        class DisposableDelegate {
+          constructor(callback: () => void) {}
+          dispose(): void {}
+        }
+        declare const disposables: { add(x: DisposableDelegate): void };
+
+        function go(): void {
+          const d = new DisposableDelegate(() => undefined);
+          defer(() => {
+            disposables.add(d);
+          });
+        }
+      `
+    },
+    {
+      // A callback stored on a field can still be run later.
+      filename: typeAwareFilename,
+      code: `
+        class DisposableDelegate {
+          constructor(callback: () => void) {}
+          dispose(): void {}
+        }
+        class Owner {
+          private _cleanup: (() => void) | null = null;
+          init(): void {
+            const d = new DisposableDelegate(() => undefined);
+            this._cleanup = () => d.dispose();
+          }
+        }
+      `
+    },
+    {
       // A custom ownership name is ADDED to the defaults, so the built-in
       // `add` keeps working alongside it.
       filename: typeAwareFilename,
@@ -1151,6 +1187,69 @@ ruleTester.run('require-disposable-ownership', requireDisposableOwnership, {
   ],
 
   invalid: [
+    {
+      // A callback that is only declared, never invoked, registered or
+      // returned, is not a cleanup path.
+      filename: typeAwareFilename,
+      code: `
+        class DisposableDelegate {
+          constructor(callback: () => void) {}
+          dispose(): void {}
+        }
+
+        function go(): void {
+          const d = new DisposableDelegate(() => undefined);
+          const cleanupLater = () => d.dispose();
+        }
+      `,
+      errors: [
+        { messageId: 'unmanagedDisposableVariable', data: { name: 'd' } }
+      ]
+    },
+    {
+      // Conditional ownership transfer inside a callback is not a transfer,
+      // matching how same-scope conditional uses are treated.
+      filename: typeAwareFilename,
+      code: `
+        declare function defer(cb: () => void): void;
+        declare const condition: boolean;
+        class DisposableDelegate {
+          constructor(callback: () => void) {}
+          dispose(): void {}
+        }
+        declare const disposables: { add(x: DisposableDelegate): void };
+
+        function go(): void {
+          const d = new DisposableDelegate(() => undefined);
+          defer(() => {
+            if (condition) {
+              disposables.add(d);
+            }
+          });
+        }
+      `,
+      errors: [
+        { messageId: 'unmanagedDisposableVariable', data: { name: 'd' } }
+      ]
+    },
+    {
+      // A reassigned export is not a module-lifetime singleton: the replaced
+      // value can no longer be reached, let alone disposed.
+      filename: typeAwareFilename,
+      code: `
+        class DisposableDelegate {
+          constructor(callback: () => void) {}
+          dispose(): void {}
+        }
+
+        export let tracker = new DisposableDelegate(() => undefined);
+        tracker = new DisposableDelegate(() => undefined);
+      `,
+      errors: [
+        { messageId: 'unmanagedDisposableVariable', data: { name: 'tracker' } },
+        { messageId: 'unmanagedDisposableVariable', data: { name: 'tracker' } }
+      ]
+    },
     {
       // A shadowing binding inside the callback must not silence the outer
       // disposable: the ownership check resolves identifiers, not names.

--- a/tests/jupyter-require-disposable-ownership.test.ts
+++ b/tests/jupyter-require-disposable-ownership.test.ts
@@ -109,6 +109,155 @@ nonTypeAwareTester.run(
 ruleTester.run('require-disposable-ownership', requireDisposableOwnership, {
   valid: [
     {
+      // A custom ownership name is ADDED to the defaults, so the built-in
+      // `add` keeps working alongside it.
+      filename: typeAwareFilename,
+      options: [{ ownershipFunctionNames: ['ownDisposable'] }],
+      code: `
+        class DisposableDelegate {
+          constructor(callback: () => void) {}
+          dispose(): void {}
+        }
+        declare const items: { add(disposable: DisposableDelegate): void };
+
+        const first = new DisposableDelegate(() => undefined);
+        items.add(first);
+      `
+    },
+    {
+      // An empty options object must behave exactly like no options at all.
+      // ESLint fills schema `default` values into the options object, so array
+      // options must not declare one or "was it provided" becomes undetectable.
+      filename: typeAwareFilename,
+      options: [{}],
+      code: `
+        class DisposableDelegate {
+          constructor(callback: () => void) {}
+          dispose(): void {}
+        }
+        declare const items: { add(disposable: DisposableDelegate): void };
+
+        const first = new DisposableDelegate(() => undefined);
+        items.add(first);
+      `
+    },
+    {
+      // Exported singleton: ownership belongs to the importers of the module.
+      filename: typeAwareFilename,
+      code: `
+        class DisposableDelegate {
+          constructor(callback: () => void) {}
+          dispose(): void {}
+        }
+        export const tracker = new DisposableDelegate(() => undefined);
+      `
+    },
+    {
+      // Exported singleton inside a namespace (Dialog.tracker,
+      // Notification.manager).
+      filename: typeAwareFilename,
+      code: `
+        class DisposableDelegate {
+          constructor(callback: () => void) {}
+          dispose(): void {}
+        }
+        export namespace Private {
+          export const tracker = new DisposableDelegate(() => undefined);
+        }
+      `
+    },
+    {
+      // Plugin activation split into a named function, referenced as
+      // `activate: activateCsv`.
+      filename: typeAwareFilename,
+      code: `
+        class DisposableDelegate {
+          constructor(callback: () => void) {}
+          dispose(): void {}
+        }
+        function activateCsv(): void {
+          const tracker = new DisposableDelegate(() => undefined);
+          void tracker;
+        }
+        const plugin = {
+          id: 'example:plugin',
+          autoStart: true,
+          activate: activateCsv
+        };
+        export default plugin;
+      `
+    },
+    {
+      // Plugin activation as `export function activate()`, the convention for
+      // activation living in a `Private` namespace.
+      filename: typeAwareFilename,
+      code: `
+        class DisposableDelegate {
+          constructor(callback: () => void) {}
+          dispose(): void {}
+        }
+        export namespace Private {
+          export function activate(): void {
+            const palette = new DisposableDelegate(() => undefined);
+            void palette;
+          }
+        }
+      `
+    },
+    {
+      // Unconditional disposal inside a callback: the
+      // `requestAnimationFrame(() => splash.dispose())` idiom.
+      filename: typeAwareFilename,
+      code: `
+        declare function defer(callback: () => void): void;
+        class DisposableDelegate {
+          constructor(callback: () => void) {}
+          dispose(): void {}
+        }
+        function load(): void {
+          const splash = new DisposableDelegate(() => undefined);
+          defer(() => {
+            splash.dispose();
+          });
+        }
+      `
+    },
+    {
+      // Disposal in a promise chain.
+      filename: typeAwareFilename,
+      code: `
+        declare function work(): Promise<void>;
+        class DisposableDelegate {
+          constructor(callback: () => void) {}
+          dispose(): void {}
+        }
+        function load(): void {
+          const splash = new DisposableDelegate(() => undefined);
+          void work()
+            .then(() => {
+              splash.dispose();
+            })
+            .catch(() => {
+              splash.dispose();
+            });
+        }
+      `
+    },
+    {
+      // Captured by a returned closure that disposes it.
+      filename: typeAwareFilename,
+      code: `
+        class DisposableDelegate {
+          constructor(callback: () => void) {}
+          dispose(): void {}
+        }
+        function createFactory(): () => void {
+          const items = new DisposableDelegate(() => undefined);
+          return () => items.dispose();
+        }
+      `
+    },
+    {
       filename: typeAwareFilename,
       code: `
         declare function cleanup(): void;
@@ -1229,9 +1378,13 @@ ruleTester.run('require-disposable-ownership', requireDisposableOwnership, {
       ]
     },
     {
+      // Disposal inside a callback that is only *conditionally* reached still
+      // counts as unmanaged. Unconditional disposal inside the callback is
+      // accepted - see the matching valid case.
       filename: typeAwareFilename,
       code: `
         declare function cleanup(): void;
+        declare const condition: boolean;
         declare function defer(callback: () => void): void;
         class DisposableDelegate {
           constructor(callback: () => void) {}
@@ -1242,7 +1395,9 @@ ruleTester.run('require-disposable-ownership', requireDisposableOwnership, {
           cleanup();
         });
         defer(() => {
-          disposable.dispose();
+          if (condition) {
+            disposable.dispose();
+          }
         });
       `,
       errors: [
@@ -1299,7 +1454,7 @@ ruleTester.run('require-disposable-ownership', requireDisposableOwnership, {
     },
     {
       filename: typeAwareFilename,
-      options: [{ ownershipFunctionNames: [] }],
+      options: [{ extendDefaultOwnershipFunctionNames: false }],
       code: `
         declare function cleanup(): void;
         class DisposableDelegate {

--- a/tests/jupyter-require-disposable-ownership.test.ts
+++ b/tests/jupyter-require-disposable-ownership.test.ts
@@ -109,6 +109,74 @@ nonTypeAwareTester.run(
 ruleTester.run('require-disposable-ownership', requireDisposableOwnership, {
   valid: [
     {
+      // Mirrors JupyterLab's createToolbarFactory (apputils/src/toolbar/factory.ts):
+      // `items` is created once, passed to a helper, captured by the returned
+      // factory closure and by handlers declared inside it, and never disposed.
+      // The returned closure owns it.
+      filename: typeAwareFilename,
+      code: `
+        declare class ObservableList<T> {
+          constructor(options: { itemCmp: (a: T, b: T) => boolean });
+          readonly changed: {
+            connect(cb: () => void): void;
+            disconnect(cb: () => void): void;
+          };
+          get(index: number): T;
+          dispose(): void;
+          readonly isDisposed: boolean;
+        }
+        declare function setToolbarItems(
+          items: ObservableList<string>
+        ): Promise<void>;
+        declare const registry: {
+          factoryAdded: {
+            connect(cb: () => void): void;
+            disconnect(cb: () => void): void;
+          };
+        };
+        declare const widget: { disposed: { connect(cb: () => void): void } };
+
+        export function createToolbarFactory(): () => void {
+          const items = new ObservableList<string>({
+            itemCmp: (a, b) => a === b
+          });
+
+          setToolbarItems(items).catch(() => undefined);
+
+          return () => {
+            const updateToolbar = () => {
+              void Array.from([items.get(0)]);
+            };
+            const updateWidget = () => {
+              void items.get(0);
+            };
+            registry.factoryAdded.connect(updateWidget);
+            items.changed.connect(updateToolbar);
+            widget.disposed.connect(() => {
+              items.changed.disconnect(updateToolbar);
+              registry.factoryAdded.disconnect(updateWidget);
+            });
+          };
+        }
+      `
+    },
+    {
+      // The same ownership handoff written with an implicit arrow return.
+      filename: typeAwareFilename,
+      code: `
+        class DisposableDelegate {
+          constructor(callback: () => void) {}
+          dispose(): void {}
+          use(): void {}
+        }
+        const makeFactory = () => {
+          const items = new DisposableDelegate(() => undefined);
+          return () => items.use();
+        };
+        void makeFactory;
+      `
+    },
+    {
       // Ownership transfer at the top level of an escaping callback.
       filename: typeAwareFilename,
       code: `
@@ -1187,6 +1255,27 @@ ruleTester.run('require-disposable-ownership', requireDisposableOwnership, {
   ],
 
   invalid: [
+    {
+      // A closure that captures the disposable but is not returned hands off
+      // nothing, so the disposable is still unowned.
+      filename: typeAwareFilename,
+      code: `
+        declare function defer(cb: () => void): void;
+        class DisposableDelegate {
+          constructor(callback: () => void) {}
+          dispose(): void {}
+          use(): void {}
+        }
+
+        function go(): void {
+          const items = new DisposableDelegate(() => undefined);
+          defer(() => items.use());
+        }
+      `,
+      errors: [
+        { messageId: 'unmanagedDisposableVariable', data: { name: 'items' } }
+      ]
+    },
     {
       // A callback that is only declared, never invoked, registered or
       // returned, is not a cleanup path.

--- a/tests/jupyter-require-disposable-ownership.test.ts
+++ b/tests/jupyter-require-disposable-ownership.test.ts
@@ -153,6 +153,42 @@ ruleTester.run('require-disposable-ownership', requireDisposableOwnership, {
       `
     },
     {
+      // Exported by a later statement rather than at the declaration.
+      filename: typeAwareFilename,
+      code: `
+        class DisposableDelegate {
+          constructor(callback: () => void) {}
+          dispose(): void {}
+        }
+        const tracker = new DisposableDelegate(() => undefined);
+        export { tracker };
+      `
+    },
+    {
+      // Exported by a later statement under a different name.
+      filename: typeAwareFilename,
+      code: `
+        class DisposableDelegate {
+          constructor(callback: () => void) {}
+          dispose(): void {}
+        }
+        const tracker = new DisposableDelegate(() => undefined);
+        export { tracker as dialogTracker };
+      `
+    },
+    {
+      // Exported as the module default.
+      filename: typeAwareFilename,
+      code: `
+        class DisposableDelegate {
+          constructor(callback: () => void) {}
+          dispose(): void {}
+        }
+        const tracker = new DisposableDelegate(() => undefined);
+        export default tracker;
+      `
+    },
+    {
       // Exported singleton inside a namespace (Dialog.tracker,
       // Notification.manager).
       filename: typeAwareFilename,
@@ -1115,6 +1151,36 @@ ruleTester.run('require-disposable-ownership', requireDisposableOwnership, {
   ],
 
   invalid: [
+    {
+      // A shadowing binding inside the callback must not silence the outer
+      // disposable: the ownership check resolves identifiers, not names.
+      filename: typeAwareFilename,
+      code: `
+        declare function defer(cb: () => void): void;
+        class DisposableDelegate {
+          constructor(callback: () => void) {}
+          dispose(): void {}
+        }
+        declare const disposables: { add(d: DisposableDelegate): void };
+
+        function go(): void {
+          const splash = new DisposableDelegate(() => undefined);
+          defer(() => {
+            {
+              const splash = new DisposableDelegate(() => undefined);
+              disposables.add(splash);
+            }
+            void splash;
+          });
+        }
+      `,
+      errors: [
+        {
+          messageId: 'unmanagedDisposableVariable',
+          data: { name: 'splash' }
+        }
+      ]
+    },
     {
       filename: typeAwareFilename,
       code: `

--- a/tests/jupyter-require-disposable-transfer.test.ts
+++ b/tests/jupyter-require-disposable-transfer.test.ts
@@ -88,6 +88,93 @@ nonTypeAwareTester.run(
 ruleTester.run('require-disposable-transfer', requireDisposableTransfer, {
   valid: [
     {
+      // A custom ignored name is ADDED to the defaults, so the built-in `get`
+      // keeps being ignored alongside it.
+      filename: typeAwareFilename,
+      options: [{ ignoredReturnFunctionNames: ['borrowThing'] }],
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+        declare const registry: {
+          borrowThing(): IDisposable;
+          createThing(): IDisposable;
+          get(id: string): IDisposable;
+        };
+
+        registry.borrowThing();
+        registry.get('example');
+      `
+    },
+    {
+      // An empty options object must behave exactly like no options at all.
+      // ESLint fills schema `default` values into the options object, so array
+      // options must not declare one or "was it provided" becomes undetectable.
+      filename: typeAwareFilename,
+      options: [{}],
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+        declare const registry: { get(id: string): IDisposable };
+
+        registry.get('example');
+      `
+    },
+    {
+      // Exported singleton: ownership belongs to the importers of the module.
+      filename: typeAwareFilename,
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+        declare function createDisposable(): IDisposable;
+        export const tracker = createDisposable();
+      `
+    },
+    {
+      // Plugin activation split into a named function.
+      filename: typeAwareFilename,
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+        declare function createDisposable(): IDisposable;
+        function activateCsv(): void {
+          const tracker = createDisposable();
+          void tracker;
+        }
+        const plugin = {
+          id: 'example:plugin',
+          autoStart: true,
+          activate: activateCsv
+        };
+        export default plugin;
+      `
+    },
+    {
+      // Unconditional disposal inside a callback.
+      filename: typeAwareFilename,
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+        declare function createDisposable(): IDisposable;
+        declare function defer(callback: () => void): void;
+        function load(): void {
+          const splash = createDisposable();
+          defer(() => {
+            splash.dispose();
+          });
+        }
+      `
+    },
+    {
       filename: typeAwareFilename,
       code: `
         interface IDisposable {
@@ -889,6 +976,45 @@ ruleTester.run('require-disposable-transfer', requireDisposableTransfer, {
 
   invalid: [
     {
+      // extendDefault...: false with no list of its own drops every default
+      // exemption, which is how to ask for the strictest checking.
+      filename: typeAwareFilename,
+      options: [
+        {
+          extendDefaultIgnoredReturnFunctionNames: false,
+          checkAllDisposableReturns: true
+        }
+      ],
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+        declare const registry: { get(id: string): IDisposable };
+
+        registry.get('example');
+      `,
+      errors: [{ messageId: 'unhandledDisposable', data: { name: 'get' } }]
+    },
+    {
+      // checkAllDisposableReturns alone widens the checked call set without
+      // touching the ignore list.
+      filename: typeAwareFilename,
+      options: [{ checkAllDisposableReturns: true }],
+      code: `
+        interface IDisposable {
+          readonly isDisposed: boolean;
+          dispose(): void;
+        }
+        declare const registry: { borrowThing(): IDisposable };
+
+        registry.borrowThing();
+      `,
+      errors: [
+        { messageId: 'unhandledDisposable', data: { name: 'borrowThing' } }
+      ]
+    },
+    {
       filename: typeAwareFilename,
       code: `
         interface IDisposable {
@@ -956,7 +1082,12 @@ ruleTester.run('require-disposable-transfer', requireDisposableTransfer, {
     },
     {
       filename: typeAwareFilename,
-      options: [{ ignoredReturnFunctionNames: [] }],
+      options: [
+        {
+          extendDefaultIgnoredReturnFunctionNames: false,
+          checkAllDisposableReturns: true
+        }
+      ],
       code: `
         interface IDisposable {
           readonly isDisposed: boolean;
@@ -984,7 +1115,12 @@ ruleTester.run('require-disposable-transfer', requireDisposableTransfer, {
     },
     {
       filename: typeAwareFilename,
-      options: [{ ignoredReturnFunctionNames: [] }],
+      options: [
+        {
+          extendDefaultIgnoredReturnFunctionNames: false,
+          checkAllDisposableReturns: true
+        }
+      ],
       code: `
         interface IDisposable {
           readonly isDisposed: boolean;
@@ -1005,7 +1141,12 @@ ruleTester.run('require-disposable-transfer', requireDisposableTransfer, {
     },
     {
       filename: typeAwareFilename,
-      options: [{ ignoredReturnFunctionNames: [] }],
+      options: [
+        {
+          extendDefaultIgnoredReturnFunctionNames: false,
+          checkAllDisposableReturns: true
+        }
+      ],
       code: `
         interface IDisposable {
           readonly isDisposed: boolean;
@@ -1026,7 +1167,12 @@ ruleTester.run('require-disposable-transfer', requireDisposableTransfer, {
     },
     {
       filename: typeAwareFilename,
-      options: [{ ignoredReturnFunctionNames: [] }],
+      options: [
+        {
+          extendDefaultIgnoredReturnFunctionNames: false,
+          checkAllDisposableReturns: true
+        }
+      ],
       code: `
         interface IDisposable {
           readonly isDisposed: boolean;
@@ -1047,7 +1193,12 @@ ruleTester.run('require-disposable-transfer', requireDisposableTransfer, {
     },
     {
       filename: typeAwareFilename,
-      options: [{ ignoredReturnFunctionNames: [] }],
+      options: [
+        {
+          extendDefaultIgnoredReturnFunctionNames: false,
+          checkAllDisposableReturns: true
+        }
+      ],
       code: `
         interface IDisposable {
           readonly isDisposed: boolean;
@@ -1171,18 +1322,24 @@ ruleTester.run('require-disposable-transfer', requireDisposableTransfer, {
       ]
     },
     {
+      // Disposal inside a callback that is only *conditionally* reached still
+      // counts as unmanaged. Unconditional disposal inside the callback is
+      // accepted - see the matching valid case.
       filename: typeAwareFilename,
       code: `
         interface IDisposable {
           readonly isDisposed: boolean;
           dispose(): void;
         }
+        declare const condition: boolean;
         declare function createDisposable(): IDisposable;
         declare function defer(callback: () => void): void;
 
         const disposable = createDisposable();
         defer(() => {
-          disposable.dispose();
+          if (condition) {
+            disposable.dispose();
+          }
         });
       `,
       errors: [
@@ -1223,7 +1380,7 @@ ruleTester.run('require-disposable-transfer', requireDisposableTransfer, {
     },
     {
       filename: typeAwareFilename,
-      options: [{ ownershipFunctionNames: [] }],
+      options: [{ extendDefaultOwnershipFunctionNames: false }],
       code: `
         interface IDisposable {
           readonly isDisposed: boolean;

--- a/website/docs/rules/require-disposable-ownership.md
+++ b/website/docs/rules/require-disposable-ownership.md
@@ -15,8 +15,12 @@ The rule checks `new` expressions that create known disposable classes such as
 `DisposableDelegate`, `ObservableDisposableDelegate`, `DisposableSet`, and
 `ObservableDisposableSet`. When TypeScript type information is available, it
 also detects objects typed as `IDisposable` or `IObservableDisposable`.
-It ignores disposable objects created directly inside a typed Jupyter plugin
+
+It ignores disposable objects created directly inside a Jupyter plugin
 `activate` function, where services commonly live for the application lifetime.
+All three ways of writing one are recognised: an inline `activate` property, a
+function named `activate`, and a separate function referenced as
+`activate: activateFoo`.
 
 It accepts common ownership patterns:
 
@@ -37,6 +41,13 @@ It accepts common ownership patterns:
   `new MainAreaWidget({ content })` or `new Dialog({ body })`
 - Passing it as a `showDialog({ body: ... })` body or launching a typed
   `Dialog` with `.launch()`
+- Disposing it unconditionally inside a callback, so the
+  `requestAnimationFrame(() => splash.dispose())` and
+  `void load().then(() => splash.dispose())` idioms are accepted. Disposal that
+  is itself conditional inside the callback is still reported.
+- Declaring it as an exported binding (`export const tracker = ...`, including
+  inside an exported `namespace`): ownership of a module singleton passes to the
+  importers of the module.
 
 ## Incorrect
 
@@ -86,11 +97,14 @@ class Owner {
 
 ### `ownershipFunctionNames`
 
-Function or method names that take ownership of disposable arguments. The
-default list is `add`, `addCell`, `addFactory`, `addItem`, `addModelFactory`,
-`addSibling`, `addMenu`, `addWidget`, `addWidgetFactory`, `insertItem`,
-`insertWidget`, and `registerStatusItem`. If provided, this list replaces the
-default. Set this option to `[]` to require stricter typed ownership checks.
+Function or method names that take ownership of disposable arguments, such as
+`add`, `addWidget`, `insertWidget`, and `registerStatusItem`. For the full
+default list see the
+[`DEFAULT_OWNERSHIP_FUNCTION_NAMES`](https://github.com/search?q=repo%3Ajupyterlab%2Feslint-plugin+DEFAULT_OWNERSHIP_FUNCTION_NAMES&type=code)
+constant.
+
+Names given here are **added** to that default list, so a project only has to
+name its own ownership helpers:
 
 ```json
 {
@@ -99,6 +113,23 @@ default. Set this option to `[]` to require stricter typed ownership checks.
     {
       "ownershipFunctionNames": ["ownDisposable", "registerDisposable"]
     }
+  ]
+}
+```
+
+### `extendDefaultOwnershipFunctionNames`
+
+Type: `boolean`, default: `true`.
+
+Set to `false` to replace the default list instead of extending it. With no
+`ownershipFunctionNames` of your own, `false` drops the defaults entirely, which
+is how to ask for the strictest typed ownership checking:
+
+```json
+{
+  "jupyter/require-disposable-ownership": [
+    "warn",
+    { "extendDefaultOwnershipFunctionNames": false }
   ]
 }
 ```

--- a/website/docs/rules/require-disposable-ownership.md
+++ b/website/docs/rules/require-disposable-ownership.md
@@ -100,7 +100,7 @@ class Owner {
 Function or method names that take ownership of disposable arguments, such as
 `add`, `addWidget`, `insertWidget`, and `registerStatusItem`. For the full
 default list see the
-[`DEFAULT_OWNERSHIP_FUNCTION_NAMES`](https://github.com/search?q=repo%3Ajupyterlab%2Feslint-plugin+DEFAULT_OWNERSHIP_FUNCTION_NAMES&type=code)
+[`DEFAULT_OWNERSHIP_FUNCTION_NAMES`](https://github.com/search?q=repo%3Ajupyterlab%2Feslint-plugin+const+DEFAULT_OWNERSHIP_FUNCTION_NAMES&type=code)
 constant.
 
 Names given here are **added** to that default list, so a project only has to

--- a/website/docs/rules/require-disposable-transfer.md
+++ b/website/docs/rules/require-disposable-transfer.md
@@ -14,9 +14,12 @@ This rule checks factory-like call expressions such as `create*`, `make*`,
 `build*`, and `new*` whose return type is compatible with `IDisposable` or
 `IObservableDisposable` when TypeScript type information is available. It also
 recognizes the known Lumino factories `DisposableSet.from(...)` and
-`ObservableDisposableSet.from(...)`. It ignores disposable values created
-directly inside a typed Jupyter plugin `activate` function, where services
-commonly live for the application lifetime.
+`ObservableDisposableSet.from(...)`.
+
+It ignores disposable values created directly inside a Jupyter plugin `activate`
+function, where services commonly live for the application lifetime. All three
+ways of writing one are recognised: an inline `activate` property, a function
+named `activate`, and a separate function referenced as `activate: activateFoo`.
 
 It accepts common ownership patterns:
 
@@ -35,17 +38,21 @@ It accepts common ownership patterns:
   `insertWidget`, or `registerStatusItem`
 - Passing it through a known owned constructor options object, such as
   `new MainAreaWidget({ content })` or `new Dialog({ body })`
+- Disposing it unconditionally inside a callback, so the
+  `requestAnimationFrame(() => splash.dispose())` and
+  `void load().then(() => splash.dispose())` idioms are accepted. Disposal that
+  is itself conditional inside the callback is still reported.
+- Declaring it as an exported binding (`export const tracker = ...`, including
+  inside an exported `namespace`): ownership of a module singleton passes to the
+  importers of the module.
 
-By default, the rule does not report common borrowed-reference,
-fluent-initializer, or registration-return calls such as `get`, `find`,
-`getCurrent`, `contextForWidget`, `insertCell`, `insertTab`,
-`initializeState`, `contextMenuWidget`, `add`, `addCommand`, `addFileType`,
-`addItem`, `addWidgetExtension`, `addToolbarButtonClass`,
-`addCommandToolbarButtonClass`, `addTab`, `delete`, `open`, `openInspector`,
-`openOrReveal`, `findWidget`, `_findWidgetByID`, `widgetAt`,
-`widgetRenderer`, `pop`, `shift`, `registerItem`, `registerStatusItem`,
-`addKeyBinding`, `addGroup`, `register`, `set`, `transform`, and
-`add*Factory`.
+By default, the rule does not report calls whose return value is a borrowed
+reference, a fluent initializer, or a registration handle that the caller is not
+expected to own. Representative entries are `get`, `find`, `add`, `addCommand`,
+`open`, `register`, `set`, and `transform`, plus any name matching
+`add*Factory`. For the full list see the
+[`DEFAULT_IGNORED_RETURN_FUNCTION_NAMES`](https://github.com/search?q=repo%3Ajupyterlab%2Feslint-plugin+DEFAULT_IGNORED_RETURN_FUNCTION_NAMES&type=code)
+constant.
 
 ## Incorrect
 
@@ -82,18 +89,46 @@ disposables.dispose();
 
 ### `ownershipFunctionNames`
 
-Function or method names that take ownership of disposable arguments. The
-default list is `add`, `addCell`, `addFactory`, `addItem`, `addModelFactory`,
-`addSibling`, `addMenu`, `addWidget`, `addWidgetFactory`, `insertItem`,
-`insertWidget`, and `registerStatusItem`. If provided, this list replaces the
-default. Set this option to `[]` to require stricter typed ownership checks.
+Function or method names that take ownership of disposable arguments, such as
+`add`, `addWidget`, `insertWidget`, and `registerStatusItem`. For the full
+default list see the
+[`DEFAULT_OWNERSHIP_FUNCTION_NAMES`](https://github.com/search?q=repo%3Ajupyterlab%2Feslint-plugin+DEFAULT_OWNERSHIP_FUNCTION_NAMES&type=code)
+constant. Names given here are **added** to that default list.
+
+### `extendDefaultOwnershipFunctionNames`
+
+Type: `boolean`, default: `true`.
+
+Set to `false` to replace the default ownership list instead of extending it.
+With no `ownershipFunctionNames` of your own, `false` drops the defaults
+entirely.
 
 ### `ignoredReturnFunctionNames`
 
 Function or method names whose disposable return value should be treated as
-borrowed or owned by a registration/session API. If provided, this list
-replaces the default and opts into stricter return checking for non-factory
-calls. Set this option to `[]` to report ignored registration return values.
+borrowed, or as owned by a registration or session API. Names given here are
+**added** to the default list described above.
+
+### `extendDefaultIgnoredReturnFunctionNames`
+
+Type: `boolean`, default: `true`.
+
+Set to `false` to replace the default ignore list instead of extending it. This
+also drops the two pattern-based default exemptions, `add*Factory` and
+`this._map.set(...)` / `this._map.delete(...)`, since those are part of the same
+defaults. With no `ignoredReturnFunctionNames` of your own, `false` ignores
+nothing at all.
+
+### `checkAllDisposableReturns`
+
+Type: `boolean`, default: `false`.
+
+By default only factory-named calls (`create*`, `build*`, `make*`, `new*`) have
+their disposable return value checked, because any call _might_ return a
+disposable and reporting all of them is too noisy. Set this to `true` to check
+every call whose return type is disposable.
+
+Extending the defaults, the common case:
 
 ```json
 {
@@ -101,7 +136,22 @@ calls. Set this option to `[]` to report ignored registration return values.
     "warn",
     {
       "ownershipFunctionNames": ["ownDisposable", "registerDisposable"],
-      "ignoredReturnFunctionNames": ["addCommand", "get", "find"]
+      "ignoredReturnFunctionNames": ["borrowWidget"]
+    }
+  ]
+}
+```
+
+Strictest possible checking, dropping every default exemption:
+
+```json
+{
+  "jupyter/require-disposable-transfer": [
+    "warn",
+    {
+      "extendDefaultOwnershipFunctionNames": false,
+      "extendDefaultIgnoredReturnFunctionNames": false,
+      "checkAllDisposableReturns": true
     }
   ]
 }

--- a/website/docs/rules/require-disposable-transfer.md
+++ b/website/docs/rules/require-disposable-transfer.md
@@ -51,7 +51,7 @@ reference, a fluent initializer, or a registration handle that the caller is not
 expected to own. Representative entries are `get`, `find`, `add`, `addCommand`,
 `open`, `register`, `set`, and `transform`, plus any name matching
 `add*Factory`. For the full list see the
-[`DEFAULT_IGNORED_RETURN_FUNCTION_NAMES`](https://github.com/search?q=repo%3Ajupyterlab%2Feslint-plugin+DEFAULT_IGNORED_RETURN_FUNCTION_NAMES&type=code)
+[`DEFAULT_IGNORED_RETURN_FUNCTION_NAMES`](https://github.com/search?q=repo%3Ajupyterlab%2Feslint-plugin+const+DEFAULT_IGNORED_RETURN_FUNCTION_NAMES&type=code)
 constant.
 
 ## Incorrect
@@ -92,7 +92,7 @@ disposables.dispose();
 Function or method names that take ownership of disposable arguments, such as
 `add`, `addWidget`, `insertWidget`, and `registerStatusItem`. For the full
 default list see the
-[`DEFAULT_OWNERSHIP_FUNCTION_NAMES`](https://github.com/search?q=repo%3Ajupyterlab%2Feslint-plugin+DEFAULT_OWNERSHIP_FUNCTION_NAMES&type=code)
+[`DEFAULT_OWNERSHIP_FUNCTION_NAMES`](https://github.com/search?q=repo%3Ajupyterlab%2Feslint-plugin+const+DEFAULT_OWNERSHIP_FUNCTION_NAMES&type=code)
 constant. Names given here are **added** to that default list.
 
 ### `extendDefaultOwnershipFunctionNames`


### PR DESCRIPTION
Closes https://github.com/jupyterlab/eslint-plugin/issues/87

Fixes source of three false positives in `require-disposable-ownership` and `require-disposable-transfer`:
- exported module singletons such as `Dialog.tracker` are owned by the importers of the module, not by the declaring file
- plugin `activate` is now recognised in all three forms it is written in, including a separate function referenced as `activate: activateCsv`
- unconditional disposal inside a callback counts as disposal, so the `requestAnimationFrame(() => splash.dispose())` and promise chain idioms are accepted

This deliberately relaxes one previously asserted behaviour: disposal inside a callback that might never run is no longer reported, which flipped two test cases, while disposal that is itself conditional inside the callback still is.

Improves API:
- both name list options now extend the built-in defaults rather than replacing them, via per-list `extendDefault...` flags,
- adds a standalone `checkAllDisposableReturns`
- removes the array schema `default:` keys that made `['error', {}]` behave differently from `'error'`

Improves documentation by no-longer providing a copy of `DEFAULT_IGNORED_RETURN_FUNCTION_NAMES` in docs to avoid drift.
