### PR TITLE
Drop owner constructor maps, replace by type-aware heuristic

### DIFF
--- a/src/utils/disposables.ts
+++ b/src/utils/disposables.ts
@@ -1445,7 +1445,11 @@ function getParameterTypeForArgument(
       // into it rather than collapsing to the union of its elements.
       if (checker.isTupleType(type)) {
         const elements = checker.getTypeArguments(type as ts.TypeReference);
-        return elements[argumentIndex] ?? elements[elements.length - 1] ?? type;
+        // The rest parameter is always last, so `index` is its position and
+        // the argument lands at that offset into the tuple. Without this,
+        // `(a: number, ...rest: [D, X])` maps the first rest argument to `X`.
+        const offset = argumentIndex - index;
+        return elements[offset] ?? elements[elements.length - 1] ?? type;
       }
       return checker.getIndexTypeOfType(type, ts.IndexKind.Number) ?? type;
     }
@@ -1659,8 +1663,18 @@ function getObjectExpression(
  * declared type of its options parameter rather than from a table of known
  * JupyterLab classes.
  */
+/**
+ * The option names a call or constructor takes ownership of at one argument
+ * position, read from the declared type of that parameter rather than from a
+ * table of known JupyterLab classes.
+ *
+ * Scoped per argument: two parameters may both declare a `payload` property
+ * with only one of them disposable, and crediting the wrong one would suppress
+ * a real finding.
+ */
 function getManagedOptionNames(
   node: TSESTree.CallExpression | TSESTree.NewExpression,
+  argumentIndex: number,
   ownership: DisposableOwnershipContext
 ): string[] {
   const { checker } = ownership;
@@ -1668,34 +1682,30 @@ function getManagedOptionNames(
     return [];
   }
 
+  const type = getParameterTypeForArgument(node, argumentIndex, ownership);
+  if (!type) {
+    return [];
+  }
+
   const names: string[] = [];
-  node.arguments.forEach((_argument, index) => {
-    // Every parameter is inspected, not only inline object literals: the
-    // options bag is often held in a variable at the call site.
-    const type = getParameterTypeForArgument(node, index, ownership);
-    if (!type) {
-      return;
+  for (const property of type.getProperties()) {
+    const declaration = property.valueDeclaration ?? property.declarations?.[0];
+    if (!declaration) {
+      continue;
     }
-    for (const property of type.getProperties()) {
-      const declaration =
-        property.valueDeclaration ?? property.declarations?.[0];
-      if (!declaration) {
-        continue;
+    try {
+      if (
+        isDisposableTypeCached(
+          checker.getTypeOfSymbolAtLocation(property, declaration),
+          checker
+        )
+      ) {
+        names.push(property.getName());
       }
-      try {
-        if (
-          isDisposableTypeCached(
-            checker.getTypeOfSymbolAtLocation(property, declaration),
-            checker
-          )
-        ) {
-          names.push(property.getName());
-        }
-      } catch {
-        // Unresolvable property type: not an ownership claim.
-      }
+    } catch {
+      // Unresolvable property type: not an ownership claim.
     }
-  });
+  }
   return names;
 }
 
@@ -1704,19 +1714,19 @@ function markManagedKnownOptionVariables(
   node: TSESTree.CallExpression | TSESTree.NewExpression,
   ownership: DisposableOwnershipContext
 ): void {
-  const optionNames = getManagedOptionNames(node, ownership);
-  if (optionNames.length === 0) {
-    return;
-  }
-
-  for (const argument of node.arguments) {
+  node.arguments.forEach((argument, index) => {
     if (argument.type === 'ObjectExpression') {
-      continue;
+      return;
     }
 
     const object = getObjectExpression(ownership.sourceCode, argument);
     if (!object) {
-      continue;
+      return;
+    }
+
+    const optionNames = getManagedOptionNames(node, index, ownership);
+    if (optionNames.length === 0) {
+      return;
     }
 
     for (const property of object.properties) {
@@ -1727,7 +1737,7 @@ function markManagedKnownOptionVariables(
         markManagedVariables(pending, property.value, ownership);
       }
     }
-  }
+  });
 }
 
 function isOptionsObjectValueManaged(

--- a/src/utils/disposables.ts
+++ b/src/utils/disposables.ts
@@ -1478,14 +1478,32 @@ function isOwnershipArgument(
     return true;
   }
 
-  const index = call.arguments.indexOf(
+  let index = call.arguments.indexOf(
     argument as TSESTree.CallExpressionArgument
   );
+  let elementOfArrayArgument = false;
+
   if (index < 0) {
-    return false;
+    // `new Owner([disposable])`: the element binds to the element type of the
+    // parameter, not to the parameter itself.
+    const array = argument.parent;
+    if (
+      array?.type === 'ArrayExpression' &&
+      array.elements.includes(argument as TSESTree.Expression)
+    ) {
+      index = call.arguments.indexOf(array as TSESTree.CallExpressionArgument);
+      elementOfArrayArgument = index >= 0;
+    }
+    if (!elementOfArrayArgument) {
+      return false;
+    }
   }
 
-  const type = getParameterTypeForArgument(call, index, ownership);
+  let type = getParameterTypeForArgument(call, index, ownership);
+  if (type && elementOfArrayArgument && ownership.checker) {
+    type =
+      ownership.checker.getIndexTypeOfType(type, ts.IndexKind.Number) ?? type;
+  }
   return (
     type !== null &&
     ownership.checker !== null &&
@@ -1980,13 +1998,14 @@ export function isDisposableExpressionManaged(
     return true;
   }
 
-  if (parent.type === 'CallExpression') {
+  if (parent.type === 'CallExpression' || parent.type === 'NewExpression') {
     return isOwnershipArgument(parent, expression, ownership);
   }
 
   if (
     parent.type === 'ArrayExpression' &&
-    parent.parent?.type === 'CallExpression'
+    (parent.parent?.type === 'CallExpression' ||
+      parent.parent?.type === 'NewExpression')
   ) {
     return isOwnershipArgument(parent.parent, expression, ownership);
   }

--- a/src/utils/disposables.ts
+++ b/src/utils/disposables.ts
@@ -19,32 +19,6 @@ const DISPOSABLE_CONSTRUCTOR_NAMES = [
 
 const DISPOSABLE_SET_NAMES = ['DisposableSet', 'ObservableDisposableSet'];
 
-const OWNED_CONSTRUCTOR_OPTION_NAMES = new Map([
-  ['CodeCell', ['model']],
-  ['CodeEditorWrapper', ['model']],
-  ['CodeViewerWidget', ['model']],
-  ['Collapser', ['widget']],
-  ['DocumentWidget', ['content']],
-  ['FileBrowser', ['model']],
-  ['FileEditorWidget', ['content']],
-  ['Dialog', ['body']],
-  ['Licenses', ['model']],
-  ['MainAreaWidget', ['content']],
-  ['MarkdownDocument', ['content']],
-  ['MarkdownViewer', ['renderer']],
-  ['MimeContent', ['renderer']],
-  ['MimeDocument', ['content']],
-  ['NotebookPanel', ['content']],
-  ['RawCell', ['model']]
-]);
-
-const OWNED_FUNCTION_OPTION_NAMES = new Map([
-  ['createNew', ['sharedModel']],
-  ['createNotebook', ['kernelHistory']],
-  ['open', ['editorWrapper']],
-  ['showPopup', ['body']]
-]);
-
 const FLUENT_DISPOSABLE_METHOD_NAMES = ['initializeState'];
 
 /**
@@ -277,30 +251,6 @@ function isOwnershipFunctionCall(
   return name !== null && ownership.ownershipFunctionNames.has(name);
 }
 
-function getReceiverName(node: TSESTree.Node): string | null {
-  if (node.type === 'Identifier') {
-    return node.name;
-  }
-  if (
-    node.type === 'MemberExpression' &&
-    !node.computed &&
-    node.property.type === 'Identifier'
-  ) {
-    return node.property.name;
-  }
-  return null;
-}
-
-function isLikelyDisposableSet(node: TSESTree.Node): boolean {
-  const name = getReceiverName(node);
-  return name === 'disposables' || name === '_disposables';
-}
-
-function isLikelyDisposableProperty(node: TSESTree.Node): boolean {
-  const name = getReceiverName(node);
-  return name === 'disposablesProperty';
-}
-
 export function isDisposableConstructor(node: TSESTree.NewExpression): boolean {
   const name = getCalleeName(node.callee);
   return name !== null && DISPOSABLE_CONSTRUCTOR_NAMES.includes(name);
@@ -423,17 +373,23 @@ function getIdentifierVariables(
 
   if (node.type === 'ArrayExpression') {
     return node.elements.flatMap(element =>
-      element && element.type !== 'SpreadElement'
-        ? getIdentifierVariables(sourceCode, element, seen)
+      element
+        ? getIdentifierVariables(
+            sourceCode,
+            element.type === 'SpreadElement' ? element.argument : element,
+            seen
+          )
         : []
     );
   }
 
   if (node.type === 'ObjectExpression') {
     return node.properties.flatMap(property =>
-      property.type === 'Property'
-        ? getIdentifierVariables(sourceCode, property.value, seen)
-        : []
+      getIdentifierVariables(
+        sourceCode,
+        property.type === 'Property' ? property.value : property.argument,
+        seen
+      )
     );
   }
 
@@ -922,7 +878,8 @@ function isEscapingUse(node: TSESTree.Node): boolean {
  */
 function isCapturedByReturnedClosure(
   identifier: TSESTree.Node,
-  variable: TSESLint.Scope.Variable
+  variable: TSESLint.Scope.Variable,
+  ownership?: DisposableOwnershipContext
 ): boolean {
   const declaringFunction = getFunctionScope(variable.scope)?.block;
   if (!declaringFunction) {
@@ -931,14 +888,42 @@ function isCapturedByReturnedClosure(
 
   let fn = getEnclosingFunction(identifier);
   while (fn && fn !== declaringFunction) {
-    const expression = getOuterExpression(fn);
+    // The closure may be returned directly, or sit in an object or array that
+    // is returned, possibly via the variable holding it:
+    // `const thisObject = { get: () => dummy.x }; return thisObject;`
+    // A closure handed to a wrapper call escapes if the wrapper's result does:
+    // `jest.fn(() => dummy.x)` as a property of a returned object.
+    let escaped: TSESTree.Node = fn;
+    for (;;) {
+      const outer = getOuterExpression(escaped);
+      const wrapper = outer.parent;
+      if (
+        wrapper?.type === 'CallExpression' &&
+        wrapper.arguments.includes(outer as TSESTree.CallExpressionArgument)
+      ) {
+        escaped = wrapper;
+        continue;
+      }
+      break;
+    }
+
+    const expression = getOuterExpression(
+      getManagedAggregateExpression(escaped) ?? escaped
+    );
     const parent = expression.parent;
 
+    const holder = ownership
+      ? getAggregateHolderVariable(expression, ownership)
+      : null;
+    const returnedViaHolder =
+      holder !== null && isVariableHandedOff(holder, ownership!);
+
     const returnedFromDeclaringFunction =
-      parent?.type === 'ReturnStatement' &&
-      parent.argument === expression &&
-      getEnclosingFunction(parent) === declaringFunction &&
-      isUnconditionalWithinFunction(parent);
+      returnedViaHolder ||
+      (parent?.type === 'ReturnStatement' &&
+        parent.argument === expression &&
+        getEnclosingFunction(parent) === declaringFunction &&
+        isUnconditionalWithinFunction(parent));
 
     // `const make = () => () => items.use()` returns implicitly.
     const isImplicitReturnBody =
@@ -976,9 +961,8 @@ function isReferenceHandedToOwnershipCall(
   while (parent && !isFunctionLike(parent)) {
     if (parent.type === 'CallExpression') {
       return (
-        getOwnershipArguments(parent, ownership).includes(
-          current as TSESTree.CallExpressionArgument
-        ) && isUnconditionalWithinFunction(parent)
+        isOwnershipArgument(parent, current, ownership) &&
+        isUnconditionalWithinFunction(parent)
       );
     }
 
@@ -1027,7 +1011,9 @@ export function isDisposedByNestedFunction(
       continue;
     }
 
-    if (isCapturedByReturnedClosure(reference.identifier, variable)) {
+    if (
+      isCapturedByReturnedClosure(reference.identifier, variable, ownership)
+    ) {
       return true;
     }
 
@@ -1315,13 +1301,6 @@ function isDialogType(
   return hasExpressionTypeOrHeritageName(node, ownership, ['Dialog']);
 }
 
-function isDocumentWidgetType(
-  node: TSESTree.Node,
-  ownership: DisposableOwnershipContext
-): boolean {
-  return hasExpressionTypeOrHeritageName(node, ownership, ['DocumentWidget']);
-}
-
 function isOwnershipAddCall(
   node: TSESTree.CallExpression,
   ownership: DisposableOwnershipContext
@@ -1333,10 +1312,7 @@ function isOwnershipAddCall(
     return false;
   }
 
-  return (
-    isDisposableSetType(node.callee.object, ownership) ||
-    isLikelyDisposableSet(node.callee.object)
-  );
+  return isDisposableSetType(node.callee.object, ownership);
 }
 
 function isOwnershipSetCall(
@@ -1350,10 +1326,7 @@ function isOwnershipSetCall(
     return false;
   }
 
-  return (
-    isAttachedPropertyType(node.callee.object, ownership) ||
-    isLikelyDisposableProperty(node.callee.object)
-  );
+  return isAttachedPropertyType(node.callee.object, ownership);
 }
 
 export function isClassFieldCollectionMutationCall(
@@ -1379,7 +1352,212 @@ function isArrayExtInsertCall(
   );
 }
 
+/**
+ * Ownership is decided by what the callee declares, not by its name: an API
+ * that types a parameter as a disposable is saying it takes something with a
+ * lifecycle, while one typing it `any` is not.
+ *
+ * Signature resolution is the expensive part of this rule, so results are
+ * memoised per call node and per type for the lifetime of the file.
+ */
+const signatureCache = new WeakMap<TSESTree.Node, ts.Signature | null>();
+const disposableTypeCache = new WeakMap<ts.Type, boolean>();
+
+function isDisposableTypeCached(
+  type: ts.Type,
+  checker: ts.TypeChecker
+): boolean {
+  const cached = disposableTypeCache.get(type);
+  if (cached !== undefined) {
+    return cached;
+  }
+  const result = isDisposableType(type, checker);
+  disposableTypeCache.set(type, result);
+  return result;
+}
+
+function getResolvedSignatureCached(
+  call: TSESTree.CallExpression | TSESTree.NewExpression,
+  ownership: DisposableOwnershipContext
+): ts.Signature | null {
+  const cached = signatureCache.get(call);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  let signature: ts.Signature | null = null;
+  const { checker, services } = ownership;
+  if (checker && services) {
+    try {
+      const tsNode = services.esTreeNodeToTSNodeMap.get(
+        call as TSESTree.Node
+      ) as ts.CallLikeExpression | undefined;
+      signature = tsNode
+        ? (checker.getResolvedSignature(tsNode) ?? null)
+        : null;
+    } catch {
+      signature = null;
+    }
+  }
+  signatureCache.set(call, signature);
+  return signature;
+}
+
+function getParameterTypeForArgument(
+  call: TSESTree.CallExpression | TSESTree.NewExpression,
+  argumentIndex: number,
+  ownership: DisposableOwnershipContext
+): ts.Type | null {
+  const { checker } = ownership;
+  if (!checker) {
+    return null;
+  }
+
+  const signature = getResolvedSignatureCached(call, ownership);
+  const parameters = signature?.getParameters() ?? [];
+  if (parameters.length === 0) {
+    return null;
+  }
+
+  try {
+    const index = Math.min(argumentIndex, parameters.length - 1);
+    const parameter = parameters[index];
+    const declaration =
+      parameter.valueDeclaration ?? parameter.declarations?.[0];
+    if (!declaration) {
+      return null;
+    }
+    // An optional parameter or one with a default is typed `T | undefined`,
+    // and `getProperty` on a union only reports properties present in every
+    // constituent. Strip the nullish part so `showDialog(options = {})` still
+    // exposes its option types.
+    const type = checker.getNonNullableType(
+      checker.getTypeOfSymbolAtLocation(parameter, declaration)
+    );
+    // A rest parameter is declared as an array; the argument binds to its
+    // element type. `console.log(x)` has `...data: any[]`, so this matters.
+    if (
+      ts.isParameter(declaration) &&
+      declaration.dotDotDotToken !== undefined
+    ) {
+      // A tuple rest parameter still names each position, as in jest's
+      // `new (...args: [IOptions, IKernelConnection | null]) => T`, so index
+      // into it rather than collapsing to the union of its elements.
+      if (checker.isTupleType(type)) {
+        const elements = checker.getTypeArguments(type as ts.TypeReference);
+        return elements[argumentIndex] ?? elements[elements.length - 1] ?? type;
+      }
+      return checker.getIndexTypeOfType(type, ts.IndexKind.Number) ?? type;
+    }
+    return type;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Whether this specific argument is one the callee takes ownership of. Lazy by
+ * design: callers ask about the one argument they care about, so a call whose
+ * arguments are all uninteresting never costs a signature resolution.
+ */
+function isOwnershipArgument(
+  call: TSESTree.CallExpression | TSESTree.NewExpression,
+  argument: TSESTree.Node,
+  ownership: DisposableOwnershipContext
+): boolean {
+  if (call.callee.type === 'Super') {
+    return true;
+  }
+
+  // Checked first: a named sink may own something that is not a direct
+  // argument, such as an element of the array in `DisposableSet.from([...])`.
+  if (
+    call.type === 'CallExpression' &&
+    isNamedOwnershipSink(call, argument, ownership)
+  ) {
+    return true;
+  }
+
+  const index = call.arguments.indexOf(
+    argument as TSESTree.CallExpressionArgument
+  );
+  if (index < 0) {
+    return false;
+  }
+
+  const type = getParameterTypeForArgument(call, index, ownership);
+  return (
+    type !== null &&
+    ownership.checker !== null &&
+    isDisposableTypeCached(type, ownership.checker)
+  );
+}
+
+/**
+ * The options-object form: the disposable is a property of an object literal
+ * argument, so the question is whether that property is declared disposable.
+ */
+function isTypedOwnedOptionProperty(
+  call: TSESTree.CallExpression | TSESTree.NewExpression,
+  argumentIndex: number,
+  propertyName: string,
+  ownership: DisposableOwnershipContext
+): boolean {
+  const { checker } = ownership;
+  const type = getParameterTypeForArgument(call, argumentIndex, ownership);
+  if (!type || !checker) {
+    return false;
+  }
+  const property = type.getProperty(propertyName);
+  const declaration =
+    property?.valueDeclaration ?? property?.declarations?.[0] ?? null;
+  if (!property || !declaration) {
+    return false;
+  }
+  try {
+    return isDisposableTypeCached(
+      checker.getTypeOfSymbolAtLocation(property, declaration),
+      checker
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * The remaining name-based sinks: an escape hatch for APIs whose types are too
+ * loose for the check above (notably test mocks typed as `any`), configured
+ * through `ownershipFunctionNames`, plus the shapes that types cannot express
+ * (a `super(...)` handoff, `DisposableSet.from([...])` unwrapping an array,
+ * `this._items.push(...)` into a field collection).
+ */
+function isNamedOwnershipSink(
+  node: TSESTree.CallExpression,
+  argument: TSESTree.Node,
+  ownership: DisposableOwnershipContext
+): boolean {
+  return getOwnershipArgumentsByName(node, ownership).includes(
+    argument as TSESTree.CallExpressionArgument
+  );
+}
+
 function getOwnershipArguments(
+  node: TSESTree.CallExpression,
+  ownership: DisposableOwnershipContext
+): TSESTree.CallExpressionArgument[] {
+  // Named sinks can name things that are not direct arguments (array elements
+  // of `DisposableSet.from([...])`), so they are unioned in rather than
+  // filtered out of `node.arguments`.
+  const named = getOwnershipArgumentsByName(node, ownership);
+  const typed = node.arguments.filter(
+    argument =>
+      !named.includes(argument) &&
+      isOwnershipArgument(node, argument, ownership)
+  );
+  return [...named, ...typed];
+}
+
+function getOwnershipArgumentsByName(
   node: TSESTree.CallExpression,
   ownership: DisposableOwnershipContext
 ): TSESTree.CallExpressionArgument[] {
@@ -1458,27 +1636,49 @@ function getObjectExpression(
   return null;
 }
 
+/**
+ * The option names a call or constructor takes ownership of, read from the
+ * declared type of its options parameter rather than from a table of known
+ * JupyterLab classes.
+ */
 function getManagedOptionNames(
   node: TSESTree.CallExpression | TSESTree.NewExpression,
   ownership: DisposableOwnershipContext
 ): string[] {
-  if (node.type === 'NewExpression') {
-    const constructorName = getCalleeName(node.callee);
-    const names =
-      constructorName === null
-        ? []
-        : (OWNED_CONSTRUCTOR_OPTION_NAMES.get(constructorName) ?? []);
-    return [
-      ...names,
-      ...(isDialogType(node, ownership) ? ['body'] : []),
-      ...(isDocumentWidgetType(node, ownership) ? ['content'] : [])
-    ];
+  const { checker } = ownership;
+  if (!checker) {
+    return [];
   }
 
-  const calleeName = getCalleeName(node.callee);
-  return calleeName === null
-    ? []
-    : (OWNED_FUNCTION_OPTION_NAMES.get(calleeName) ?? []);
+  const names: string[] = [];
+  node.arguments.forEach((_argument, index) => {
+    // Every parameter is inspected, not only inline object literals: the
+    // options bag is often held in a variable at the call site.
+    const type = getParameterTypeForArgument(node, index, ownership);
+    if (!type) {
+      return;
+    }
+    for (const property of type.getProperties()) {
+      const declaration =
+        property.valueDeclaration ?? property.declarations?.[0];
+      if (!declaration) {
+        continue;
+      }
+      try {
+        if (
+          isDisposableTypeCached(
+            checker.getTypeOfSymbolAtLocation(property, declaration),
+            checker
+          )
+        ) {
+          names.push(property.getName());
+        }
+      } catch {
+        // Unresolvable property type: not an ownership claim.
+      }
+    }
+  });
+  return names;
 }
 
 function markManagedKnownOptionVariables(
@@ -1548,39 +1748,21 @@ function isOptionsObjectValueManaged(
     return false;
   }
 
-  if (parent.type === 'NewExpression') {
-    const constructorName = getCalleeName(parent.callee);
-    return (
-      propertyName !== null &&
-      ((constructorName !== null &&
-        (OWNED_CONSTRUCTOR_OPTION_NAMES.get(constructorName)?.includes(
-          propertyName
-        ) ??
-          false)) ||
-        (propertyName === 'body' && isDialogType(parent, ownership)) ||
-        (propertyName === 'content' && isDocumentWidgetType(parent, ownership)))
+  if (propertyName !== null) {
+    const argumentIndex = parent.arguments.indexOf(
+      object as TSESTree.CallExpressionArgument
     );
-  }
-
-  if (getCalleeName(parent.callee) === 'showDialog') {
-    return propertyName === 'body';
-  }
-
-  const calleeName = getCalleeName(parent.callee);
-  if (
-    calleeName !== null &&
-    propertyName !== null &&
-    (OWNED_FUNCTION_OPTION_NAMES.get(calleeName)?.includes(propertyName) ??
-      false)
-  ) {
-    return true;
+    if (
+      argumentIndex >= 0 &&
+      isTypedOwnedOptionProperty(parent, argumentIndex, propertyName, ownership)
+    ) {
+      return true;
+    }
   }
 
   return (
     parent.callee.type === 'Super' ||
-    getOwnershipArguments(parent, ownership).includes(
-      object as TSESTree.CallExpressionArgument
-    )
+    isOwnershipArgument(parent, object, ownership)
   );
 }
 
@@ -1599,6 +1781,13 @@ function getManagedAggregateExpression(
       continue;
     }
 
+    if (parent.type === 'SpreadElement' && parent.argument === current) {
+      current = parent;
+      parent = current.parent;
+      foundAggregate = true;
+      continue;
+    }
+
     if (
       parent.type === 'ArrayExpression' &&
       parent.elements.includes(current as TSESTree.Expression)
@@ -1611,7 +1800,9 @@ function getManagedAggregateExpression(
 
     if (
       parent.type === 'ObjectExpression' &&
-      parent.properties.includes(current as TSESTree.Property)
+      parent.properties.includes(
+        current as TSESTree.Property | TSESTree.SpreadElement
+      )
     ) {
       current = parent;
       parent = current.parent;
@@ -1623,6 +1814,85 @@ function getManagedAggregateExpression(
   }
 
   return foundAggregate ? current : null;
+}
+
+/**
+ * Checks whether a variable is itself handed off: returned, assigned to a
+ * field, or passed to an ownership sink. Used to follow a disposable one hop
+ * further, through the variable that holds the aggregate containing it:
+ *
+ * ```ts
+ * const thisObject = { contents: new ContentsManagerMock() };
+ * return thisObject;
+ * ```
+ */
+function isVariableHandedOff(
+  variable: TSESLint.Scope.Variable,
+  ownership: DisposableOwnershipContext
+): boolean {
+  return variable.references.some(reference => {
+    if (reference.init) {
+      return false;
+    }
+
+    // Walk out through any aggregate the reference sits in, so a spread such
+    // as `new Notebook({ ...history })` still counts as handing off `history`.
+    const aggregate =
+      getManagedAggregateExpression(reference.identifier) ??
+      reference.identifier;
+    const expression = getOuterFallbackExpression(aggregate);
+    const parent = expression.parent;
+    if (!parent) {
+      return false;
+    }
+
+    if (parent.type === 'ReturnStatement' && parent.argument === expression) {
+      return true;
+    }
+    if (
+      parent.type === 'ArrowFunctionExpression' &&
+      parent.body === expression
+    ) {
+      return true;
+    }
+    if (
+      parent.type === 'AssignmentExpression' &&
+      parent.right === expression &&
+      parent.left.type === 'MemberExpression'
+    ) {
+      return true;
+    }
+    if (parent.type === 'PropertyDefinition' && parent.value === expression) {
+      return true;
+    }
+    if (parent.type === 'CallExpression' || parent.type === 'NewExpression') {
+      return isOwnershipArgument(
+        parent as TSESTree.CallExpression,
+        expression,
+        ownership
+      );
+    }
+    return false;
+  });
+}
+
+/**
+ * Resolves the variable an aggregate is assigned to, if any:
+ * `const thisObject = { ... }`.
+ */
+function getAggregateHolderVariable(
+  aggregate: TSESTree.Node,
+  ownership: DisposableOwnershipContext
+): TSESLint.Scope.Variable | null {
+  const parent = aggregate.parent;
+  if (
+    parent?.type !== 'VariableDeclarator' ||
+    parent.init !== aggregate ||
+    parent.id.type !== 'Identifier'
+  ) {
+    return null;
+  }
+  return ownership.sourceCode.getDeclaredVariables(parent)[0] ?? null;
 }
 
 function isAggregateExpressionManaged(
@@ -1638,6 +1908,12 @@ function isAggregateExpressionManaged(
   const parent = outerAggregate.parent;
   if (!parent) {
     return false;
+  }
+
+  // One hop through the variable holding the aggregate.
+  const holder = getAggregateHolderVariable(outerAggregate, ownership);
+  if (holder && isVariableHandedOff(holder, ownership)) {
+    return true;
   }
 
   if (parent.type === 'ReturnStatement' && parent.argument === outerAggregate) {
@@ -1668,9 +1944,7 @@ function isAggregateExpressionManaged(
   }
 
   if (parent.type === 'CallExpression') {
-    return getOwnershipArguments(parent, ownership).includes(
-      outerAggregate as TSESTree.CallExpressionArgument
-    );
+    return isOwnershipArgument(parent, outerAggregate, ownership);
   }
 
   return false;
@@ -1707,18 +1981,14 @@ export function isDisposableExpressionManaged(
   }
 
   if (parent.type === 'CallExpression') {
-    return getOwnershipArguments(parent, ownership).includes(
-      expression as TSESTree.CallExpressionArgument
-    );
+    return isOwnershipArgument(parent, expression, ownership);
   }
 
   if (
     parent.type === 'ArrayExpression' &&
     parent.parent?.type === 'CallExpression'
   ) {
-    return getOwnershipArguments(parent.parent, ownership).includes(
-      expression as TSESTree.CallExpressionArgument
-    );
+    return isOwnershipArgument(parent.parent, expression, ownership);
   }
 
   if (isOptionsObjectValueManaged(expression, ownership)) {
@@ -2017,7 +2287,9 @@ export function markManagedDisposableUse(
     markImmediateForEachOwnership(pending, node, ownership);
   }
 
-  markManagedKnownOptionVariables(pending, node, ownership);
+  if (pending.size > 0) {
+    markManagedKnownOptionVariables(pending, node, ownership);
+  }
 
   for (const argument of node.arguments) {
     if (argument.type !== 'ObjectExpression') {
@@ -2033,11 +2305,10 @@ export function markManagedDisposableUse(
     }
   }
 
-  if (node.type === 'NewExpression') {
-    return;
-  }
-
-  const ownershipArguments = getOwnershipArguments(node, ownership);
+  const ownershipArguments =
+    pending.size > 0
+      ? getOwnershipArguments(node as TSESTree.CallExpression, ownership)
+      : [];
   if (ownershipArguments.length > 0) {
     for (const argument of ownershipArguments) {
       markManagedVariables(pending, argument, ownership);
@@ -2046,6 +2317,7 @@ export function markManagedDisposableUse(
   }
 
   if (
+    node.type === 'CallExpression' &&
     isStaticMemberCall(node, 'dispose') &&
     node.callee.type === 'MemberExpression' &&
     node.callee.object.type !== 'Super'
@@ -2065,7 +2337,7 @@ export function markManagedDisposableUse(
     }
   }
 
-  if (isDialogLaunchCall(node, ownership)) {
+  if (node.type === 'CallExpression' && isDialogLaunchCall(node, ownership)) {
     const variable = getIdentifierVariable(
       ownership.sourceCode,
       node.callee.object

--- a/tests/jupyter-require-disposable-ownership.test.ts
+++ b/tests/jupyter-require-disposable-ownership.test.ts
@@ -109,6 +109,28 @@ nonTypeAwareTester.run(
 ruleTester.run('require-disposable-ownership', requireDisposableOwnership, {
   valid: [
     {
+      // A tuple rest parameter after a leading parameter: the first rest
+      // argument maps to tuple element 0, not to element 1.
+      filename: typeAwareFilename,
+      code: `
+        class DisposableDelegate {
+          readonly isDisposed = false;
+          constructor(callback: () => void) {}
+          dispose(): void {}
+        }
+        class Plain {
+          value = 1;
+        }
+        declare const sink: {
+          (a: number, ...rest: [DisposableDelegate, Plain]): void;
+        };
+
+        export function go(): void {
+          sink(1, new DisposableDelegate(() => undefined), new Plain());
+        }
+      `
+    },
+    {
       // A disposable created inline as a constructor argument: the constructor
       // declares the parameter as disposable, so it takes ownership.
       filename: typeAwareFilename,
@@ -1355,6 +1377,35 @@ ruleTester.run('require-disposable-ownership', requireDisposableOwnership, {
   ],
 
   invalid: [
+    {
+      // Owned option names are scoped to the parameter they came from: `payload`
+      // is disposable on the first parameter only, so the second argument's
+      // object must not be credited by it.
+      filename: typeAwareFilename,
+      code: `
+        class DisposableDelegate {
+          readonly isDisposed = false;
+          constructor(callback: () => void) {}
+          dispose(): void {}
+        }
+        class Plain {
+          value = 1;
+        }
+        declare function two(
+          first: { payload: DisposableDelegate },
+          second: { payload: Plain }
+        ): void;
+
+        export function go(): void {
+          const leaked = new DisposableDelegate(() => undefined);
+          const secondBag = { payload: leaked as unknown as Plain };
+          two({ payload: new DisposableDelegate(() => undefined) }, secondBag);
+        }
+      `,
+      errors: [
+        { messageId: 'unmanagedDisposableVariable', data: { name: 'leaked' } }
+      ]
+    },
     {
       // A closure that captures the disposable but is not returned hands off
       // nothing, so the disposable is still unowned.

--- a/tests/jupyter-require-disposable-ownership.test.ts
+++ b/tests/jupyter-require-disposable-ownership.test.ts
@@ -109,6 +109,48 @@ nonTypeAwareTester.run(
 ruleTester.run('require-disposable-ownership', requireDisposableOwnership, {
   valid: [
     {
+      // A disposable created inline as a constructor argument: the constructor
+      // declares the parameter as disposable, so it takes ownership.
+      filename: typeAwareFilename,
+      code: `
+        class DisposableDelegate {
+          readonly isDisposed = false;
+          constructor(callback: () => void) {}
+          dispose(): void {}
+        }
+        class Owner {
+          readonly isDisposed = false;
+          constructor(disposable: DisposableDelegate) {}
+          dispose(): void {}
+        }
+
+        export function make(): Owner {
+          return new Owner(new DisposableDelegate(() => undefined));
+        }
+      `
+    },
+    {
+      // The same through an array argument: the element binds to the element
+      // type of the declared parameter.
+      filename: typeAwareFilename,
+      code: `
+        class DisposableDelegate {
+          readonly isDisposed = false;
+          constructor(callback: () => void) {}
+          dispose(): void {}
+        }
+        class Owner {
+          readonly isDisposed = false;
+          constructor(items: DisposableDelegate[]) {}
+          dispose(): void {}
+        }
+
+        export function make(): Owner {
+          return new Owner([new DisposableDelegate(() => undefined)]);
+        }
+      `
+    },
+    {
       // Mirrors ServiceManagerMock (services/src/testutils.ts): disposables are
       // properties of an object literal held in a variable that is returned.
       filename: typeAwareFilename,

--- a/tests/jupyter-require-disposable-ownership.test.ts
+++ b/tests/jupyter-require-disposable-ownership.test.ts
@@ -109,6 +109,64 @@ nonTypeAwareTester.run(
 ruleTester.run('require-disposable-ownership', requireDisposableOwnership, {
   valid: [
     {
+      // Mirrors ServiceManagerMock (services/src/testutils.ts): disposables are
+      // properties of an object literal held in a variable that is returned.
+      filename: typeAwareFilename,
+      code: `
+        class Manager {
+          dispose(): void {}
+          readonly isDisposed: boolean = false;
+        }
+
+        export function makeServiceManager(): { contents: Manager } {
+          const thisObject = {
+            contents: new Manager(),
+            sessions: new Manager()
+          };
+          return thisObject;
+        }
+      `
+    },
+    {
+      // Mirrors ContentsManagerMock: the disposable is captured by callbacks
+      // that are wrapped in jest.fn() and hung off the returned object.
+      filename: typeAwareFilename,
+      code: `
+        class Manager {
+          driveName(path: string): string {
+            return path;
+          }
+          dispose(): void {}
+          readonly isDisposed: boolean = false;
+        }
+        declare function wrap<T>(fn: T): T;
+
+        export function makeContentsManager(): { get: (p: string) => string } {
+          const dummy = new Manager();
+          const thisObject = {
+            get: wrap((p: string) => dummy.driveName(p))
+          };
+          return thisObject;
+        }
+      `
+    },
+    {
+      // A spread carries the aggregate onwards.
+      filename: typeAwareFilename,
+      code: `
+        class Manager {
+          dispose(): void {}
+          readonly isDisposed: boolean = false;
+        }
+        declare const disposables: { add(x: unknown): void };
+
+        export function build(): void {
+          const extra = { manager: new Manager() };
+          disposables.add({ ...extra, name: 'x' });
+        }
+      `
+    },
+    {
       // Mirrors JupyterLab's createToolbarFactory (apputils/src/toolbar/factory.ts):
       // `items` is created once, passed to a helper, captured by the returned
       // factory closure and by handlers declared inside it, and never disposed.
@@ -1393,7 +1451,7 @@ ruleTester.run('require-disposable-ownership', requireDisposableOwnership, {
           dispose(): void {}
         }
         class Widget {
-          constructor(options: { disposable: DisposableDelegate }) {}
+          constructor(options: { disposable: unknown }) {}
         }
 
         new Widget({
@@ -1412,7 +1470,7 @@ ruleTester.run('require-disposable-ownership', requireDisposableOwnership, {
         }
         declare const widget: object;
         declare const values: {
-          set(owner: object, value: DisposableSet): void;
+          set(owner: object, value: unknown): void;
         };
 
         const disposables = new DisposableSet();
@@ -1715,7 +1773,7 @@ ruleTester.run('require-disposable-ownership', requireDisposableOwnership, {
           constructor(callback: () => void) {}
           dispose(): void {}
         }
-        declare const items: { add(disposable: DisposableDelegate): void };
+        declare const items: { add(disposable: unknown): void };
 
         const disposable = new DisposableDelegate(() => {
           cleanup();

--- a/tests/jupyter-require-disposable-transfer.test.ts
+++ b/tests/jupyter-require-disposable-transfer.test.ts
@@ -1447,7 +1447,7 @@ ruleTester.run('require-disposable-transfer', requireDisposableTransfer, {
         }
         declare function createDisposable(): IDisposable;
         class Owner {
-          constructor(disposable: IDisposable) {}
+          constructor(disposable: unknown) {}
         }
 
         new Owner(createDisposable());

--- a/tests/jupyter-require-disposable-transfer.test.ts
+++ b/tests/jupyter-require-disposable-transfer.test.ts
@@ -1387,7 +1387,7 @@ ruleTester.run('require-disposable-transfer', requireDisposableTransfer, {
           dispose(): void;
         }
         declare function createDisposable(): IDisposable;
-        declare const items: { add(disposable: IDisposable): void };
+        declare const items: { add(disposable: unknown): void };
 
         const disposable = createDisposable();
         items.add(disposable);

--- a/website/docs/rules/require-disposable-ownership.md
+++ b/website/docs/rules/require-disposable-ownership.md
@@ -22,32 +22,49 @@ All three ways of writing one are recognised: an inline `activate` property, a
 function named `activate`, and a separate function referenced as
 `activate: activateFoo`.
 
-It accepts common ownership patterns:
+### How a handoff is recognised
 
-- Adding the object to a typed `DisposableSet` or a conventionally named
-  disposable collection such as `this._disposables.add(...)`
-- Passing the object as a direct array item to `DisposableSet.from(...)` or
-  `ObservableDisposableSet.from(...)`
+Whether a call takes ownership is decided by **what the callee declares**, not by
+its name. If the parameter the disposable binds to is itself typed as a
+disposable, the API is saying it takes something with a lifecycle:
+
+```ts
+// Owned: `Context` declares `factory` as an IModelFactory, which is disposable.
+const factory = new TextModelFactory();
+const context = new Context({ manager, factory, path });
+
+// Not owned: `console.log` declares `...data: any[]`, so this still reports.
+const factory = new TextModelFactory();
+console.log(factory);
+```
+
+The same applies to options objects: a property of an options bag counts when
+the corresponding property of the parameter's type is declared disposable. This
+means the rule needs no table of known classes and keeps working for your own
+APIs, provided they are typed. Without type information no call is treated as
+taking ownership, so the rule falls back to the syntactic patterns below.
+
+### Other accepted ownership patterns
+
+- Adding the object to a typed `DisposableSet`, or passing it as a direct array
+  item to `DisposableSet.from(...)` / `ObservableDisposableSet.from(...)`
 - Returning it
 - Assigning it to an object field or class field initializer
 - Storing it in a class-field collection with `this._items.set(...)`
 - Calling `.dispose()` immediately
 - Storing it in a variable that is later added, returned, assigned to a field,
-  or disposed
-- Passing it to a configured ownership helper function or default ownership
-  sink such as `add`, `addCell`, `addItem`, `addMenu`, `addWidget`,
-  `insertWidget`, or `registerStatusItem`
-- Passing it through a known owned constructor options object, such as
-  `new MainAreaWidget({ content })` or `new Dialog({ body })`
-- Passing it as a `showDialog({ body: ... })` body or launching a typed
-  `Dialog` with `.launch()`
+  or disposed, including one hop through an object or array that is itself
+  handed off: `const options = { model }; return new Completer(options);`
 - Disposing it unconditionally inside a callback, so the
   `requestAnimationFrame(() => splash.dispose())` and
   `void load().then(() => splash.dispose())` idioms are accepted. Disposal that
   is itself conditional inside the callback is still reported.
+- Capturing it in a closure that the declaring function returns, the factory
+  pattern: the closure is the function's product, so it owns what it captures.
 - Declaring it as an exported binding (`export const tracker = ...`, including
   inside an exported `namespace`): ownership of a module singleton passes to the
-  importers of the module.
+  importers of the module. A reassigned export does not count, since only the
+  last value can still be reached.
 
 ## Incorrect
 
@@ -96,6 +113,10 @@ class Owner {
 ## Options
 
 ### `ownershipFunctionNames`
+
+An escape hatch for APIs whose types cannot express the handoff, most often test
+mocks and helpers typed as `any`. Ownership is normally decided from the
+declared parameter type, so this list is only needed where that fails.
 
 Function or method names that take ownership of disposable arguments, such as
 `add`, `addWidget`, `insertWidget`, and `registerStatusItem`. For the full

--- a/website/docs/rules/require-disposable-transfer.md
+++ b/website/docs/rules/require-disposable-transfer.md
@@ -115,9 +115,10 @@ Note that this option has no effect under the default settings: only
 factory-named calls (`create*`, `build*`, `make*`, `new*`) have their return
 value checked, and no name in the default list matches that pattern. The list
 becomes load-bearing only once `checkAllDisposableReturns` is enabled, where on
-JupyterLab it takes the finding count from 589 down to 37. Whether a returned
-disposable is borrowed or freshly created is not something the declared types
-express, which is why this remains a name list while ownership does not.
+JupyterLab it takes the finding count down by an order of magnitude.
+Whether a returned disposable is borrowed or freshly created is not something
+the declared types express, which is why this remains a name list while ownership
+does not.
 
 ### `extendDefaultIgnoredReturnFunctionNames`
 

--- a/website/docs/rules/require-disposable-transfer.md
+++ b/website/docs/rules/require-disposable-transfer.md
@@ -36,8 +36,10 @@ It accepts common ownership patterns:
 - Passing it to a configured ownership helper function or default ownership
   sink such as `add`, `addCell`, `addItem`, `addMenu`, `addWidget`,
   `insertWidget`, or `registerStatusItem`
-- Passing it through a known owned constructor options object, such as
-  `new MainAreaWidget({ content })` or `new Dialog({ body })`
+- Passing it to a call or constructor that declares the corresponding parameter
+  as a disposable type, including as a property of an options object. This is
+  decided from the callee's declared types, so it works for your own APIs and
+  needs no table of known classes.
 - Disposing it unconditionally inside a callback, so the
   `requestAnimationFrame(() => splash.dispose())` and
   `void load().then(() => splash.dispose())` idioms are accepted. Disposal that
@@ -108,6 +110,14 @@ entirely.
 Function or method names whose disposable return value should be treated as
 borrowed, or as owned by a registration or session API. Names given here are
 **added** to the default list described above.
+
+Note that this option has no effect under the default settings: only
+factory-named calls (`create*`, `build*`, `make*`, `new*`) have their return
+value checked, and no name in the default list matches that pattern. The list
+becomes load-bearing only once `checkAllDisposableReturns` is enabled, where on
+JupyterLab it takes the finding count from 589 down to 37. Whether a returned
+disposable is borrowed or freshly created is not something the declared types
+express, which is why this remains a name list while ownership does not.
 
 ### `extendDefaultIgnoredReturnFunctionNames`
 


### PR DESCRIPTION
Follow-up to https://github.com/jupyterlab/eslint-plugin/pull/89

Reduces false positives count for disposable ownership check

On JupyterLab codebase:
 
| ref | total | true positives | not actionable | false positives |
|--|--|--|--|--|
| After #77 | 45 |	6|	2|	37|
| After #89 |	28 |	6|	2|	20|
| This PR |	9|	6|	2|	1|

True positives (6)
- packages/lsp-extension/src/renderer.tsx:214
- packages/notebook-extension/src/index.ts:1322
- packages/notebook-extension/src/index.ts:1337
- packages/notebook-extension/src/index.ts:1369
- packages/toc/src/factory.ts:77
- packages/apputils/src/licenses.tsx:131

Not actionable (2)
- packages/running-extension/src/kernels.tsx:52
- packages/running-extension/src/kernels.tsx:56

False positive (1)
- packages/notebook/src/testutils.ts:203
