### PR TITLE
Add `no-dynamic-translation` rule

### DIFF
--- a/eslint.downstream.config.mjs
+++ b/eslint.downstream.config.mjs
@@ -44,6 +44,7 @@ function makeProjectConfig(projectName) {
       'jupyter/plugin-activation-args': 'error',
       'jupyter/plugin-description': 'error',
       'jupyter/no-translation-concatenation': 'error',
+      'jupyter/no-dynamic-translation': 'error',
       'jupyter/token-format': 'error',
       'jupyter/require-soft-assertions-before-snapshots': 'error',
       'jupyter/require-disposable-ownership': 'error',
@@ -128,9 +129,9 @@ function makeTestConfig(projectName) {
       ],
       ignores: [`${projectName}/galata/src/helpers/**`],
       plugins: {
-        'jupyter': resolvedPlugin,
+        jupyter: resolvedPlugin,
         '@typescript-eslint': resolvedTsPlugin,
-        'jest': jestStub,
+        jest: jestStub
       },
       rules: {
         'jupyter/galata-prefer-filebrowser-helper': 'error'

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import pluginActivationArgs from './rules/plugin-activation-args';
 import commandDescribedBy from './rules/command-described-by';
 import pluginDescription from './rules/plugin-description';
 import noTranslationConcatenation from './rules/no-translation-concatenation';
+import noDynamicTranslation from './rules/no-dynamic-translation';
 import tokenFormat from './rules/token-format';
 import noUntranslatedString from './rules/no-untranslated-string';
 import noSchemaEnum from './rules/no-schema-enum';
@@ -24,6 +25,7 @@ const plugin = {
     'command-described-by': commandDescribedBy,
     'plugin-description': pluginDescription,
     'no-translation-concatenation': noTranslationConcatenation,
+    'no-dynamic-translation': noDynamicTranslation,
     'token-format': tokenFormat,
     'no-untranslated-string': noUntranslatedString,
     'no-schema-enum': noSchemaEnum,
@@ -44,6 +46,7 @@ const plugin = {
           'jupyter/command-described-by': 'warn',
           'jupyter/plugin-description': 'warn',
           'jupyter/no-translation-concatenation': 'error',
+          'jupyter/no-dynamic-translation': 'warn',
           'jupyter/token-format': 'error',
           'jupyter/no-untranslated-string': 'warn',
           'jupyter/no-pageconfig-base-url': 'warn',
@@ -73,6 +76,7 @@ const plugin = {
         'jupyter/command-described-by': 'warn',
         'jupyter/plugin-description': 'warn',
         'jupyter/no-translation-concatenation': 'error',
+        'jupyter/no-dynamic-translation': 'warn',
         'jupyter/token-format': 'error',
         'jupyter/no-untranslated-string': 'warn',
         'jupyter/no-schema-enum': 'warn',

--- a/src/rules/incorrect-translator-usage.ts
+++ b/src/rules/incorrect-translator-usage.ts
@@ -5,34 +5,12 @@
 
 import { createRule } from '../utils/create-rule';
 import { TSESTree } from '@typescript-eslint/types';
-
-/**
- * Methods of the TranslationBundle interface from `@jupyterlab/translation`.
- */
-const BUNDLE_METHODS = new Set([
-  '__',
-  '_n',
-  '_p',
-  '_np',
-  'gettext',
-  'ngettext',
-  'pgettext',
-  'npgettext',
-  'dcnpgettext'
-]);
-
-/**
- * Property names under which a translation bundle may be stored so that the
- * string extractor recognizes its usages (this.trans, this._trans,
- * this.props.trans, props.trans).
- * See jupyterlab.readthedocs.io/en/stable/extension/internationalization.html#rules
- */
-const BUNDLE_PROPERTY_NAMES = new Set(['trans', '_trans']);
-
-/**
- * The only accepted name for a local variable holding a translation bundle.
- */
-const BUNDLE_VARIABLE_NAME = 'trans';
+import {
+  BUNDLE_METHODS,
+  BUNDLE_PROPERTY_NAMES,
+  BUNDLE_VARIABLE_NAME,
+  isRecognizedBundleMember
+} from '../utils/translation';
 
 /**
  * Skips TypeScript-only and optional-chaining wrapper nodes so the
@@ -97,43 +75,6 @@ function isTranslatorReference(node: TSESTree.Node): boolean {
 function isTranslatorLoadCall(node: TSESTree.Node): boolean {
   const object = getLoadCallObject(node);
   return object !== null && isTranslatorReference(object);
-}
-
-/**
- * Returns true when a member expression names one of the exact targets the
- * string extractor recognizes as a translation bundle:
- * this.trans, this._trans, props.trans, this.props.trans.
- * See jupyterlab.readthedocs.io/en/stable/extension/internationalization.html#rules
- */
-function isRecognizedBundleMember(node: TSESTree.MemberExpression): boolean {
-  if (node.computed || node.property.type !== 'Identifier') {
-    return false;
-  }
-  const propertyName = node.property.name;
-  const object = node.object;
-
-  // this.trans / this._trans
-  if (object.type === 'ThisExpression') {
-    return BUNDLE_PROPERTY_NAMES.has(propertyName);
-  }
-
-  if (propertyName !== BUNDLE_VARIABLE_NAME) {
-    return false;
-  }
-
-  // props.trans
-  if (object.type === 'Identifier' && object.name === 'props') {
-    return true;
-  }
-
-  // this.props.trans
-  return (
-    object.type === 'MemberExpression' &&
-    !object.computed &&
-    object.object.type === 'ThisExpression' &&
-    object.property.type === 'Identifier' &&
-    object.property.name === 'props'
-  );
 }
 
 /**

--- a/src/rules/incorrect-translator-usage.ts
+++ b/src/rules/incorrect-translator-usage.ts
@@ -9,25 +9,9 @@ import {
   BUNDLE_METHODS,
   BUNDLE_PROPERTY_NAMES,
   BUNDLE_VARIABLE_NAME,
-  isRecognizedBundleMember
+  isRecognizedBundleMember,
+  unwrapExpression
 } from '../utils/translation';
-
-/**
- * Skips TypeScript-only and optional-chaining wrapper nodes so the
- * underlying expression can be inspected.
- */
-function unwrapExpression(node: TSESTree.Node): TSESTree.Node {
-  switch (node.type) {
-    case 'ChainExpression':
-    case 'TSNonNullExpression':
-    case 'TSAsExpression':
-    case 'TSSatisfiesExpression':
-    case 'TSTypeAssertion':
-      return unwrapExpression(node.expression);
-    default:
-      return node;
-  }
-}
 
 /**
  * Returns the object on which `.load(...)` is called when the node is a call

--- a/src/rules/no-dynamic-translation.ts
+++ b/src/rules/no-dynamic-translation.ts
@@ -66,7 +66,7 @@ const noDynamicTranslation = createRule({
       noInterpolation:
         'Do not interpolate values into translation strings. Use a placeholder instead, e.g. trans.__("Delete %1", fileName).',
       noDynamicMessage:
-        'Write the translation string as a literal in the call itself. e.g. trans.__("Kernel %1", status).'
+        'Write the translation string as a literal in the call itself or use a placeholder instead, e.g. trans.__("Kernel %1", status).'
     },
     schema: []
   },

--- a/src/rules/no-dynamic-translation.ts
+++ b/src/rules/no-dynamic-translation.ts
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import { createRule } from '../utils/create-rule';
+import { TSESTree } from '@typescript-eslint/types';
+import {
+  BUNDLE_METHODS,
+  STATIC_ARGUMENT_INDICES,
+  isTransBundle,
+  unwrapExpression
+} from '../utils/translation';
+
+type MessageId = 'noInterpolation' | 'noDynamicMessage';
+
+/**
+ * Returns true when the message is written out at the call site, so the string
+ * extractor can read it straight from the source: a quoted string, or a
+ * template literal with nothing interpolated into it.
+ *
+ * The extractor reads the call site and nothing else — it never follows a
+ * variable to its definition — so anything else leaves it with no message to
+ * extract, however static the value may be at runtime.
+ */
+function isStaticString(node: TSESTree.Node): boolean {
+  const expression = unwrapExpression(node);
+  if (expression.type === 'Literal') {
+    return typeof expression.value === 'string';
+  }
+  if (expression.type === 'TemplateLiteral') {
+    return expression.expressions.length === 0;
+  }
+  return false;
+}
+
+/**
+ * Returns true for a `+` expression. Concatenation is the concern of the
+ * `no-translation-concatenation` rule, so this rule leaves it alone rather than
+ * reporting the same line twice.
+ */
+function isConcatenation(node: TSESTree.Node): boolean {
+  const expression = unwrapExpression(node);
+  return expression.type === 'BinaryExpression' && expression.operator === '+';
+}
+
+/**
+ * Picks the message that best explains why an argument is not extractable.
+ */
+function getMessageId(node: TSESTree.Node): MessageId {
+  return unwrapExpression(node).type === 'TemplateLiteral'
+    ? 'noInterpolation'
+    : 'noDynamicMessage';
+}
+
+const noDynamicTranslation = createRule({
+  name: 'no-dynamic-translation',
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Require translation messages to be written as literals at the call site',
+      url: 'https://eslint-plugin.readthedocs.io/en/latest/rules/no-dynamic-translation/'
+    },
+    messages: {
+      noInterpolation:
+        'Do not interpolate values into translation strings. Use a placeholder instead, e.g. trans.__("Delete %1", fileName).',
+      noDynamicMessage:
+        'Write the translation string as a literal in the call itself. e.g. trans.__("Kernel %1", status).'
+    },
+    schema: []
+  },
+  defaultOptions: [],
+
+  create(context) {
+    return {
+      CallExpression(node) {
+        if (node.callee.type !== 'MemberExpression') {
+          return;
+        }
+        const callee = node.callee;
+        if (callee.computed || callee.property.type !== 'Identifier') {
+          return;
+        }
+        const method = callee.property.name;
+        if (!BUNDLE_METHODS.has(method)) {
+          return;
+        }
+        if (!isTransBundle(callee.object)) {
+          return;
+        }
+
+        for (const index of STATIC_ARGUMENT_INDICES[method]) {
+          const argument = node.arguments[index];
+          if (!argument || isConcatenation(argument)) {
+            continue;
+          }
+          if (!isStaticString(argument)) {
+            context.report({
+              node: argument,
+              messageId: getMessageId(argument)
+            });
+          }
+        }
+      }
+    };
+  }
+});
+
+export = noDynamicTranslation;

--- a/src/rules/no-translation-concatenation.ts
+++ b/src/rules/no-translation-concatenation.ts
@@ -77,7 +77,7 @@ const noTranslationConcatenation = createRule({
     },
     messages: {
       noConcatenation:
-        'Do not use string concatenation inside translation wrappers. Use a placeholder instead, e.g. trans.__("Hello %1", name).',
+        'Do not concatenate values into translation strings. Use a placeholder instead, e.g. trans.__("Hello %1", name).',
       noInterpolation:
         'Do not interpolate values into translation strings. Use a placeholder instead, e.g. trans.__("Delete %1", fileName).',
       noDynamicMessage:
@@ -107,7 +107,7 @@ const noTranslationConcatenation = createRule({
 
         for (const index of STATIC_ARGUMENT_INDICES[method]) {
           const argument = node.arguments[index];
-          if (!argument || argument.type === 'SpreadElement') {
+          if (!argument) {
             continue;
           }
           if (!isStaticString(argument)) {

--- a/src/rules/no-translation-concatenation.ts
+++ b/src/rules/no-translation-concatenation.ts
@@ -5,7 +5,6 @@
 
 import { createRule } from '../utils/create-rule';
 import { TSESTree } from '@typescript-eslint/types';
-import { TSESLint } from '@typescript-eslint/utils';
 import {
   BUNDLE_METHODS,
   STATIC_ARGUMENT_INDICES,
@@ -13,11 +12,6 @@ import {
 } from '../utils/translation';
 
 type MessageId = 'noConcatenation' | 'noInterpolation' | 'noDynamicMessage';
-
-interface Problem {
-  node: TSESTree.Node;
-  messageId: MessageId;
-}
 
 /**
  * Skips TypeScript-only and optional-chaining wrapper nodes so the underlying
@@ -37,30 +31,12 @@ function unwrapExpression(node: TSESTree.Node): TSESTree.Node {
 }
 
 /**
- * Unwraps string methods that pass their receiver's text through, so that
- * `("Delete " + name).trim()` is still judged on the concatenation inside.
- */
-const TRANSPARENT_STRING_METHODS = new Set(['trim', 'trimStart', 'trimEnd']);
-
-function unwrapTransparentCall(node: TSESTree.Node): TSESTree.Node {
-  const expression = unwrapExpression(node);
-  if (
-    expression.type === 'CallExpression' &&
-    expression.arguments.length === 0 &&
-    expression.callee.type === 'MemberExpression' &&
-    !expression.callee.computed &&
-    expression.callee.property.type === 'Identifier' &&
-    TRANSPARENT_STRING_METHODS.has(expression.callee.property.name)
-  ) {
-    return unwrapTransparentCall(expression.callee.object);
-  }
-  return expression;
-}
-
-/**
- * Returns true when the translation string extractor can read this
- * expression's text straight from the source: a string literal, a template
- * literal with no interpolation, or a `+` tree of those.
+ * Returns true when the message is written out at the call site: a string
+ * literal, a template literal with no interpolation, or a `+` tree of those.
+ *
+ * The string extractor reads the call site and nothing else — it never follows
+ * a variable to its definition — so anything else leaves it with no message to
+ * extract, however static the value may be at runtime.
  */
 function isStaticString(node: TSESTree.Node): boolean {
   const expression = unwrapExpression(node);
@@ -77,115 +53,17 @@ function isStaticString(node: TSESTree.Node): boolean {
 }
 
 /**
- * Walks up the scope chain to find the variable an identifier refers to.
+ * Picks the message that best explains why an argument is not extractable.
  */
-function resolveVariable(
-  sourceCode: TSESLint.SourceCode,
-  identifier: TSESTree.Identifier
-): TSESLint.Scope.Variable | null {
-  let scope: TSESLint.Scope.Scope | null = sourceCode.getScope(identifier);
-  while (scope) {
-    const variable = scope.set.get(identifier.name);
-    if (variable) {
-      return variable;
-    }
-    scope = scope.upper;
-  }
-  return null;
-}
-
-/**
- * Returns the single expression that determines a variable's value, or null
- * when that cannot be established with confidence: parameters, imports,
- * destructured bindings, and variables written more than once. Skipping those
- * keeps generic translation helpers such as
- * `function t(key: string) { return trans.__(key); }` quiet.
- */
-function getSoleWrittenExpression(
-  variable: TSESLint.Scope.Variable
-): TSESTree.Node | null {
-  if (variable.defs.length !== 1) {
-    return null;
-  }
-  const [definition] = variable.defs;
-  if (
-    definition.type !== 'Variable' ||
-    definition.node.type !== 'VariableDeclarator' ||
-    definition.node.id.type !== 'Identifier' ||
-    !definition.node.init
-  ) {
-    return null;
-  }
-  const writes = variable.references.filter(reference => reference.isWrite());
-  if (writes.length !== 1 || writes[0].writeExpr !== definition.node.init) {
-    return null;
-  }
-  return definition.node.init;
-}
-
-/**
- * Reports what makes an argument unreadable to the string extractor, or null
- * when the extractor can handle it.
- */
-function classify(
-  sourceCode: TSESLint.SourceCode,
-  node: TSESTree.Node,
-  seen: Set<TSESLint.Scope.Variable>
-): Problem | null {
-  const expression = unwrapTransparentCall(node);
-  if (isStaticString(expression)) {
-    return null;
-  }
-
-  // 'Delete ' + fileName
+function getMessageId(node: TSESTree.Node): MessageId {
+  const expression = unwrapExpression(node);
   if (expression.type === 'BinaryExpression' && expression.operator === '+') {
-    return { node: expression, messageId: 'noConcatenation' };
+    return 'noConcatenation';
   }
-
-  // `Delete ${fileName}`
   if (expression.type === 'TemplateLiteral') {
-    return {
-      node: expression.expressions[0] ?? expression,
-      messageId: 'noInterpolation'
-    };
+    return 'noInterpolation';
   }
-
-  // cond ? 'Yes' : 'No' — both branches are extracted, so check both.
-  if (expression.type === 'ConditionalExpression') {
-    return (
-      classify(sourceCode, expression.consequent, seen) ??
-      classify(sourceCode, expression.alternate, seen)
-    );
-  }
-
-  if (expression.type === 'Identifier') {
-    return classifyIdentifier(sourceCode, expression, seen);
-  }
-
-  // Calls, member access and everything else are left alone: the extractor
-  // cannot read them either, but flagging them would bury the real problems.
-  return null;
-}
-
-function classifyIdentifier(
-  sourceCode: TSESLint.SourceCode,
-  identifier: TSESTree.Identifier,
-  seen: Set<TSESLint.Scope.Variable>
-): Problem | null {
-  const variable = resolveVariable(sourceCode, identifier);
-  if (!variable || seen.has(variable)) {
-    return null;
-  }
-  // Guards against cycles such as `let a = b; let b = a;`.
-  seen.add(variable);
-
-  const written = getSoleWrittenExpression(variable);
-  if (!written) {
-    return null;
-  }
-
-  const problem = classify(sourceCode, written, seen);
-  return problem ? { node: problem.node, messageId: 'noDynamicMessage' } : null;
+  return 'noDynamicMessage';
 }
 
 const noTranslationConcatenation = createRule({
@@ -194,7 +72,7 @@ const noTranslationConcatenation = createRule({
     type: 'problem',
     docs: {
       description:
-        'Forbid dynamically built strings inside translation wrapper calls',
+        'Require translation messages to be written as literals at the call site',
       url: 'https://eslint-plugin.readthedocs.io/en/latest/rules/no-translation-concatenation/'
     },
     messages: {
@@ -203,15 +81,13 @@ const noTranslationConcatenation = createRule({
       noInterpolation:
         'Do not interpolate values into translation strings; the extractor only reads the literal text around ${}. Use a placeholder instead, e.g. trans.__("Delete %1", fileName).',
       noDynamicMessage:
-        'This translation string is built dynamically, so the translation string extractor cannot read it. Pass a literal with placeholders instead, e.g. trans.__("Kernel %1", status).'
+        'Write the translation string as a literal in the call itself. The extractor reads this call site only and does not follow variables or expressions, e.g. trans.__("Kernel %1", status).'
     },
     schema: []
   },
   defaultOptions: [],
 
   create(context) {
-    const sourceCode = context.sourceCode;
-
     return {
       CallExpression(node) {
         if (node.callee.type !== 'MemberExpression') {
@@ -234,11 +110,10 @@ const noTranslationConcatenation = createRule({
           if (!argument || argument.type === 'SpreadElement') {
             continue;
           }
-          const problem = classify(sourceCode, argument, new Set());
-          if (problem) {
+          if (!isStaticString(argument)) {
             context.report({
-              node: problem.node,
-              messageId: problem.messageId
+              node: argument,
+              messageId: getMessageId(argument)
             });
           }
         }

--- a/src/rules/no-translation-concatenation.ts
+++ b/src/rules/no-translation-concatenation.ts
@@ -5,105 +5,187 @@
 
 import { createRule } from '../utils/create-rule';
 import { TSESTree } from '@typescript-eslint/types';
+import { TSESLint } from '@typescript-eslint/utils';
+import {
+  BUNDLE_METHODS,
+  STATIC_ARGUMENT_INDICES,
+  isTransBundle
+} from '../utils/translation';
 
-const TRANS_METHOD = '__';
+type MessageId = 'noConcatenation' | 'noInterpolation' | 'noDynamicMessage';
+
+interface Problem {
+  node: TSESTree.Node;
+  messageId: MessageId;
+}
 
 /**
- * Returns true when every leaf of a `+` expression tree is a string literal.
- * Such concatenation is static and translation tools can handle it.
+ * Skips TypeScript-only and optional-chaining wrapper nodes so the underlying
+ * expression can be inspected.
  */
-function isAllStringLiterals(node: TSESTree.Node): boolean {
-  if (node.type === 'Literal') {
-    return typeof node.value === 'string';
+function unwrapExpression(node: TSESTree.Node): TSESTree.Node {
+  switch (node.type) {
+    case 'ChainExpression':
+    case 'TSNonNullExpression':
+    case 'TSAsExpression':
+    case 'TSSatisfiesExpression':
+    case 'TSTypeAssertion':
+      return unwrapExpression(node.expression);
+    default:
+      return node;
   }
-  if (node.type === 'BinaryExpression' && node.operator === '+') {
-    return isAllStringLiterals(node.left) && isAllStringLiterals(node.right);
+}
+
+/**
+ * Unwraps string methods that pass their receiver's text through, so that
+ * `("Delete " + name).trim()` is still judged on the concatenation inside.
+ */
+const TRANSPARENT_STRING_METHODS = new Set(['trim', 'trimStart', 'trimEnd']);
+
+function unwrapTransparentCall(node: TSESTree.Node): TSESTree.Node {
+  const expression = unwrapExpression(node);
+  if (
+    expression.type === 'CallExpression' &&
+    expression.arguments.length === 0 &&
+    expression.callee.type === 'MemberExpression' &&
+    !expression.callee.computed &&
+    expression.callee.property.type === 'Identifier' &&
+    TRANSPARENT_STRING_METHODS.has(expression.callee.property.name)
+  ) {
+    return unwrapTransparentCall(expression.callee.object);
+  }
+  return expression;
+}
+
+/**
+ * Returns true when the translation string extractor can read this
+ * expression's text straight from the source: a string literal, a template
+ * literal with no interpolation, or a `+` tree of those.
+ */
+function isStaticString(node: TSESTree.Node): boolean {
+  const expression = unwrapExpression(node);
+  if (expression.type === 'Literal') {
+    return typeof expression.value === 'string';
+  }
+  if (expression.type === 'TemplateLiteral') {
+    return expression.expressions.length === 0;
+  }
+  if (expression.type === 'BinaryExpression' && expression.operator === '+') {
+    return isStaticString(expression.left) && isStaticString(expression.right);
   }
   return false;
 }
 
 /**
- * Returns the first `+` BinaryExpression found anywhere in the subtree that
- * involves a non-literal operand, or null if none exists.
+ * Walks up the scope chain to find the variable an identifier refers to.
  */
-function findConcatenation(
-  node: TSESTree.Node
-): TSESTree.BinaryExpression | null {
-  if (node.type === 'BinaryExpression' && node.operator === '+') {
-    return isAllStringLiterals(node) ? null : node;
-  }
-  const record = node as unknown as Record<string, unknown>;
-  for (const key of Object.keys(record)) {
-    if (
-      key === 'type' ||
-      key === 'loc' ||
-      key === 'range' ||
-      key === 'parent'
-    ) {
-      continue;
+function resolveVariable(
+  sourceCode: TSESLint.SourceCode,
+  identifier: TSESTree.Identifier
+): TSESLint.Scope.Variable | null {
+  let scope: TSESLint.Scope.Scope | null = sourceCode.getScope(identifier);
+  while (scope) {
+    const variable = scope.set.get(identifier.name);
+    if (variable) {
+      return variable;
     }
-    const child = record[key];
-    if (child && typeof child === 'object') {
-      if (Array.isArray(child)) {
-        for (const item of child) {
-          if (item && typeof (item as TSESTree.Node).type === 'string') {
-            const found = findConcatenation(item as TSESTree.Node);
-            if (found) return found;
-          }
-        }
-      } else if (typeof (child as TSESTree.Node).type === 'string') {
-        const found = findConcatenation(child as TSESTree.Node);
-        if (found) return found;
-      }
-    }
+    scope = scope.upper;
   }
   return null;
 }
 
 /**
- * Returns true if the node is a recognized JupyterLab translation bundle:
- * trans | this.trans | this._trans | props.trans | this.props.trans
- * See jupyterlab.readthedocs.io/en/stable/extension/internationalization.html#rules
+ * Returns the single expression that determines a variable's value, or null
+ * when that cannot be established with confidence: parameters, imports,
+ * destructured bindings, and variables written more than once. Skipping those
+ * keeps generic translation helpers such as
+ * `function t(key: string) { return trans.__(key); }` quiet.
  */
-function isTransBundle(node: TSESTree.Node): boolean {
-  if (node.type === 'Identifier') {
-    return node.name === 'trans';
+function getSoleWrittenExpression(
+  variable: TSESLint.Scope.Variable
+): TSESTree.Node | null {
+  if (variable.defs.length !== 1) {
+    return null;
+  }
+  const [definition] = variable.defs;
+  if (
+    definition.type !== 'Variable' ||
+    definition.node.type !== 'VariableDeclarator' ||
+    definition.node.id.type !== 'Identifier' ||
+    !definition.node.init
+  ) {
+    return null;
+  }
+  const writes = variable.references.filter(reference => reference.isWrite());
+  if (writes.length !== 1 || writes[0].writeExpr !== definition.node.init) {
+    return null;
+  }
+  return definition.node.init;
+}
+
+/**
+ * Reports what makes an argument unreadable to the string extractor, or null
+ * when the extractor can handle it.
+ */
+function classify(
+  sourceCode: TSESLint.SourceCode,
+  node: TSESTree.Node,
+  seen: Set<TSESLint.Scope.Variable>
+): Problem | null {
+  const expression = unwrapTransparentCall(node);
+  if (isStaticString(expression)) {
+    return null;
   }
 
-  if (node.type === 'MemberExpression' && !node.computed) {
-    const prop = node.property;
-    if (prop.type !== 'Identifier') {
-      return false;
-    }
-
-    // this.trans / this._trans
-    if (node.object.type === 'ThisExpression') {
-      return prop.name === 'trans' || prop.name === '_trans';
-    }
-
-    // props.trans
-    if (
-      prop.name === 'trans' &&
-      node.object.type === 'Identifier' &&
-      node.object.name === 'props'
-    ) {
-      return true;
-    }
-
-    // this.props.trans
-    if (
-      prop.name === 'trans' &&
-      node.object.type === 'MemberExpression' &&
-      !node.object.computed &&
-      node.object.object.type === 'ThisExpression' &&
-      node.object.property.type === 'Identifier' &&
-      node.object.property.name === 'props'
-    ) {
-      return true;
-    }
+  // 'Delete ' + fileName
+  if (expression.type === 'BinaryExpression' && expression.operator === '+') {
+    return { node: expression, messageId: 'noConcatenation' };
   }
 
-  return false;
+  // `Delete ${fileName}`
+  if (expression.type === 'TemplateLiteral') {
+    return {
+      node: expression.expressions[0] ?? expression,
+      messageId: 'noInterpolation'
+    };
+  }
+
+  // cond ? 'Yes' : 'No' — both branches are extracted, so check both.
+  if (expression.type === 'ConditionalExpression') {
+    return (
+      classify(sourceCode, expression.consequent, seen) ??
+      classify(sourceCode, expression.alternate, seen)
+    );
+  }
+
+  if (expression.type === 'Identifier') {
+    return classifyIdentifier(sourceCode, expression, seen);
+  }
+
+  // Calls, member access and everything else are left alone: the extractor
+  // cannot read them either, but flagging them would bury the real problems.
+  return null;
+}
+
+function classifyIdentifier(
+  sourceCode: TSESLint.SourceCode,
+  identifier: TSESTree.Identifier,
+  seen: Set<TSESLint.Scope.Variable>
+): Problem | null {
+  const variable = resolveVariable(sourceCode, identifier);
+  if (!variable || seen.has(variable)) {
+    return null;
+  }
+  // Guards against cycles such as `let a = b; let b = a;`.
+  seen.add(variable);
+
+  const written = getSoleWrittenExpression(variable);
+  if (!written) {
+    return null;
+  }
+
+  const problem = classify(sourceCode, written, seen);
+  return problem ? { node: problem.node, messageId: 'noDynamicMessage' } : null;
 }
 
 const noTranslationConcatenation = createRule({
@@ -112,18 +194,24 @@ const noTranslationConcatenation = createRule({
     type: 'problem',
     docs: {
       description:
-        'Forbid string concatenation inside translation wrapper calls',
+        'Forbid dynamically built strings inside translation wrapper calls',
       url: 'https://eslint-plugin.readthedocs.io/en/latest/rules/no-translation-concatenation/'
     },
     messages: {
       noConcatenation:
-        'Do not use string concatenation inside translation wrappers. Use a placeholder instead, e.g. trans.__("Hello %1", name).'
+        'Do not use string concatenation inside translation wrappers. Use a placeholder instead, e.g. trans.__("Hello %1", name).',
+      noInterpolation:
+        'Do not interpolate values into translation strings; the extractor only reads the literal text around ${}. Use a placeholder instead, e.g. trans.__("Delete %1", fileName).',
+      noDynamicMessage:
+        'This translation string is built dynamically, so the translation string extractor cannot read it. Pass a literal with placeholders instead, e.g. trans.__("Kernel %1", status).'
     },
     schema: []
   },
   defaultOptions: [],
 
   create(context) {
+    const sourceCode = context.sourceCode;
+
     return {
       CallExpression(node) {
         if (node.callee.type !== 'MemberExpression') {
@@ -133,20 +221,26 @@ const noTranslationConcatenation = createRule({
         if (callee.computed || callee.property.type !== 'Identifier') {
           return;
         }
-        if (callee.property.name !== TRANS_METHOD) {
+        const method = callee.property.name;
+        if (!BUNDLE_METHODS.has(method)) {
           return;
         }
         if (!isTransBundle(callee.object)) {
           return;
         }
 
-        const message = node.arguments[0];
-        if (!message) {
-          return;
-        }
-        const concat = findConcatenation(message);
-        if (concat) {
-          context.report({ node: concat, messageId: 'noConcatenation' });
+        for (const index of STATIC_ARGUMENT_INDICES[method]) {
+          const argument = node.arguments[index];
+          if (!argument || argument.type === 'SpreadElement') {
+            continue;
+          }
+          const problem = classify(sourceCode, argument, new Set());
+          if (problem) {
+            context.report({
+              node: problem.node,
+              messageId: problem.messageId
+            });
+          }
         }
       }
     };

--- a/src/rules/no-translation-concatenation.ts
+++ b/src/rules/no-translation-concatenation.ts
@@ -8,35 +8,17 @@ import { TSESTree } from '@typescript-eslint/types';
 import {
   BUNDLE_METHODS,
   STATIC_ARGUMENT_INDICES,
-  isTransBundle
+  isTransBundle,
+  unwrapExpression
 } from '../utils/translation';
 
-type MessageId = 'noConcatenation' | 'noInterpolation' | 'noDynamicMessage';
-
 /**
- * Skips TypeScript-only and optional-chaining wrapper nodes so the underlying
- * expression can be inspected.
- */
-function unwrapExpression(node: TSESTree.Node): TSESTree.Node {
-  switch (node.type) {
-    case 'ChainExpression':
-    case 'TSNonNullExpression':
-    case 'TSAsExpression':
-    case 'TSSatisfiesExpression':
-    case 'TSTypeAssertion':
-      return unwrapExpression(node.expression);
-    default:
-      return node;
-  }
-}
-
-/**
- * Returns true when the message is written out at the call site: a string
- * literal, a template literal with no interpolation, or a `+` tree of those.
+ * Returns true when the expression is text the string extractor can read
+ * straight from the source: a quoted string, a template literal with nothing
+ * interpolated into it, or a `+` tree of those.
  *
- * The string extractor reads the call site and nothing else — it never follows
- * a variable to its definition — so anything else leaves it with no message to
- * extract, however static the value may be at runtime.
+ * Concatenating literals is only ever a source-formatting choice — the
+ * extractor still sees the whole message — so it stays allowed.
  */
 function isStaticString(node: TSESTree.Node): boolean {
   const expression = unwrapExpression(node);
@@ -53,17 +35,23 @@ function isStaticString(node: TSESTree.Node): boolean {
 }
 
 /**
- * Picks the message that best explains why an argument is not extractable.
+ * Returns the message argument's `+` expression when it concatenates something
+ * the extractor cannot read, or null otherwise.
+ *
+ * Only the argument's own top-level form is inspected. A `+` buried inside a
+ * larger expression — `('Delete ' + name).trim()`, `xs.map(x => 'p' + x)` —
+ * is not what reaches the message slot, so reporting it here would point at
+ * the wrong node and duplicate what `no-dynamic-translation` already says
+ * about the argument as a whole.
  */
-function getMessageId(node: TSESTree.Node): MessageId {
+function getDynamicConcatenation(
+  node: TSESTree.Node
+): TSESTree.BinaryExpression | null {
   const expression = unwrapExpression(node);
-  if (expression.type === 'BinaryExpression' && expression.operator === '+') {
-    return 'noConcatenation';
+  if (expression.type !== 'BinaryExpression' || expression.operator !== '+') {
+    return null;
   }
-  if (expression.type === 'TemplateLiteral') {
-    return 'noInterpolation';
-  }
-  return 'noDynamicMessage';
+  return isStaticString(expression) ? null : expression;
 }
 
 const noTranslationConcatenation = createRule({
@@ -72,16 +60,12 @@ const noTranslationConcatenation = createRule({
     type: 'problem',
     docs: {
       description:
-        'Require translation messages to be written as literals at the call site',
+        'Forbid concatenating dynamic values into translation messages',
       url: 'https://eslint-plugin.readthedocs.io/en/latest/rules/no-translation-concatenation/'
     },
     messages: {
       noConcatenation:
-        'Do not concatenate values into translation strings. Use a placeholder instead, e.g. trans.__("Hello %1", name).',
-      noInterpolation:
-        'Do not interpolate values into translation strings. Use a placeholder instead, e.g. trans.__("Delete %1", fileName).',
-      noDynamicMessage:
-        'Write the translation string as a literal in the call itself. e.g. trans.__("Kernel %1", status).'
+        'Do not concatenate values into translation strings; the extractor only reads the literal parts. Use a placeholder instead, e.g. trans.__("Hello %1", name).'
     },
     schema: []
   },
@@ -110,10 +94,11 @@ const noTranslationConcatenation = createRule({
           if (!argument) {
             continue;
           }
-          if (!isStaticString(argument)) {
+          const concatenation = getDynamicConcatenation(argument);
+          if (concatenation) {
             context.report({
-              node: argument,
-              messageId: getMessageId(argument)
+              node: concatenation,
+              messageId: 'noConcatenation'
             });
           }
         }

--- a/src/rules/no-translation-concatenation.ts
+++ b/src/rules/no-translation-concatenation.ts
@@ -79,9 +79,9 @@ const noTranslationConcatenation = createRule({
       noConcatenation:
         'Do not use string concatenation inside translation wrappers. Use a placeholder instead, e.g. trans.__("Hello %1", name).',
       noInterpolation:
-        'Do not interpolate values into translation strings; the extractor only reads the literal text around ${}. Use a placeholder instead, e.g. trans.__("Delete %1", fileName).',
+        'Do not interpolate values into translation strings. Use a placeholder instead, e.g. trans.__("Delete %1", fileName).',
       noDynamicMessage:
-        'Write the translation string as a literal in the call itself. The extractor reads this call site only and does not follow variables or expressions, e.g. trans.__("Kernel %1", status).'
+        'Write the translation string as a literal in the call itself. e.g. trans.__("Kernel %1", status).'
     },
     schema: []
   },

--- a/src/utils/translation.ts
+++ b/src/utils/translation.ts
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import { TSESTree } from '@typescript-eslint/types';
+
+/**
+ * Methods of the TranslationBundle interface from `@jupyterlab/translation`.
+ */
+export const BUNDLE_METHODS = new Set([
+  '__',
+  '_n',
+  '_p',
+  '_np',
+  'gettext',
+  'ngettext',
+  'pgettext',
+  'npgettext',
+  'dcnpgettext'
+]);
+
+/**
+ * Property names under which a translation bundle may be stored so that the
+ * string extractor recognizes its usages (this.trans, this._trans,
+ * this.props.trans, props.trans).
+ * See jupyterlab.readthedocs.io/en/stable/extension/internationalization.html#rules
+ */
+export const BUNDLE_PROPERTY_NAMES = new Set(['trans', '_trans']);
+
+/**
+ * The only accepted name for a local variable holding a translation bundle.
+ */
+export const BUNDLE_VARIABLE_NAME = 'trans';
+
+/**
+ * For each bundle method, the argument indices the string extractor reads
+ * straight from the source and must therefore be static text.
+ *
+ * The `domain` argument of `dcnpgettext` is deliberately left out: it selects a
+ * catalog at runtime, it is not extracted message text.
+ */
+export const STATIC_ARGUMENT_INDICES: Record<string, readonly number[]> = {
+  // (msgid, ...args)
+  __: [0],
+  gettext: [0],
+  // (msgid, msgid_plural, n, ...args)
+  _n: [0, 1],
+  ngettext: [0, 1],
+  // (msgctxt, msgid, ...args)
+  _p: [0, 1],
+  pgettext: [0, 1],
+  // (msgctxt, msgid, msgid_plural, n, ...args)
+  _np: [0, 1, 2],
+  npgettext: [0, 1, 2],
+  // (domain, msgctxt, msgid, msgid_plural, n, ...args)
+  dcnpgettext: [1, 2, 3]
+};
+
+/**
+ * Returns true when a member expression names one of the exact targets the
+ * string extractor recognizes as a translation bundle:
+ * this.trans, this._trans, props.trans, this.props.trans.
+ * See jupyterlab.readthedocs.io/en/stable/extension/internationalization.html#rules
+ */
+export function isRecognizedBundleMember(
+  node: TSESTree.MemberExpression
+): boolean {
+  if (node.computed || node.property.type !== 'Identifier') {
+    return false;
+  }
+  const propertyName = node.property.name;
+  const object = node.object;
+
+  // this.trans / this._trans
+  if (object.type === 'ThisExpression') {
+    return BUNDLE_PROPERTY_NAMES.has(propertyName);
+  }
+
+  if (propertyName !== BUNDLE_VARIABLE_NAME) {
+    return false;
+  }
+
+  // props.trans
+  if (object.type === 'Identifier' && object.name === 'props') {
+    return true;
+  }
+
+  // this.props.trans
+  return (
+    object.type === 'MemberExpression' &&
+    !object.computed &&
+    object.object.type === 'ThisExpression' &&
+    object.property.type === 'Identifier' &&
+    object.property.name === 'props'
+  );
+}
+
+/**
+ * Returns true if the node is a recognized JupyterLab translation bundle:
+ * trans | this.trans | this._trans | props.trans | this.props.trans
+ * See jupyterlab.readthedocs.io/en/stable/extension/internationalization.html#rules
+ */
+export function isTransBundle(node: TSESTree.Node): boolean {
+  if (node.type === 'Identifier') {
+    return node.name === BUNDLE_VARIABLE_NAME;
+  }
+  if (node.type === 'MemberExpression') {
+    return isRecognizedBundleMember(node);
+  }
+  return false;
+}

--- a/src/utils/translation.ts
+++ b/src/utils/translation.ts
@@ -87,7 +87,7 @@ export function isRecognizedBundleMember(
     return false;
   }
   const propertyName = node.property.name;
-  const object = node.object;
+  const object = unwrapExpression(node.object);
 
   // this.trans / this._trans
   if (object.type === 'ThisExpression') {
@@ -116,14 +116,18 @@ export function isRecognizedBundleMember(
 /**
  * Returns true if the node is a recognized JupyterLab translation bundle:
  * trans | this.trans | this._trans | props.trans | this.props.trans
+ *
+ * TypeScript-only wrappers are seen through, so `this.trans!` and
+ * `(trans as any)` are recognized too — they still name the same bundle.
  * See jupyterlab.readthedocs.io/en/stable/extension/internationalization.html#rules
  */
 export function isTransBundle(node: TSESTree.Node): boolean {
-  if (node.type === 'Identifier') {
-    return node.name === BUNDLE_VARIABLE_NAME;
+  const expression = unwrapExpression(node);
+  if (expression.type === 'Identifier') {
+    return expression.name === BUNDLE_VARIABLE_NAME;
   }
-  if (node.type === 'MemberExpression') {
-    return isRecognizedBundleMember(node);
+  if (expression.type === 'MemberExpression') {
+    return isRecognizedBundleMember(expression);
   }
   return false;
 }

--- a/src/utils/translation.ts
+++ b/src/utils/translation.ts
@@ -58,6 +58,23 @@ export const STATIC_ARGUMENT_INDICES: Record<string, readonly number[]> = {
 };
 
 /**
+ * Skips TypeScript-only and optional-chaining wrapper nodes so the underlying
+ * expression can be inspected.
+ */
+export function unwrapExpression(node: TSESTree.Node): TSESTree.Node {
+  switch (node.type) {
+    case 'ChainExpression':
+    case 'TSNonNullExpression':
+    case 'TSAsExpression':
+    case 'TSSatisfiesExpression':
+    case 'TSTypeAssertion':
+      return unwrapExpression(node.expression);
+    default:
+      return node;
+  }
+}
+
+/**
  * Returns true when a member expression names one of the exact targets the
  * string extractor recognizes as a translation bundle:
  * this.trans, this._trans, props.trans, this.props.trans.

--- a/tests/jupyter-no-dynamic-translation.test.ts
+++ b/tests/jupyter-no-dynamic-translation.test.ts
@@ -16,44 +16,25 @@ const ruleTester = new RuleTester({
   }
 });
 
+// The recognized bundle receivers are exercised by the
+// no-translation-concatenation tests; both rules share isTransBundle.
 ruleTester.run('no-dynamic-translation', noDynamicTranslation, {
   valid: [
     { code: `trans.__("Delete %1", fileName)` },
-    { code: `this.trans.__("Hello")` },
-    { code: `this._trans.__("Hello %1", x)` },
-    { code: `this.props.trans.__("Hello")` },
-    { code: `props.trans.__("Hello %1", x)` },
-
-    // A template literal without interpolation is as static as a quoted string
+    // A template literal with nothing interpolated is as static as a quote
     { code: 'trans.__(`Delete this file`)' },
     { code: `trans.__("Delete" as const)` },
 
     // Concatenation belongs to no-translation-concatenation, not to this rule
     { code: `trans.__("Delete " + fileName)` },
-    { code: `this.trans.__("Hello " + name)` },
-    {
-      code: `trans.__('Part 1 of long message.\\n' + 'Part 2 of long message.\\n')`
-    },
 
-    // Other bundle methods, all-static message arguments
-    { code: `trans._n('%1 file', '%1 files', n)` },
-    { code: `trans._p('menu', 'Open')` },
-    { code: `trans._np('menu', '%1 file', '%1 files', n)` },
-    { code: `trans.gettext('Delete')` },
-    { code: `trans.ngettext('%1 file', '%1 files', n)` },
-    { code: `trans.pgettext('menu', 'Open')` },
-    { code: `trans.npgettext('menu', '%1 file', '%1 files', n)` },
+    // Dynamic values outside the extracted message slots are fine
+    { code: 'trans.__("Total %1", `${a}${b}`)' },
+    { code: `trans.__('Delete %1', ...args)` },
     // The domain selects a catalog, it is not extracted message text
     { code: `trans.dcnpgettext(domain, 'menu', '%1 file', '%1 files', n)` },
 
-    // Dynamic values outside the extracted argument slots are fine
-    { code: 'trans.__("Total %1", `${a}${b}`)' },
-    { code: 'trans._n("%1 file", "%1 files", `${n}`)' },
-    { code: `trans.__('Delete %1', 'a' + b)` },
-    { code: `trans.__('Delete %1', ...args)` },
-
     // Not a translation bundle
-    { code: 'logger.__(`Delete ${fileName}`)' },
     { code: 'other.trans.__(`Delete ${fileName}`)' }
   ],
 
@@ -63,52 +44,36 @@ ruleTester.run('no-dynamic-translation', noDynamicTranslation, {
       code: 'trans.__(`Delete ${fileName}`)',
       errors: [{ messageId: 'noInterpolation' }]
     },
+    // A TypeScript wrapper still names the same bundle, at either level
     {
-      code: 'this.trans.__(`Hello ${name}!`)',
+      code: 'this.trans!.__(`Delete ${fileName}`)',
       errors: [{ messageId: 'noInterpolation' }]
     },
     {
-      code: 'this._trans.__(`${count} items`)',
-      errors: [{ messageId: 'noInterpolation' }]
-    },
-    {
-      code: 'props.trans.__(`Kernel ${status}`)',
+      code: '(this as any).trans.__(`Delete ${fileName}`)',
       errors: [{ messageId: 'noInterpolation' }]
     },
 
-    // A message reaching the call through a variable is never extracted
+    // A message reaching the call through a variable is never extracted —
+    // the verbatim jupyter/notebook#8013 shape
     {
       code:
         'let text = `Kernel ${Text.titleCase(status)}`;\n' +
         'widget.node.textContent = trans.__(text);',
       errors: [{ messageId: 'noDynamicMessage' }]
     },
+    // ...even when the variable plainly holds a literal
     {
       code: `const MESSAGE = 'Delete'; trans.__(MESSAGE);`,
       errors: [{ messageId: 'noDynamicMessage' }]
     },
-    {
-      code: `const text = 'Kernel ' + status; trans.__(text);`,
-      errors: [{ messageId: 'noDynamicMessage' }]
-    },
-    {
-      code: `import { MESSAGE } from './messages'; trans.__(MESSAGE);`,
-      errors: [{ messageId: 'noDynamicMessage' }]
-    },
+    // ...and a generic helper is no different
     {
       code: `function t(key: string) { return trans.__(key); }`,
       errors: [{ messageId: 'noDynamicMessage' }]
     },
-    {
-      code: `items.map(s => trans.__(s))`,
-      errors: [{ messageId: 'noDynamicMessage' }]
-    },
 
     // Other expressions the extractor cannot read
-    {
-      code: `trans.__(labels[i])`,
-      errors: [{ messageId: 'noDynamicMessage' }]
-    },
     {
       code: `trans.__(err.message)`,
       errors: [{ messageId: 'noDynamicMessage' }]
@@ -119,10 +84,6 @@ ruleTester.run('no-dynamic-translation', noDynamicTranslation, {
     },
     {
       code: `trans.__(cond ? 'Yes' : 'No')`,
-      errors: [{ messageId: 'noDynamicMessage' }]
-    },
-    {
-      code: `trans.__(['Delete', fileName].join(' '))`,
       errors: [{ messageId: 'noDynamicMessage' }]
     },
     // A concatenation wrapped in a call is no longer a bare `+`, so it is this
@@ -141,7 +102,7 @@ ruleTester.run('no-dynamic-translation', noDynamicTranslation, {
       errors: [{ messageId: 'noDynamicMessage' }]
     },
 
-    // Non-`__` bundle methods, at their own extracted argument positions
+    // Each method's own message positions
     {
       code: 'trans.gettext(`Hi ${x}`)',
       errors: [{ messageId: 'noInterpolation' }]

--- a/tests/jupyter-no-dynamic-translation.test.ts
+++ b/tests/jupyter-no-dynamic-translation.test.ts
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import noDynamicTranslation from '../src/rules/no-dynamic-translation';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parser: require('@typescript-eslint/parser'),
+    parserOptions: {
+      ecmaVersion: 2020,
+      sourceType: 'module'
+    }
+  }
+});
+
+ruleTester.run('no-dynamic-translation', noDynamicTranslation, {
+  valid: [
+    { code: `trans.__("Delete %1", fileName)` },
+    { code: `this.trans.__("Hello")` },
+    { code: `this._trans.__("Hello %1", x)` },
+    { code: `this.props.trans.__("Hello")` },
+    { code: `props.trans.__("Hello %1", x)` },
+
+    // A template literal without interpolation is as static as a quoted string
+    { code: 'trans.__(`Delete this file`)' },
+    { code: `trans.__("Delete" as const)` },
+
+    // Concatenation belongs to no-translation-concatenation, not to this rule
+    { code: `trans.__("Delete " + fileName)` },
+    { code: `this.trans.__("Hello " + name)` },
+    {
+      code: `trans.__('Part 1 of long message.\\n' + 'Part 2 of long message.\\n')`
+    },
+
+    // Other bundle methods, all-static message arguments
+    { code: `trans._n('%1 file', '%1 files', n)` },
+    { code: `trans._p('menu', 'Open')` },
+    { code: `trans._np('menu', '%1 file', '%1 files', n)` },
+    { code: `trans.gettext('Delete')` },
+    { code: `trans.ngettext('%1 file', '%1 files', n)` },
+    { code: `trans.pgettext('menu', 'Open')` },
+    { code: `trans.npgettext('menu', '%1 file', '%1 files', n)` },
+    // The domain selects a catalog, it is not extracted message text
+    { code: `trans.dcnpgettext(domain, 'menu', '%1 file', '%1 files', n)` },
+
+    // Dynamic values outside the extracted argument slots are fine
+    { code: 'trans.__("Total %1", `${a}${b}`)' },
+    { code: 'trans._n("%1 file", "%1 files", `${n}`)' },
+    { code: `trans.__('Delete %1', 'a' + b)` },
+    { code: `trans.__('Delete %1', ...args)` },
+
+    // Not a translation bundle
+    { code: 'logger.__(`Delete ${fileName}`)' },
+    { code: 'other.trans.__(`Delete ${fileName}`)' }
+  ],
+
+  invalid: [
+    // Template literal interpolation — jupyter/notebook#8013
+    {
+      code: 'trans.__(`Delete ${fileName}`)',
+      errors: [{ messageId: 'noInterpolation' }]
+    },
+    {
+      code: 'this.trans.__(`Hello ${name}!`)',
+      errors: [{ messageId: 'noInterpolation' }]
+    },
+    {
+      code: 'this._trans.__(`${count} items`)',
+      errors: [{ messageId: 'noInterpolation' }]
+    },
+    {
+      code: 'props.trans.__(`Kernel ${status}`)',
+      errors: [{ messageId: 'noInterpolation' }]
+    },
+
+    // A message reaching the call through a variable is never extracted
+    {
+      code:
+        'let text = `Kernel ${Text.titleCase(status)}`;\n' +
+        'widget.node.textContent = trans.__(text);',
+      errors: [{ messageId: 'noDynamicMessage' }]
+    },
+    {
+      code: `const MESSAGE = 'Delete'; trans.__(MESSAGE);`,
+      errors: [{ messageId: 'noDynamicMessage' }]
+    },
+    {
+      code: `const text = 'Kernel ' + status; trans.__(text);`,
+      errors: [{ messageId: 'noDynamicMessage' }]
+    },
+    {
+      code: `import { MESSAGE } from './messages'; trans.__(MESSAGE);`,
+      errors: [{ messageId: 'noDynamicMessage' }]
+    },
+    {
+      code: `function t(key: string) { return trans.__(key); }`,
+      errors: [{ messageId: 'noDynamicMessage' }]
+    },
+    {
+      code: `items.map(s => trans.__(s))`,
+      errors: [{ messageId: 'noDynamicMessage' }]
+    },
+
+    // Other expressions the extractor cannot read
+    {
+      code: `trans.__(labels[i])`,
+      errors: [{ messageId: 'noDynamicMessage' }]
+    },
+    {
+      code: `trans.__(err.message)`,
+      errors: [{ messageId: 'noDynamicMessage' }]
+    },
+    {
+      code: `trans.__(format(x))`,
+      errors: [{ messageId: 'noDynamicMessage' }]
+    },
+    {
+      code: `trans.__(cond ? 'Yes' : 'No')`,
+      errors: [{ messageId: 'noDynamicMessage' }]
+    },
+    {
+      code: `trans.__(['Delete', fileName].join(' '))`,
+      errors: [{ messageId: 'noDynamicMessage' }]
+    },
+    // A concatenation wrapped in a call is no longer a bare `+`, so it is this
+    // rule's concern rather than no-translation-concatenation's
+    {
+      code: `trans.__(("Delete " + fileName).trim())`,
+      errors: [{ messageId: 'noDynamicMessage' }]
+    },
+    // A spread lands no readable text in the message slot either
+    {
+      code: `trans.__(...args)`,
+      errors: [{ messageId: 'noDynamicMessage' }]
+    },
+    {
+      code: `trans._n('%1 file', ...rest)`,
+      errors: [{ messageId: 'noDynamicMessage' }]
+    },
+
+    // Non-`__` bundle methods, at their own extracted argument positions
+    {
+      code: 'trans.gettext(`Hi ${x}`)',
+      errors: [{ messageId: 'noInterpolation' }]
+    },
+    {
+      code: 'trans._n("%1 file", `${n} files`, n)',
+      errors: [{ messageId: 'noInterpolation' }]
+    },
+    {
+      code: 'trans._p("menu", `Open ${name}`)',
+      errors: [{ messageId: 'noInterpolation' }]
+    },
+    {
+      code: 'trans._np("menu", "%1 file", `${n} files`, n)',
+      errors: [{ messageId: 'noInterpolation' }]
+    },
+    {
+      code: 'trans.dcnpgettext(domain, "menu", `Open ${name}`, "Opens", n)',
+      errors: [{ messageId: 'noInterpolation' }]
+    },
+
+    // Each extracted argument is reported independently
+    {
+      code: 'trans._n(`${n} file`, `${n} files`, n)',
+      errors: [
+        { messageId: 'noInterpolation' },
+        { messageId: 'noInterpolation' }
+      ]
+    },
+
+    // Outer call is dynamic, inner call interpolates — both are real problems
+    {
+      code: 'trans.__(format(trans.__(`Delete ${fileName}`)))',
+      errors: [
+        { messageId: 'noDynamicMessage' },
+        { messageId: 'noInterpolation' }
+      ]
+    }
+  ]
+});

--- a/tests/jupyter-no-translation-concatenation.test.ts
+++ b/tests/jupyter-no-translation-concatenation.test.ts
@@ -29,7 +29,47 @@ ruleTester.run('no-translation-concatenation', noTranslationConcatenation, {
       code: `trans.__('Part 1 of long message.\\n' + 'Part 2 of long message.\\n')`
     },
     { code: `this.props.trans.__("a" + "b")` },
-    { code: `props.trans.__("a" + "b")` }
+    { code: `props.trans.__("a" + "b")` },
+
+    // A template literal without interpolation is as static as a quoted string
+    { code: 'trans.__(`Delete this file`)' },
+    { code: 'trans.__(`a` + "b")' },
+    { code: `trans.__("Delete" as const)` },
+
+    // Variables resolving to a static string are extractable
+    { code: `const MSG = 'Delete'; trans.__(MSG);` },
+    { code: 'const MSG = `Delete`; trans.__(MSG);' },
+    { code: `const MSG = 'a' + 'b'; trans.__(MSG);` },
+
+    // Variables we cannot resolve with confidence are left alone, so generic
+    // translation helpers do not light up
+    { code: `function t(key: string) { return trans.__(key); }` },
+    { code: `items.map(s => trans.__(s))` },
+    { code: `import { MSG } from './messages'; trans.__(MSG);` },
+    { code: 'let m = "a"; m = `b${x}`; trans.__(m);' },
+
+    // Both ternary branches are extractable
+    { code: `trans.__(cond ? 'Yes' : 'No')` },
+
+    // Out of scope by design: calls and member access
+    { code: `trans.__(labels[i])` },
+    { code: `trans.__(err.message)` },
+    { code: `trans.__(format(x))` },
+
+    // Other bundle methods, all-static arguments
+    { code: `trans._n('%1 file', '%1 files', n)` },
+    { code: `trans._p('menu', 'Open')` },
+    { code: `trans._np('menu', '%1 file', '%1 files', n)` },
+    { code: `trans.gettext('Delete')` },
+    { code: `trans.ngettext('%1 file', '%1 files', n)` },
+    { code: `trans.pgettext('menu', 'Open')` },
+    { code: `trans.npgettext('menu', '%1 file', '%1 files', n)` },
+    { code: `trans.dcnpgettext(domain, 'menu', '%1 file', '%1 files', n)` },
+
+    // Dynamic values outside the extracted argument slots are fine
+    { code: 'trans.__("Total %1", `${a}${b}`)' },
+    { code: 'trans._n("%1 file", "%1 files", `${n}`)' },
+    { code: `trans.__('Delete %1', 'a' + b)` }
   ],
 
   invalid: [
@@ -48,6 +88,89 @@ ruleTester.run('no-translation-concatenation', noTranslationConcatenation, {
     {
       code: `trans.__(("Delete " + fileName).trim())`,
       errors: [{ messageId: 'noConcatenation' }]
+    },
+
+    // Template literal interpolation — jupyter/notebook#8013
+    {
+      code: 'trans.__(`Delete ${fileName}`)',
+      errors: [{ messageId: 'noInterpolation' }]
+    },
+    {
+      code: 'this.trans.__(`Hello ${name}!`)',
+      errors: [{ messageId: 'noInterpolation' }]
+    },
+    {
+      code: 'this._trans.__(`${count} items`)',
+      errors: [{ messageId: 'noInterpolation' }]
+    },
+    {
+      code: 'props.trans.__(`Kernel ${status}`)',
+      errors: [{ messageId: 'noInterpolation' }]
+    },
+
+    // A dynamic string reaching the call through a variable — the exact
+    // shape reported in jupyter/notebook#8013
+    {
+      code:
+        'let text = `Kernel ${Text.titleCase(status)}`;\n' +
+        'widget.node.textContent = trans.__(text);',
+      errors: [{ messageId: 'noDynamicMessage' }]
+    },
+    {
+      code: `const text = 'Kernel ' + status; trans.__(text);`,
+      errors: [{ messageId: 'noDynamicMessage' }]
+    },
+    // Multi-hop indirection
+    {
+      code: 'const a = `x ${y}`; const b = a; trans.__(b);',
+      errors: [{ messageId: 'noDynamicMessage' }]
+    },
+
+    // Non-`__` bundle methods, at their own extracted argument positions
+    {
+      code: 'trans.gettext(`Hi ${x}`)',
+      errors: [{ messageId: 'noInterpolation' }]
+    },
+    {
+      code: 'trans._n("%1 file", `${n} files`, n)',
+      errors: [{ messageId: 'noInterpolation' }]
+    },
+    {
+      code: 'trans._p("menu", `Open ${name}`)',
+      errors: [{ messageId: 'noInterpolation' }]
+    },
+    {
+      code: `trans._p("menu " + section, "Open")`,
+      errors: [{ messageId: 'noConcatenation' }]
+    },
+    {
+      code: 'trans._np("menu", "%1 file", `${n} files`, n)',
+      errors: [{ messageId: 'noInterpolation' }]
+    },
+    {
+      code: 'trans.dcnpgettext(domain, "menu", `Open ${name}`, "Opens", n)',
+      errors: [{ messageId: 'noInterpolation' }]
+    },
+
+    // Only one branch of the ternary is extractable
+    {
+      code: 'trans.__(cond ? "Yes" : `No ${x}`)',
+      errors: [{ messageId: 'noInterpolation' }]
+    },
+
+    // Each extracted argument is reported independently
+    {
+      code: 'trans._n(`${n} file`, `${n} files`, n)',
+      errors: [
+        { messageId: 'noInterpolation' },
+        { messageId: 'noInterpolation' }
+      ]
+    },
+
+    // A nested violation is reported once by the inner call, not twice
+    {
+      code: 'trans.__(format(trans.__(`Delete ${fileName}`)))',
+      errors: [{ messageId: 'noInterpolation' }]
     }
   ]
 });

--- a/tests/jupyter-no-translation-concatenation.test.ts
+++ b/tests/jupyter-no-translation-concatenation.test.ts
@@ -51,6 +51,7 @@ ruleTester.run('no-translation-concatenation', noTranslationConcatenation, {
     { code: 'trans.__("Total %1", `${a}${b}`)' },
     { code: 'trans._n("%1 file", "%1 files", `${n}`)' },
     { code: `trans.__('Delete %1', 'a' + b)` },
+    { code: `trans.__('Delete %1', ...args)` },
 
     // Not a translation bundle
     { code: 'logger.__(`Delete ${fileName}`)' },
@@ -140,6 +141,15 @@ ruleTester.run('no-translation-concatenation', noTranslationConcatenation, {
     },
     {
       code: `trans.__(['Delete', fileName].join(' '))`,
+      errors: [{ messageId: 'noDynamicMessage' }]
+    },
+    // A spread lands no readable text in the message slot either
+    {
+      code: `trans.__(...args)`,
+      errors: [{ messageId: 'noDynamicMessage' }]
+    },
+    {
+      code: `trans._n('%1 file', ...rest)`,
       errors: [{ messageId: 'noDynamicMessage' }]
     },
 

--- a/tests/jupyter-no-translation-concatenation.test.ts
+++ b/tests/jupyter-no-translation-concatenation.test.ts
@@ -31,10 +31,9 @@ ruleTester.run('no-translation-concatenation', noTranslationConcatenation, {
     { code: `this.props.trans.__("a" + "b")` },
     { code: `props.trans.__("a" + "b")` },
 
-    // A template literal without interpolation is as static as a quoted string
-    { code: 'trans.__(`Delete this file`)' },
+    // Template literals without interpolation are as static as quoted strings
+    { code: 'trans.__(`a` + `b`)' },
     { code: 'trans.__(`a` + "b")' },
-    { code: `trans.__("Delete" as const)` },
 
     // Other bundle methods, all-static message arguments
     { code: `trans._n('%1 file', '%1 files', n)` },
@@ -45,17 +44,22 @@ ruleTester.run('no-translation-concatenation', noTranslationConcatenation, {
     { code: `trans.pgettext('menu', 'Open')` },
     { code: `trans.npgettext('menu', '%1 file', '%1 files', n)` },
     // The domain selects a catalog, it is not extracted message text
-    { code: `trans.dcnpgettext(domain, 'menu', '%1 file', '%1 files', n)` },
+    { code: `trans.dcnpgettext(domain + suffix, 'menu', 'a', 'b', n)` },
 
-    // Dynamic values outside the extracted argument slots are fine
-    { code: 'trans.__("Total %1", `${a}${b}`)' },
-    { code: 'trans._n("%1 file", "%1 files", `${n}`)' },
-    { code: `trans.__('Delete %1', 'a' + b)` },
-    { code: `trans.__('Delete %1', ...args)` },
+    // Concatenation outside the extracted argument slots is fine
+    { code: `trans._n('%1 file', '%1 files', a + b)` },
+    { code: `trans._p('menu', 'Open', a + b)` },
 
     // Not a translation bundle
-    { code: 'logger.__(`Delete ${fileName}`)' },
-    { code: 'other.trans.__(`Delete ${fileName}`)' }
+    { code: `logger.__("Delete " + fileName)` },
+    { code: `other.trans.__("Delete " + fileName)` },
+
+    // Not a concatenation at all — no-dynamic-translation reports these
+    { code: 'trans.__(`Delete ${fileName}`)' },
+    { code: `trans.__(message)` },
+    // The `+` is not what reaches the message slot; the call result is
+    { code: `trans.__(("Delete " + fileName).trim())` },
+    { code: `trans.__(items.map(s => "p" + s).join(""))` }
   ],
 
   invalid: [
@@ -72,129 +76,55 @@ ruleTester.run('no-translation-concatenation', noTranslationConcatenation, {
       errors: [{ messageId: 'noConcatenation' }]
     },
     {
-      code: `trans.__(("Delete " + fileName).trim())`,
-      errors: [{ messageId: 'noDynamicMessage' }]
+      code: `this.props.trans.__("Hello " + name)`,
+      errors: [{ messageId: 'noConcatenation' }]
     },
-
-    // Template literal interpolation — jupyter/notebook#8013
+    // A TypeScript wrapper does not change what reaches the message slot
     {
-      code: 'trans.__(`Delete ${fileName}`)',
-      errors: [{ messageId: 'noInterpolation' }]
+      code: `trans.__(("Delete " + fileName) as string)`,
+      errors: [{ messageId: 'noConcatenation' }]
     },
+    // A template literal is static only with nothing interpolated into it
     {
-      code: 'this.trans.__(`Hello ${name}!`)',
-      errors: [{ messageId: 'noInterpolation' }]
-    },
-    {
-      code: 'this._trans.__(`${count} items`)',
-      errors: [{ messageId: 'noInterpolation' }]
-    },
-    {
-      code: 'props.trans.__(`Kernel ${status}`)',
-      errors: [{ messageId: 'noInterpolation' }]
-    },
-
-    // A message reaching the call through a variable is never extracted
-    {
-      code:
-        'let text = `Kernel ${Text.titleCase(status)}`;\n' +
-        'widget.node.textContent = trans.__(text);',
-      errors: [{ messageId: 'noDynamicMessage' }]
-    },
-    {
-      code: `const MESSAGE = 'Delete'; trans.__(MESSAGE);`,
-      errors: [{ messageId: 'noDynamicMessage' }]
-    },
-    {
-      code: `const text = 'Kernel ' + status; trans.__(text);`,
-      errors: [{ messageId: 'noDynamicMessage' }]
-    },
-    {
-      code: `import { MESSAGE } from './messages'; trans.__(MESSAGE);`,
-      errors: [{ messageId: 'noDynamicMessage' }]
-    },
-    {
-      code: `function t(key: string) { return trans.__(key); }`,
-      errors: [{ messageId: 'noDynamicMessage' }]
-    },
-    {
-      code: `items.map(s => trans.__(s))`,
-      errors: [{ messageId: 'noDynamicMessage' }]
-    },
-
-    // Other expressions the extractor cannot read
-    {
-      code: `trans.__(labels[i])`,
-      errors: [{ messageId: 'noDynamicMessage' }]
-    },
-    {
-      code: `trans.__(err.message)`,
-      errors: [{ messageId: 'noDynamicMessage' }]
-    },
-    {
-      code: `trans.__(format(x))`,
-      errors: [{ messageId: 'noDynamicMessage' }]
-    },
-    {
-      code: `trans.__(cond ? 'Yes' : 'No')`,
-      errors: [{ messageId: 'noDynamicMessage' }]
-    },
-    {
-      code: `trans.__(['Delete', fileName].join(' '))`,
-      errors: [{ messageId: 'noDynamicMessage' }]
-    },
-    // A spread lands no readable text in the message slot either
-    {
-      code: `trans.__(...args)`,
-      errors: [{ messageId: 'noDynamicMessage' }]
-    },
-    {
-      code: `trans._n('%1 file', ...rest)`,
-      errors: [{ messageId: 'noDynamicMessage' }]
+      code: 'trans.__(`Delete ` + `${fileName}`)',
+      errors: [{ messageId: 'noConcatenation' }]
     },
 
     // Non-`__` bundle methods, at their own extracted argument positions
     {
-      code: 'trans.gettext(`Hi ${x}`)',
-      errors: [{ messageId: 'noInterpolation' }]
+      code: `trans.gettext("Hi " + x)`,
+      errors: [{ messageId: 'noConcatenation' }]
     },
     {
-      code: 'trans._n("%1 file", `${n} files`, n)',
-      errors: [{ messageId: 'noInterpolation' }]
-    },
-    {
-      code: 'trans._p("menu", `Open ${name}`)',
-      errors: [{ messageId: 'noInterpolation' }]
+      code: `trans._n("%1 file", "%1 " + word, n)`,
+      errors: [{ messageId: 'noConcatenation' }]
     },
     {
       code: `trans._p("menu " + section, "Open")`,
       errors: [{ messageId: 'noConcatenation' }]
     },
     {
-      code: 'trans._np("menu", "%1 file", `${n} files`, n)',
-      errors: [{ messageId: 'noInterpolation' }]
+      code: `trans._np("menu", "%1 file", "%1 " + word, n)`,
+      errors: [{ messageId: 'noConcatenation' }]
     },
     {
-      code: 'trans.dcnpgettext(domain, "menu", `Open ${name}`, "Opens", n)',
-      errors: [{ messageId: 'noInterpolation' }]
+      code: `trans.dcnpgettext(domain, "menu", "Open " + name, "Opens", n)`,
+      errors: [{ messageId: 'noConcatenation' }]
     },
 
     // Each extracted argument is reported independently
     {
-      code: 'trans._n(`${n} file`, `${n} files`, n)',
+      code: `trans._n("%1 " + a, "%1 " + b, n)`,
       errors: [
-        { messageId: 'noInterpolation' },
-        { messageId: 'noInterpolation' }
+        { messageId: 'noConcatenation' },
+        { messageId: 'noConcatenation' }
       ]
     },
 
-    // Outer call is dynamic, inner call interpolates — both are real problems
+    // A nested call reports on its own, not through the outer one
     {
-      code: 'trans.__(format(trans.__(`Delete ${fileName}`)))',
-      errors: [
-        { messageId: 'noDynamicMessage' },
-        { messageId: 'noInterpolation' }
-      ]
+      code: `trans.__(format(trans.__("Delete " + fileName)))`,
+      errors: [{ messageId: 'noConcatenation' }]
     }
   ]
 });

--- a/tests/jupyter-no-translation-concatenation.test.ts
+++ b/tests/jupyter-no-translation-concatenation.test.ts
@@ -19,50 +19,36 @@ const ruleTester = new RuleTester({
 ruleTester.run('no-translation-concatenation', noTranslationConcatenation, {
   valid: [
     { code: `trans.__("Delete %1", fileName)` },
-    { code: `this.trans.__("Hello")` },
-    { code: `this._trans.__("Hello %1", x)` },
-    { code: `this.props.trans.__("Hello")` },
-    { code: `props.trans.__("Hello %1", x)` },
-    { code: `trans.__('Total %1', a + b)` },
-    // Pure string literal concatenation is static — translation tools handle it
+    // Literal concatenation stays readable, so it is a fine way to break up a
+    // long message
     {
       code: `trans.__('Part 1 of long message.\\n' + 'Part 2 of long message.\\n')`
     },
-    { code: `this.props.trans.__("a" + "b")` },
-    { code: `props.trans.__("a" + "b")` },
-
-    // Template literals without interpolation are as static as quoted strings
+    // A template literal with nothing interpolated is as static as a quote
     { code: 'trans.__(`a` + `b`)' },
-    { code: 'trans.__(`a` + "b")' },
 
-    // Other bundle methods, all-static message arguments
-    { code: `trans._n('%1 file', '%1 files', n)` },
-    { code: `trans._p('menu', 'Open')` },
-    { code: `trans._np('menu', '%1 file', '%1 files', n)` },
-    { code: `trans.gettext('Delete')` },
-    { code: `trans.ngettext('%1 file', '%1 files', n)` },
-    { code: `trans.pgettext('menu', 'Open')` },
-    { code: `trans.npgettext('menu', '%1 file', '%1 files', n)` },
+    // Concatenation outside the extracted message slots is fine
+    { code: `trans._n('%1 file', '%1 files', a + b)` },
     // The domain selects a catalog, it is not extracted message text
     { code: `trans.dcnpgettext(domain + suffix, 'menu', 'a', 'b', n)` },
 
-    // Concatenation outside the extracted argument slots is fine
-    { code: `trans._n('%1 file', '%1 files', a + b)` },
-    { code: `trans._p('menu', 'Open', a + b)` },
-
     // Not a translation bundle
-    { code: `logger.__("Delete " + fileName)` },
     { code: `other.trans.__("Delete " + fileName)` },
+    { code: `getBundle().__("Delete " + fileName)` },
+    // The extractor matches by name, so computed access is not a match
+    { code: `trans["__"]("Delete " + fileName)` },
+    { code: `this["trans"].__("Delete " + fileName)` },
+    // No message argument to check
+    { code: `trans.__()` },
 
-    // Not a concatenation at all — no-dynamic-translation reports these
+    // Not a concatenation — no-dynamic-translation reports these instead
     { code: 'trans.__(`Delete ${fileName}`)' },
-    { code: `trans.__(message)` },
     // The `+` is not what reaches the message slot; the call result is
-    { code: `trans.__(("Delete " + fileName).trim())` },
-    { code: `trans.__(items.map(s => "p" + s).join(""))` }
+    { code: `trans.__(("Delete " + fileName).trim())` }
   ],
 
   invalid: [
+    // Each recognized bundle receiver
     {
       code: `trans.__("Delete " + fileName)`,
       errors: [{ messageId: 'noConcatenation' }]
@@ -76,10 +62,23 @@ ruleTester.run('no-translation-concatenation', noTranslationConcatenation, {
       errors: [{ messageId: 'noConcatenation' }]
     },
     {
+      code: `props.trans.__("Hello " + name)`,
+      errors: [{ messageId: 'noConcatenation' }]
+    },
+    {
       code: `this.props.trans.__("Hello " + name)`,
       errors: [{ messageId: 'noConcatenation' }]
     },
-    // A TypeScript wrapper does not change what reaches the message slot
+    // A TypeScript wrapper does not change which bundle the call is on
+    {
+      code: `this.trans!.__("Delete " + fileName)`,
+      errors: [{ messageId: 'noConcatenation' }]
+    },
+    {
+      code: `(trans as any).__("Delete " + fileName)`,
+      errors: [{ messageId: 'noConcatenation' }]
+    },
+    // ...nor what reaches the message slot
     {
       code: `trans.__(("Delete " + fileName) as string)`,
       errors: [{ messageId: 'noConcatenation' }]
@@ -90,7 +89,7 @@ ruleTester.run('no-translation-concatenation', noTranslationConcatenation, {
       errors: [{ messageId: 'noConcatenation' }]
     },
 
-    // Non-`__` bundle methods, at their own extracted argument positions
+    // Each method's own message positions
     {
       code: `trans.gettext("Hi " + x)`,
       errors: [{ messageId: 'noConcatenation' }]

--- a/tests/jupyter-no-translation-concatenation.test.ts
+++ b/tests/jupyter-no-translation-concatenation.test.ts
@@ -19,6 +19,11 @@ const ruleTester = new RuleTester({
 ruleTester.run('no-translation-concatenation', noTranslationConcatenation, {
   valid: [
     { code: `trans.__("Delete %1", fileName)` },
+    { code: `this.trans.__("Hello")` },
+    { code: `this._trans.__("Hello %1", x)` },
+    { code: `this.props.trans.__("Hello")` },
+    { code: `props.trans.__("Hello %1", x)` },
+    { code: `trans.__('Total %1', a + b)` },
     // Literal concatenation stays readable, so it is a fine way to break up a
     // long message
     {

--- a/tests/jupyter-no-translation-concatenation.test.ts
+++ b/tests/jupyter-no-translation-concatenation.test.ts
@@ -93,8 +93,7 @@ ruleTester.run('no-translation-concatenation', noTranslationConcatenation, {
       errors: [{ messageId: 'noInterpolation' }]
     },
 
-    // A message reaching the call through a variable is never extracted, no
-    // matter what the variable holds — the extractor reads the call site only.
+    // A message reaching the call through a variable is never extracted
     {
       code:
         'let text = `Kernel ${Text.titleCase(status)}`;\n' +

--- a/tests/jupyter-no-translation-concatenation.test.ts
+++ b/tests/jupyter-no-translation-concatenation.test.ts
@@ -36,27 +36,7 @@ ruleTester.run('no-translation-concatenation', noTranslationConcatenation, {
     { code: 'trans.__(`a` + "b")' },
     { code: `trans.__("Delete" as const)` },
 
-    // Variables resolving to a static string are extractable
-    { code: `const MSG = 'Delete'; trans.__(MSG);` },
-    { code: 'const MSG = `Delete`; trans.__(MSG);' },
-    { code: `const MSG = 'a' + 'b'; trans.__(MSG);` },
-
-    // Variables we cannot resolve with confidence are left alone, so generic
-    // translation helpers do not light up
-    { code: `function t(key: string) { return trans.__(key); }` },
-    { code: `items.map(s => trans.__(s))` },
-    { code: `import { MSG } from './messages'; trans.__(MSG);` },
-    { code: 'let m = "a"; m = `b${x}`; trans.__(m);' },
-
-    // Both ternary branches are extractable
-    { code: `trans.__(cond ? 'Yes' : 'No')` },
-
-    // Out of scope by design: calls and member access
-    { code: `trans.__(labels[i])` },
-    { code: `trans.__(err.message)` },
-    { code: `trans.__(format(x))` },
-
-    // Other bundle methods, all-static arguments
+    // Other bundle methods, all-static message arguments
     { code: `trans._n('%1 file', '%1 files', n)` },
     { code: `trans._p('menu', 'Open')` },
     { code: `trans._np('menu', '%1 file', '%1 files', n)` },
@@ -64,12 +44,17 @@ ruleTester.run('no-translation-concatenation', noTranslationConcatenation, {
     { code: `trans.ngettext('%1 file', '%1 files', n)` },
     { code: `trans.pgettext('menu', 'Open')` },
     { code: `trans.npgettext('menu', '%1 file', '%1 files', n)` },
+    // The domain selects a catalog, it is not extracted message text
     { code: `trans.dcnpgettext(domain, 'menu', '%1 file', '%1 files', n)` },
 
     // Dynamic values outside the extracted argument slots are fine
     { code: 'trans.__("Total %1", `${a}${b}`)' },
     { code: 'trans._n("%1 file", "%1 files", `${n}`)' },
-    { code: `trans.__('Delete %1', 'a' + b)` }
+    { code: `trans.__('Delete %1', 'a' + b)` },
+
+    // Not a translation bundle
+    { code: 'logger.__(`Delete ${fileName}`)' },
+    { code: 'other.trans.__(`Delete ${fileName}`)' }
   ],
 
   invalid: [
@@ -87,7 +72,7 @@ ruleTester.run('no-translation-concatenation', noTranslationConcatenation, {
     },
     {
       code: `trans.__(("Delete " + fileName).trim())`,
-      errors: [{ messageId: 'noConcatenation' }]
+      errors: [{ messageId: 'noDynamicMessage' }]
     },
 
     // Template literal interpolation — jupyter/notebook#8013
@@ -108,8 +93,8 @@ ruleTester.run('no-translation-concatenation', noTranslationConcatenation, {
       errors: [{ messageId: 'noInterpolation' }]
     },
 
-    // A dynamic string reaching the call through a variable — the exact
-    // shape reported in jupyter/notebook#8013
+    // A message reaching the call through a variable is never extracted, no
+    // matter what the variable holds — the extractor reads the call site only.
     {
       code:
         'let text = `Kernel ${Text.titleCase(status)}`;\n' +
@@ -117,12 +102,45 @@ ruleTester.run('no-translation-concatenation', noTranslationConcatenation, {
       errors: [{ messageId: 'noDynamicMessage' }]
     },
     {
+      code: `const MESSAGE = 'Delete'; trans.__(MESSAGE);`,
+      errors: [{ messageId: 'noDynamicMessage' }]
+    },
+    {
       code: `const text = 'Kernel ' + status; trans.__(text);`,
       errors: [{ messageId: 'noDynamicMessage' }]
     },
-    // Multi-hop indirection
     {
-      code: 'const a = `x ${y}`; const b = a; trans.__(b);',
+      code: `import { MESSAGE } from './messages'; trans.__(MESSAGE);`,
+      errors: [{ messageId: 'noDynamicMessage' }]
+    },
+    {
+      code: `function t(key: string) { return trans.__(key); }`,
+      errors: [{ messageId: 'noDynamicMessage' }]
+    },
+    {
+      code: `items.map(s => trans.__(s))`,
+      errors: [{ messageId: 'noDynamicMessage' }]
+    },
+
+    // Other expressions the extractor cannot read
+    {
+      code: `trans.__(labels[i])`,
+      errors: [{ messageId: 'noDynamicMessage' }]
+    },
+    {
+      code: `trans.__(err.message)`,
+      errors: [{ messageId: 'noDynamicMessage' }]
+    },
+    {
+      code: `trans.__(format(x))`,
+      errors: [{ messageId: 'noDynamicMessage' }]
+    },
+    {
+      code: `trans.__(cond ? 'Yes' : 'No')`,
+      errors: [{ messageId: 'noDynamicMessage' }]
+    },
+    {
+      code: `trans.__(['Delete', fileName].join(' '))`,
       errors: [{ messageId: 'noDynamicMessage' }]
     },
 
@@ -152,12 +170,6 @@ ruleTester.run('no-translation-concatenation', noTranslationConcatenation, {
       errors: [{ messageId: 'noInterpolation' }]
     },
 
-    // Only one branch of the ternary is extractable
-    {
-      code: 'trans.__(cond ? "Yes" : `No ${x}`)',
-      errors: [{ messageId: 'noInterpolation' }]
-    },
-
     // Each extracted argument is reported independently
     {
       code: 'trans._n(`${n} file`, `${n} files`, n)',
@@ -167,10 +179,13 @@ ruleTester.run('no-translation-concatenation', noTranslationConcatenation, {
       ]
     },
 
-    // A nested violation is reported once by the inner call, not twice
+    // Outer call is dynamic, inner call interpolates — both are real problems
     {
       code: 'trans.__(format(trans.__(`Delete ${fileName}`)))',
-      errors: [{ messageId: 'noInterpolation' }]
+      errors: [
+        { messageId: 'noDynamicMessage' },
+        { messageId: 'noInterpolation' }
+      ]
     }
   ]
 });

--- a/website/docs/rules/index.md
+++ b/website/docs/rules/index.md
@@ -7,6 +7,7 @@ This section documents all rules currently provided by `eslint-plugin-jupyter`.
 - [command-described-by](./command-described-by)
 - [galata-prefer-filebrowser-helper](./galata-prefer-filebrowser-helper)
 - [incorrect-translator-usage](./incorrect-translator-usage)
+- [no-dynamic-translation](./no-dynamic-translation)
 - [no-schema-enum](./no-schema-enum)
 - [no-translation-concatenation](./no-translation-concatenation)
 - [no-pageconfig-base-url](./no-pageconfig-base-url)
@@ -31,6 +32,7 @@ The plugin ships with a recommended configuration that enables all current rules
 | [jupyter/no-untranslated-string](./no-untranslated-string)                                     | `warn`   |
 | [jupyter/plugin-description](./plugin-description)                                             | `warn`   |
 | [jupyter/no-translation-concatenation](./no-translation-concatenation)                         | `error`  |
+| [jupyter/no-dynamic-translation](./no-dynamic-translation)                                     | `warn`   |
 | [jupyter/token-format](./token-format)                                                         | `error`  |
 | [jupyter/require-disposable-ownership](./require-disposable-ownership)                         | `warn`   |
 | [jupyter/require-disposable-transfer](./require-disposable-transfer)                           | `warn`   |

--- a/website/docs/rules/no-dynamic-translation.md
+++ b/website/docs/rules/no-dynamic-translation.md
@@ -1,0 +1,72 @@
+# `no-dynamic-translation`
+
+Require JupyterLab translation messages to be written as literals at the call
+site.
+
+## Why
+
+The translation string extractor reads your source statically — it never runs
+it, and it never looks anywhere but the call itself. So whatever message you
+want translated has to be spelled out inside the call:
+
+```ts
+trans.__(`Delete ${fileName}`); // template interpolation
+trans.__(message); // a variable
+```
+
+In both cases the extractor finds no message to put in the catalog, so the
+string is never translated.
+
+This holds even when the variable obviously holds a plain string:
+
+```ts
+const MESSAGE = 'Delete';
+trans.__(MESSAGE); // still not extracted
+```
+
+The extractor does not follow `MESSAGE` to its definition. It sees an
+identifier where a message should be, and moves on.
+
+See [Rules](https://jupyterlab.readthedocs.io/en/stable/extension/internationalization.html#rules).
+
+## Rule details
+
+The rule checks calls to any `TranslationBundle` method on a recognized
+translation bundle — `trans`, `this.trans`, `this._trans`, `props.trans`, or
+`this.props.trans`.
+
+A message argument must be either a string literal or a template literal with
+no interpolation. Anything else is reported: variables, property access,
+function calls, conditionals, spread arguments, and interpolated template
+literals.
+
+Only the arguments that carry message text are checked. For
+`trans.__(msgid, ...args)` that is `msgid` alone — the placeholder arguments
+after it are exactly where dynamic values belong. The other methods follow the
+same idea.
+
+## Incorrect
+
+```ts
+trans.__(`Delete ${fileName}`);
+trans._n('%1 file', `${n} files`, n);
+
+let text = `Kernel ${Text.titleCase(status)}`;
+widget.node.textContent = trans.__(text);
+
+const MESSAGE = 'Delete';
+trans.__(MESSAGE);
+```
+
+## Correct
+
+```ts
+trans.__('Delete %1', fileName);
+trans._n('%1 file', '%1 files', n);
+
+widget.node.textContent = trans.__('Kernel %1', Text.titleCase(status));
+```
+
+## Options
+
+This rule has no options.

--- a/website/docs/rules/no-dynamic-translation.md
+++ b/website/docs/rules/no-dynamic-translation.md
@@ -45,6 +45,20 @@ Only the arguments that carry message text are checked. For
 after it are exactly where dynamic values belong. The other methods follow the
 same idea.
 
+### Known limitation
+
+The rule cannot tell that a value already reached the catalog by another route.
+Settings schema text, for example, is extracted from the JSON itself, so
+`trans._p('schema', schema.description)` is translated even though the argument
+is not a literal — but it is still reported.
+
+There is no option for this; silence the individual call site instead:
+
+```ts
+// eslint-disable-next-line jupyter/no-dynamic-translation
+trans._p('schema', schema.description);
+```
+
 ## Incorrect
 
 ```ts

--- a/website/docs/rules/no-translation-concatenation.md
+++ b/website/docs/rules/no-translation-concatenation.md
@@ -1,24 +1,35 @@
 # `no-translation-concatenation`
 
-Forbid dynamically built strings inside JupyterLab translation wrapper calls.
+Require JupyterLab translation messages to be written as literals at the call
+site.
 
 ## Why
 
-Translation extractors read your source statically — they never run it. So the
-message passed to `trans.__()` has to be readable straight from the file. Three
-common patterns break that, all for the same reason:
+The translation string extractor reads your source statically — it never runs
+it, and it never looks anywhere but the call itself. So whatever message you
+want translated has to be spelled out inside the call:
 
 ```ts
 trans.__('Delete ' + fileName); // concatenation
 trans.__(`Delete ${fileName}`); // template interpolation
-
-let text = `Kernel ${status}`; // a dynamic string reaching the call
-trans.__(text); //   through a variable
+trans.__(message); // a variable
 ```
 
-In every case the extractor sees no complete message, so the string is never translated. Pure literal concatenation
-(`'a' + 'b'`) and a template literal with no interpolation (`` `a` ``) are still
-static, so both are allowed.
+In every case the extractor finds no message to put in the catalog, so the
+string is never translated.
+
+This holds even when the variable obviously holds a plain string:
+
+```ts
+const MESSAGE = 'Delete';
+trans.__(MESSAGE); // still not extracted
+```
+
+The extractor does not follow `MESSAGE` to its definition. It sees an
+identifier where a message should be, and moves on.
+
+Literal concatenation (`'a' + 'b'`) and template literals with no interpolation
+(`` `a` ``) are spelled out in the call, so both are fine.
 
 See [Rules](https://jupyterlab.readthedocs.io/en/stable/extension/internationalization.html#rules).
 
@@ -28,18 +39,21 @@ The rule checks calls to any `TranslationBundle` method on a recognized
 translation bundle — `trans`, `this.trans`, `this._trans`, `props.trans`, or
 `this.props.trans`.
 
-For `trans.__(msgid, ...args)`, the rule checks only `msgid`.
+A message argument must be one of:
 
-Dynamic values should go in later placeholder arguments (`...args`), which are
-not checked.
+- a string literal,
+- a template literal with no interpolation, or
+- a `+` concatenation of those.
 
-If `msgid` is an identifier, the rule follows it to its definition. A variable
-assigned once from a static string is allowed; one built with concatenation or
-template interpolation is reported. If the value cannot be resolved reliably
-(for example, parameters, imports, or variables reassigned), it is ignored.
+Anything else is reported: variables, property access, function calls,
+conditionals, and interpolated template literals.
 
-Other translation methods follow the same idea: only message-text arguments are
-checked.
+Only the arguments that carry message text are checked. For
+`trans.__(msgid, ...args)` that is `msgid` alone — the placeholder arguments
+after it are exactly where dynamic values belong. The other methods follow the
+same idea: `_n`/`ngettext` check the singular and plural, `_p`/`pgettext` check
+the context and message, and `dcnpgettext` checks everything except its
+`domain`, which selects a catalog rather than carrying text.
 
 ## Incorrect
 
@@ -50,6 +64,9 @@ trans._n('%1 file', `${n} files`, n);
 
 let text = `Kernel ${Text.titleCase(status)}`;
 widget.node.textContent = trans.__(text);
+
+const MESSAGE = 'Delete';
+trans.__(MESSAGE);
 ```
 
 ## Correct
@@ -60,11 +77,8 @@ trans._n('%1 file', '%1 files', n);
 
 widget.node.textContent = trans.__('Kernel %1', Text.titleCase(status));
 
-// Still static, so still fine:
+// Spelled out in the call, so still fine:
 trans.__('Part 1 of long message.\n' + 'Part 2 of long message.\n');
-
-const MESSAGE = 'Delete';
-trans.__(MESSAGE);
 ```
 
 ## Options

--- a/website/docs/rules/no-translation-concatenation.md
+++ b/website/docs/rules/no-translation-concatenation.md
@@ -1,32 +1,70 @@
 # `no-translation-concatenation`
 
-Forbid string concatenation inside JupyterLab translation wrapper calls.
+Forbid dynamically built strings inside JupyterLab translation wrapper calls.
 
 ## Why
 
-Translation extractors only pick up static string content in calls like `trans.__("...")`. Pure string-literal concatenation (for example, `"a" + "b"`) is still static and allowed, but concatenation with a variable (for example, `"Hello " + name`) is dynamic and cannot be extracted, so it never gets translated.
+Translation extractors read your source statically — they never run it. So the
+message passed to `trans.__()` has to be readable straight from the file. Three
+common patterns break that, all for the same reason:
+
+```ts
+trans.__('Delete ' + fileName); // concatenation
+trans.__(`Delete ${fileName}`); // template interpolation
+
+let text = `Kernel ${status}`; // a dynamic string reaching the call
+trans.__(text); //   through a variable
+```
+
+In every case the extractor sees no complete message, so the string is never translated. Pure literal concatenation
+(`'a' + 'b'`) and a template literal with no interpolation (`` `a` ``) are still
+static, so both are allowed.
+
 See [Rules](https://jupyterlab.readthedocs.io/en/stable/extension/internationalization.html#rules).
 
 ## Rule details
 
-The rule reports any `+` binary expression passed as an argument to a translation method (`__`) called on a recognized translation bundle:
+The rule checks calls to any `TranslationBundle` method on a recognized
+translation bundle — `trans`, `this.trans`, `this._trans`, `props.trans`, or
+`this.props.trans`.
 
-- `trans`
-- `this.trans`
-- `this._trans`
-- `this.props.trans`
-- `props.trans`
+For `trans.__(msgid, ...args)`, the rule checks only `msgid`.
+
+Dynamic values should go in later placeholder arguments (`...args`), which are
+not checked.
+
+If `msgid` is an identifier, the rule follows it to its definition. A variable
+assigned once from a static string is allowed; one built with concatenation or
+template interpolation is reported. If the value cannot be resolved reliably
+(for example, parameters, imports, or variables reassigned), it is ignored.
+
+Other translation methods follow the same idea: only message-text arguments are
+checked.
 
 ## Incorrect
 
 ```ts
-this.trans.__('Hello ' + userName);
+trans.__('Delete ' + fileName);
+trans.__(`Delete ${fileName}`);
+trans._n('%1 file', `${n} files`, n);
+
+let text = `Kernel ${Text.titleCase(status)}`;
+widget.node.textContent = trans.__(text);
 ```
 
 ## Correct
 
 ```ts
-this.trans.__('Hello %1', userName);
+trans.__('Delete %1', fileName);
+trans._n('%1 file', '%1 files', n);
+
+widget.node.textContent = trans.__('Kernel %1', Text.titleCase(status));
+
+// Still static, so still fine:
+trans.__('Part 1 of long message.\n' + 'Part 2 of long message.\n');
+
+const MESSAGE = 'Delete';
+trans.__(MESSAGE);
 ```
 
 ## Options

--- a/website/docs/rules/no-translation-concatenation.md
+++ b/website/docs/rules/no-translation-concatenation.md
@@ -46,7 +46,7 @@ A message argument must be one of:
 - a `+` concatenation of those.
 
 Anything else is reported: variables, property access, function calls,
-conditionals, and interpolated template literals.
+conditionals, spread arguments, and interpolated template literals.
 
 Only the arguments that carry message text are checked. For
 `trans.__(msgid, ...args)` that is `msgid` alone — the placeholder arguments

--- a/website/docs/rules/no-translation-concatenation.md
+++ b/website/docs/rules/no-translation-concatenation.md
@@ -1,35 +1,21 @@
 # `no-translation-concatenation`
 
-Require JupyterLab translation messages to be written as literals at the call
-site.
+Forbid concatenating dynamic values into JupyterLab translation messages.
 
 ## Why
 
 The translation string extractor reads your source statically — it never runs
-it, and it never looks anywhere but the call itself. So whatever message you
-want translated has to be spelled out inside the call:
+it. When a message is built with `+`, only the literal parts are in the source,
+so the extractor has nothing complete to put in the catalog and the string
+never gets translated:
 
 ```ts
-trans.__('Delete ' + fileName); // concatenation
-trans.__(`Delete ${fileName}`); // template interpolation
-trans.__(message); // a variable
+trans.__('Hello ' + userName); // never extracted
 ```
 
-In every case the extractor finds no message to put in the catalog, so the
-string is never translated.
-
-This holds even when the variable obviously holds a plain string:
-
-```ts
-const MESSAGE = 'Delete';
-trans.__(MESSAGE); // still not extracted
-```
-
-The extractor does not follow `MESSAGE` to its definition. It sees an
-identifier where a message should be, and moves on.
-
-Literal concatenation (`'a' + 'b'`) and template literals with no interpolation
-(`` `a` ``) are spelled out in the call, so both are fine.
+Concatenating literals is different. `'a' + 'b'` is only a source-formatting
+choice — the extractor still sees the whole message — so it stays allowed, and
+is a useful way to break a long string across lines.
 
 See [Rules](https://jupyterlab.readthedocs.io/en/stable/extension/internationalization.html#rules).
 
@@ -39,14 +25,10 @@ The rule checks calls to any `TranslationBundle` method on a recognized
 translation bundle — `trans`, `this.trans`, `this._trans`, `props.trans`, or
 `this.props.trans`.
 
-A message argument must be one of:
-
-- a string literal,
-- a template literal with no interpolation, or
-- a `+` concatenation of those.
-
-Anything else is reported: variables, property access, function calls,
-conditionals, spread arguments, and interpolated template literals.
+A message argument is reported when its own top-level form is a `+` expression
+with at least one operand the extractor cannot read. String literals and
+template literals with no interpolation count as readable, so a `+` tree made
+only of those is fine.
 
 Only the arguments that carry message text are checked. For
 `trans.__(msgid, ...args)` that is `msgid` alone — the placeholder arguments
@@ -58,26 +40,19 @@ the context and message, and `dcnpgettext` checks everything except its
 ## Incorrect
 
 ```ts
-trans.__('Delete ' + fileName);
-trans.__(`Delete ${fileName}`);
-trans._n('%1 file', `${n} files`, n);
-
-let text = `Kernel ${Text.titleCase(status)}`;
-widget.node.textContent = trans.__(text);
-
-const MESSAGE = 'Delete';
-trans.__(MESSAGE);
+this.trans.__('Hello ' + userName);
+trans._p('menu ' + section, 'Open');
+trans._n('%1 file', '%1 ' + word, n);
 ```
 
 ## Correct
 
 ```ts
-trans.__('Delete %1', fileName);
+this.trans.__('Hello %1', userName);
+trans._p('menu', 'Open');
 trans._n('%1 file', '%1 files', n);
 
-widget.node.textContent = trans.__('Kernel %1', Text.titleCase(status));
-
-// Spelled out in the call, so still fine:
+// Literal concatenation is still readable, so it stays fine:
 trans.__('Part 1 of long message.\n' + 'Part 2 of long message.\n');
 ```
 

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -22,6 +22,7 @@ const sidebars: SidebarsConfig = {
         'rules/command-described-by',
         'rules/galata-prefer-filebrowser-helper',
         'rules/incorrect-translator-usage',
+        'rules/no-dynamic-translation',
         'rules/no-pageconfig-base-url',
         'rules/no-schema-enum',
         'rules/no-translation-concatenation',


### PR DESCRIPTION
## Fixes #90

### Description
`no-translation-concatenation` only caught `+` concatenation in `trans.__()` and missed the cases from jupyter/notebook#8013.

Adds a new rule, **`no-dynamic-translation`**, for everything else that isn't readable at the call site — interpolated templates, variables, calls, member access, conditionals, spreads:

```ts
trans.__(`Delete ${fileName}`);   // interpolation
trans.__(text);                   // variable
```

The two rules split by form, so nothing is reported twice and nothing falls between them. Added at warn in recommended ruleset.
