### PR TITLE
Catch untranslated `label` props via a configurable name list in `no-untranslated-string`

### DIFF
--- a/eslint.downstream.config.mjs
+++ b/eslint.downstream.config.mjs
@@ -41,7 +41,28 @@ function makeProjectConfig(projectName) {
     },
     rules: {
       'jupyter/command-described-by': 'error',
-      'jupyter/no-untranslated-string': 'error',
+      // Options are spelled out (they match the rule defaults) so the
+      // downstream run visibly exercises each list.
+      'jupyter/no-untranslated-string': [
+        'error',
+        {
+          checkProperties: ['label', 'category'],
+          checkJsxAttributes: [
+            'aria-label',
+            'aria-description',
+            'title',
+            'label'
+          ],
+          checkAssignments: [
+            'title',
+            'ariaLabel',
+            'alt',
+            'textContent',
+            'label',
+            'caption'
+          ]
+        }
+      ],
       'jupyter/plugin-activation-args': 'error',
       'jupyter/plugin-description': 'error',
       'jupyter/no-translation-concatenation': 'error',

--- a/eslint.downstream.config.mjs
+++ b/eslint.downstream.config.mjs
@@ -41,28 +41,7 @@ function makeProjectConfig(projectName) {
     },
     rules: {
       'jupyter/command-described-by': 'error',
-      // Options are spelled out (they match the rule defaults) so the
-      // downstream run visibly exercises each list.
-      'jupyter/no-untranslated-string': [
-        'error',
-        {
-          checkProperties: ['label', 'category'],
-          checkJsxAttributes: [
-            'aria-label',
-            'aria-description',
-            'title',
-            'label'
-          ],
-          checkAssignments: [
-            'title',
-            'ariaLabel',
-            'alt',
-            'textContent',
-            'label',
-            'caption'
-          ]
-        }
-      ],
+      'jupyter/no-untranslated-string': 'error',
       'jupyter/plugin-activation-args': 'error',
       'jupyter/plugin-description': 'error',
       'jupyter/no-translation-concatenation': 'error',

--- a/src/rules/no-untranslated-string.ts
+++ b/src/rules/no-untranslated-string.ts
@@ -100,24 +100,70 @@ const noUntranslatedString = createRule({
       untranslatedDialogButtonLabel:
         'Dialog button "label" option has an untranslated string literal. Wrap it with trans.__().',
       untranslatedJsxText:
-        'JSX text content has an untranslated string literal. Wrap it with {trans.__(...)}'
+        'JSX text content has an untranslated string literal. Wrap it with {trans.__(...)}',
+      untranslatedLabelProp:
+        '"label" has an untranslated string literal. Wrap it with trans.__().'
     },
     schema: [
       {
         type: 'object',
         properties: {
-          enforcePunctuation: { type: 'boolean' }
+          enforcePunctuation: { type: 'boolean' },
+          checkAllLabels: { type: 'boolean' }
         },
         additionalProperties: false
       }
     ]
   },
-  defaultOptions: [{ enforcePunctuation: false }],
+  defaultOptions: [{ enforcePunctuation: false, checkAllLabels: false }],
 
   create(context) {
-    const enforcePunctuation =
-      (context.options[0] as { enforcePunctuation?: boolean })
-        ?.enforcePunctuation ?? false;
+    const options = context.options[0] as
+      | { enforcePunctuation?: boolean; checkAllLabels?: boolean }
+      | undefined;
+    const enforcePunctuation = options?.enforcePunctuation ?? false;
+    const checkAllLabels = options?.checkAllLabels ?? false;
+
+    // Nodes already reported by a more specific branch (e.g. addCommand or a
+    // Dialog button builder), so the generic `label` check does not duplicate
+    // them. Enclosing calls are visited before the properties they contain.
+    const reportedNodes = new Set<TSESTree.Node>();
+
+    function report(
+      node: TSESTree.Node,
+      messageId:
+        | 'untranslatedCommandProp'
+        | 'untranslatedSetAttribute'
+        | 'untranslatedPropertyAssign'
+        | 'untranslatedTitleProp'
+        | 'untranslatedDialogOption'
+        | 'untranslatedDialogButtonLabel'
+        | 'untranslatedJsxText'
+        | 'untranslatedLabelProp',
+      data?: Record<string, string>
+    ): void {
+      reportedNodes.add(node);
+      context.report({ node, messageId, data });
+    }
+
+    /**
+     * Returns the message id to use for a JSX attribute, or null when the
+     * attribute is not monitored.
+     */
+    function getJsxAttrMessageId(
+      attrName: string | null
+    ): 'untranslatedJsxText' | 'untranslatedLabelProp' | null {
+      if (!attrName) {
+        return null;
+      }
+      if (MONITORED_JSX_ATTRS.includes(attrName)) {
+        return 'untranslatedJsxText';
+      }
+      if (checkAllLabels && attrName === 'label') {
+        return 'untranslatedLabelProp';
+      }
+      return null;
+    }
 
     return {
       CallExpression(node) {
@@ -134,11 +180,7 @@ const noUntranslatedString = createRule({
           for (const propName of MONITORED_COMMAND_PROPS) {
             const prop = properties.get(propName);
             if (prop && isRawStringNode(prop.value)) {
-              context.report({
-                node: prop.value,
-                messageId: 'untranslatedCommandProp',
-                data: { prop: propName }
-              });
+              report(prop.value, 'untranslatedCommandProp', { prop: propName });
             }
           }
           return;
@@ -159,10 +201,8 @@ const noUntranslatedString = createRule({
           }
           const attrValueArg = node.arguments[1];
           if (isRawStringNode(attrValueArg)) {
-            context.report({
-              node: attrValueArg,
-              messageId: 'untranslatedSetAttribute',
-              data: { attr: attrNameArg.value }
+            report(attrValueArg, 'untranslatedSetAttribute', {
+              attr: attrNameArg.value
             });
           }
           return;
@@ -181,10 +221,8 @@ const noUntranslatedString = createRule({
           for (const propName of MONITORED_DIALOG_PROPS) {
             const prop = properties.get(propName);
             if (prop && isRawStringNode(prop.value)) {
-              context.report({
-                node: prop.value,
-                messageId: 'untranslatedDialogOption',
-                data: { prop: propName }
+              report(prop.value, 'untranslatedDialogOption', {
+                prop: propName
               });
             }
           }
@@ -203,10 +241,7 @@ const noUntranslatedString = createRule({
           const properties = getObjectProperties(optionsArg);
           const labelProp = properties.get('label');
           if (labelProp && isRawStringNode(labelProp.value)) {
-            context.report({
-              node: labelProp.value,
-              messageId: 'untranslatedDialogButtonLabel'
-            });
+            report(labelProp.value, 'untranslatedDialogButtonLabel');
           }
         }
       },
@@ -227,11 +262,7 @@ const noUntranslatedString = createRule({
         for (const propName of MONITORED_DIALOG_PROPS) {
           const prop = properties.get(propName);
           if (prop && isRawStringNode(prop.value)) {
-            context.report({
-              node: prop.value,
-              messageId: 'untranslatedDialogOption',
-              data: { prop: propName }
-            });
+            report(prop.value, 'untranslatedDialogOption', { prop: propName });
           }
         }
       },
@@ -254,10 +285,8 @@ const noUntranslatedString = createRule({
           MONITORED_ASSIGNMENT_PROPS.includes(left.property.name) &&
           isRawStringNode(node.right)
         ) {
-          context.report({
-            node: node.right,
-            messageId: 'untranslatedPropertyAssign',
-            data: { prop: left.property.name }
+          report(node.right, 'untranslatedPropertyAssign', {
+            prop: left.property.name
           });
           return;
         }
@@ -272,12 +301,32 @@ const noUntranslatedString = createRule({
           left.object.property.name === 'title' &&
           isRawStringNode(node.right)
         ) {
-          context.report({
-            node: node.right,
-            messageId: 'untranslatedTitleProp',
-            data: { prop: left.property.name }
+          report(node.right, 'untranslatedTitleProp', {
+            prop: left.property.name
           });
         }
+      },
+
+      // Any `label: 'raw string'` object property, when `checkAllLabels` is on.
+      // Runs after the more specific branches above, which mark the nodes they
+      // already reported.
+      Property(node) {
+        if (!checkAllLabels || node.computed || node.shorthand) {
+          return;
+        }
+        const keyName =
+          node.key.type === 'Identifier'
+            ? node.key.name
+            : node.key.type === 'Literal' && typeof node.key.value === 'string'
+              ? node.key.value
+              : null;
+        if (keyName !== 'label') {
+          return;
+        }
+        if (reportedNodes.has(node.value) || !isRawStringNode(node.value)) {
+          return;
+        }
+        report(node.value, 'untranslatedLabelProp');
       },
 
       // Accessibility attribute with a plain string: <span aria-label="text" />
@@ -287,14 +336,12 @@ const noUntranslatedString = createRule({
         }
         const attrName =
           node.name.type === 'JSXIdentifier' ? node.name.name : null;
-        if (!attrName || !MONITORED_JSX_ATTRS.includes(attrName)) {
+        const messageId = getJsxAttrMessageId(attrName);
+        if (!messageId) {
           return;
         }
         if (isRawStringNode(node.value)) {
-          context.report({
-            node: node.value,
-            messageId: 'untranslatedJsxText'
-          });
+          report(node.value, messageId);
         }
       },
 
@@ -304,10 +351,7 @@ const noUntranslatedString = createRule({
           node.value.trim().length > 0 &&
           (enforcePunctuation || hasLetters(node.value))
         ) {
-          context.report({
-            node,
-            messageId: 'untranslatedJsxText'
-          });
+          report(node, 'untranslatedJsxText');
         }
       },
 
@@ -321,14 +365,12 @@ const noUntranslatedString = createRule({
             node.parent.name.type === 'JSXIdentifier'
               ? node.parent.name.name
               : null;
-          if (!attrName || !MONITORED_JSX_ATTRS.includes(attrName)) {
+          const messageId = getJsxAttrMessageId(attrName);
+          if (!messageId) {
             return;
           }
           if (isRawStringNode(node.expression)) {
-            context.report({
-              node: node.expression,
-              messageId: 'untranslatedJsxText'
-            });
+            report(node.expression, messageId);
           }
           return;
         }
@@ -338,10 +380,7 @@ const noUntranslatedString = createRule({
             value !== null &&
             (enforcePunctuation ? value.trim().length > 0 : hasLetters(value))
           ) {
-            context.report({
-              node: node.expression,
-              messageId: 'untranslatedJsxText'
-            });
+            report(node.expression, 'untranslatedJsxText');
           }
         }
       }

--- a/src/rules/no-untranslated-string.ts
+++ b/src/rules/no-untranslated-string.ts
@@ -73,9 +73,64 @@ function isDialogButtonCall(node: TSESTree.CallExpression): boolean {
 const MONITORED_COMMAND_PROPS = ['label', 'caption', 'usage'];
 const MONITORED_A11Y_ATTRS = ['aria-label', 'aria-description', 'title'];
 const MONITORED_SET_ATTRIBUTE_ATTRS = MONITORED_A11Y_ATTRS;
-const MONITORED_ASSIGNMENT_PROPS = ['title', 'ariaLabel'];
 const MONITORED_DIALOG_PROPS = ['title', 'body'];
-const MONITORED_JSX_ATTRS = MONITORED_A11Y_ATTRS;
+
+/** Object property names checked in any object literal. */
+const DEFAULT_CHECK_PROPERTIES = ['label', 'category'];
+/** JSX attribute names checked on any element. */
+const DEFAULT_CHECK_JSX_ATTRIBUTES = [...MONITORED_A11Y_ATTRS, 'label'];
+/**
+ * Property names checked on the left-hand side of an assignment. `label` and
+ * `caption` also cover Lumino widget titles (`this.title.label = '...'`).
+ */
+const DEFAULT_CHECK_ASSIGNMENTS = [
+  'title',
+  'ariaLabel',
+  'alt',
+  'textContent',
+  'label',
+  'caption'
+];
+
+interface Options {
+  enforcePunctuation?: boolean;
+  checkProperties?: string[];
+  checkJsxAttributes?: string[];
+  checkAssignments?: string[];
+}
+
+type MessageId =
+  | 'untranslatedCommandProp'
+  | 'untranslatedSetAttribute'
+  | 'untranslatedPropertyAssign'
+  | 'untranslatedDialogOption'
+  | 'untranslatedDialogButtonLabel'
+  | 'untranslatedJsxText'
+  | 'untranslatedJsxAttribute'
+  | 'untranslatedProperty';
+
+/**
+ * Returns the static name of a non-computed object property key, or null when
+ * the key is computed or not a plain identifier/string.
+ */
+function getPropertyKeyName(node: TSESTree.Property): string | null {
+  if (node.computed) {
+    return null;
+  }
+  if (node.key.type === 'Identifier') {
+    return node.key.name;
+  }
+  if (node.key.type === 'Literal' && typeof node.key.value === 'string') {
+    return node.key.value;
+  }
+  return null;
+}
+
+const NAME_LIST_SCHEMA = {
+  type: 'array' as const,
+  items: { type: 'string' as const },
+  uniqueItems: true
+};
 
 const noUntranslatedString = createRule({
   name: 'no-untranslated-string',
@@ -93,53 +148,61 @@ const noUntranslatedString = createRule({
         'setAttribute("{{ attr }}", ...) has an untranslated string literal. Wrap the value with trans.__().',
       untranslatedPropertyAssign:
         'Assignment to "{{ prop }}" has an untranslated string literal. Wrap it with trans.__().',
-      untranslatedTitleProp:
-        'Assignment to "title.{{ prop }}" has an untranslated string literal. Wrap it with trans.__().',
       untranslatedDialogOption:
         'Dialog/showDialog "{{ prop }}" option has an untranslated string literal. Wrap it with trans.__().',
       untranslatedDialogButtonLabel:
         'Dialog button "label" option has an untranslated string literal. Wrap it with trans.__().',
       untranslatedJsxText:
         'JSX text content has an untranslated string literal. Wrap it with {trans.__(...)}',
-      untranslatedLabelProp:
-        '"label" has an untranslated string literal. Wrap it with trans.__().'
+      untranslatedJsxAttribute:
+        'JSX attribute "{{ prop }}" has an untranslated string literal. Wrap it with {trans.__(...)}',
+      untranslatedProperty:
+        'Property "{{ prop }}" has an untranslated string literal. Wrap it with trans.__().'
     },
     schema: [
       {
         type: 'object',
         properties: {
           enforcePunctuation: { type: 'boolean' },
-          checkAllLabels: { type: 'boolean' }
+          checkProperties: NAME_LIST_SCHEMA,
+          checkJsxAttributes: NAME_LIST_SCHEMA,
+          checkAssignments: NAME_LIST_SCHEMA
         },
         additionalProperties: false
       }
     ]
   },
-  defaultOptions: [{ enforcePunctuation: false, checkAllLabels: false }],
+  defaultOptions: [
+    {
+      enforcePunctuation: false,
+      checkProperties: DEFAULT_CHECK_PROPERTIES,
+      checkJsxAttributes: DEFAULT_CHECK_JSX_ATTRIBUTES,
+      checkAssignments: DEFAULT_CHECK_ASSIGNMENTS
+    }
+  ],
 
   create(context) {
-    const options = context.options[0] as
-      | { enforcePunctuation?: boolean; checkAllLabels?: boolean }
-      | undefined;
+    const options = context.options[0] as Options | undefined;
     const enforcePunctuation = options?.enforcePunctuation ?? false;
-    const checkAllLabels = options?.checkAllLabels ?? false;
+    const checkProperties = new Set(
+      options?.checkProperties ?? DEFAULT_CHECK_PROPERTIES
+    );
+    const checkJsxAttributes = new Set(
+      options?.checkJsxAttributes ?? DEFAULT_CHECK_JSX_ATTRIBUTES
+    );
+    const checkAssignments = new Set(
+      options?.checkAssignments ?? DEFAULT_CHECK_ASSIGNMENTS
+    );
 
     // Nodes already reported by a more specific branch (e.g. addCommand or a
-    // Dialog button builder), so the generic `label` check does not duplicate
-    // them. Enclosing calls are visited before the properties they contain.
+    // Dialog button builder), so the generic `checkProperties` check does not
+    // duplicate them. Enclosing calls are visited before the properties they
+    // contain, so the specific branch always runs first.
     const reportedNodes = new Set<TSESTree.Node>();
 
     function report(
       node: TSESTree.Node,
-      messageId:
-        | 'untranslatedCommandProp'
-        | 'untranslatedSetAttribute'
-        | 'untranslatedPropertyAssign'
-        | 'untranslatedTitleProp'
-        | 'untranslatedDialogOption'
-        | 'untranslatedDialogButtonLabel'
-        | 'untranslatedJsxText'
-        | 'untranslatedLabelProp',
+      messageId: MessageId,
       data?: Record<string, string>
     ): void {
       reportedNodes.add(node);
@@ -147,22 +210,18 @@ const noUntranslatedString = createRule({
     }
 
     /**
-     * Returns the message id to use for a JSX attribute, or null when the
-     * attribute is not monitored.
+     * Reports a monitored JSX attribute whose value is a raw string.
      */
-    function getJsxAttrMessageId(
-      attrName: string | null
-    ): 'untranslatedJsxText' | 'untranslatedLabelProp' | null {
-      if (!attrName) {
-        return null;
+    function checkJsxAttributeValue(
+      attrName: string | null,
+      value: TSESTree.Node
+    ): void {
+      if (!attrName || !checkJsxAttributes.has(attrName)) {
+        return;
       }
-      if (MONITORED_JSX_ATTRS.includes(attrName)) {
-        return 'untranslatedJsxText';
+      if (isRawStringNode(value)) {
+        report(value, 'untranslatedJsxAttribute', { prop: attrName });
       }
-      if (checkAllLabels && attrName === 'label') {
-        return 'untranslatedLabelProp';
-      }
-      return null;
     }
 
     return {
@@ -280,69 +339,44 @@ const noUntranslatedString = createRule({
           return;
         }
 
-        // element.title = STRING  or  element.ariaLabel = STRING
+        // Any monitored assignment target: element.title = STRING,
+        // widget.label = STRING, this.label = STRING, node.textContent = STRING,
+        // and Lumino widget titles such as this.title.label = STRING
         if (
-          MONITORED_ASSIGNMENT_PROPS.includes(left.property.name) &&
+          checkAssignments.has(left.property.name) &&
           isRawStringNode(node.right)
         ) {
           report(node.right, 'untranslatedPropertyAssign', {
             prop: left.property.name
           });
-          return;
-        }
-
-        // *.title.label = STRING  or  *.title.caption = STRING
-        if (
-          (left.property.name === 'label' ||
-            left.property.name === 'caption') &&
-          left.object.type === 'MemberExpression' &&
-          !left.object.computed &&
-          left.object.property.type === 'Identifier' &&
-          left.object.property.name === 'title' &&
-          isRawStringNode(node.right)
-        ) {
-          report(node.right, 'untranslatedTitleProp', {
-            prop: left.property.name
-          });
         }
       },
 
-      // Any `label: 'raw string'` object property, when `checkAllLabels` is on.
-      // Runs after the more specific branches above, which mark the nodes they
-      // already reported.
+      // Any monitored object property: { label: 'raw string' }.
+      // Runs after the call-specific branches above, which mark the nodes they
+      // already reported so a property is never reported twice.
       Property(node) {
-        if (!checkAllLabels || node.computed || node.shorthand) {
+        if (node.shorthand) {
           return;
         }
-        const keyName =
-          node.key.type === 'Identifier'
-            ? node.key.name
-            : node.key.type === 'Literal' && typeof node.key.value === 'string'
-              ? node.key.value
-              : null;
-        if (keyName !== 'label') {
+        const keyName = getPropertyKeyName(node);
+        if (!keyName || !checkProperties.has(keyName)) {
           return;
         }
         if (reportedNodes.has(node.value) || !isRawStringNode(node.value)) {
           return;
         }
-        report(node.value, 'untranslatedLabelProp');
+        report(node.value, 'untranslatedProperty', { prop: keyName });
       },
 
-      // Accessibility attribute with a plain string: <span aria-label="text" />
+      // Monitored attribute with a plain string: <span aria-label="text" />
       JSXAttribute(node) {
         if (!node.value || node.value.type === 'JSXExpressionContainer') {
           return;
         }
         const attrName =
           node.name.type === 'JSXIdentifier' ? node.name.name : null;
-        const messageId = getJsxAttrMessageId(attrName);
-        if (!messageId) {
-          return;
-        }
-        if (isRawStringNode(node.value)) {
-          report(node.value, messageId);
-        }
+        checkJsxAttributeValue(attrName, node.value);
       },
 
       // Raw text between JSX tags: <span>Untranslated text</span>
@@ -365,13 +399,7 @@ const noUntranslatedString = createRule({
             node.parent.name.type === 'JSXIdentifier'
               ? node.parent.name.name
               : null;
-          const messageId = getJsxAttrMessageId(attrName);
-          if (!messageId) {
-            return;
-          }
-          if (isRawStringNode(node.expression)) {
-            report(node.expression, messageId);
-          }
+          checkJsxAttributeValue(attrName, node.expression);
           return;
         }
         if (isRawStringNode(node.expression)) {

--- a/src/rules/no-untranslated-string.ts
+++ b/src/rules/no-untranslated-string.ts
@@ -28,15 +28,6 @@ function getRawStringValue(node: TSESTree.Node): string | null {
   return null;
 }
 
-/**
- * Returns true if the node is a non-empty raw string literal that should be
- * wrapped in a translation call.
- */
-function isRawStringNode(node: TSESTree.Node): boolean {
-  const rawValue = getRawStringValue(node);
-  return rawValue !== null && rawValue.trim().length > 0;
-}
-
 function isSetAttributeCall(node: TSESTree.CallExpression): boolean {
   return (
     node.callee.type === 'MemberExpression' &&
@@ -194,6 +185,26 @@ const noUntranslatedString = createRule({
       options?.checkAssignments ?? DEFAULT_CHECK_ASSIGNMENTS
     );
 
+    /**
+     * Returns true if the text should be wrapped in a translation call. Blank
+     * strings are never reported. Strings with no letters, such as '/' and '¶',
+     * are only reported when `enforcePunctuation` is on.
+     */
+    function isReportableText(value: string): boolean {
+      return (
+        value.trim().length > 0 && (enforcePunctuation || hasLetters(value))
+      );
+    }
+
+    /**
+     * Returns true if the node is a raw string literal (or a concise arrow
+     * returning one) whose text should be wrapped in a translation call.
+     */
+    function isReportableString(node: TSESTree.Node): boolean {
+      const value = getRawStringValue(node);
+      return value !== null && isReportableText(value);
+    }
+
     // Nodes already reported by a more specific branch (e.g. addCommand or a
     // Dialog button builder), so the generic `checkProperties` check does not
     // duplicate them. Enclosing calls are visited before the properties they
@@ -219,7 +230,7 @@ const noUntranslatedString = createRule({
       if (!attrName || !checkJsxAttributes.has(attrName)) {
         return;
       }
-      if (isRawStringNode(value)) {
+      if (isReportableString(value)) {
         report(value, 'untranslatedJsxAttribute', { prop: attrName });
       }
     }
@@ -238,7 +249,7 @@ const noUntranslatedString = createRule({
           const properties = getObjectProperties(optionsArg);
           for (const propName of MONITORED_COMMAND_PROPS) {
             const prop = properties.get(propName);
-            if (prop && isRawStringNode(prop.value)) {
+            if (prop && isReportableString(prop.value)) {
               report(prop.value, 'untranslatedCommandProp', { prop: propName });
             }
           }
@@ -259,7 +270,7 @@ const noUntranslatedString = createRule({
             return;
           }
           const attrValueArg = node.arguments[1];
-          if (isRawStringNode(attrValueArg)) {
+          if (isReportableString(attrValueArg)) {
             report(attrValueArg, 'untranslatedSetAttribute', {
               attr: attrNameArg.value
             });
@@ -279,7 +290,7 @@ const noUntranslatedString = createRule({
           const properties = getObjectProperties(optionsArg);
           for (const propName of MONITORED_DIALOG_PROPS) {
             const prop = properties.get(propName);
-            if (prop && isRawStringNode(prop.value)) {
+            if (prop && isReportableString(prop.value)) {
               report(prop.value, 'untranslatedDialogOption', {
                 prop: propName
               });
@@ -299,7 +310,7 @@ const noUntranslatedString = createRule({
           }
           const properties = getObjectProperties(optionsArg);
           const labelProp = properties.get('label');
-          if (labelProp && isRawStringNode(labelProp.value)) {
+          if (labelProp && isReportableString(labelProp.value)) {
             report(labelProp.value, 'untranslatedDialogButtonLabel');
           }
         }
@@ -320,7 +331,7 @@ const noUntranslatedString = createRule({
         const properties = getObjectProperties(optionsArg);
         for (const propName of MONITORED_DIALOG_PROPS) {
           const prop = properties.get(propName);
-          if (prop && isRawStringNode(prop.value)) {
+          if (prop && isReportableString(prop.value)) {
             report(prop.value, 'untranslatedDialogOption', { prop: propName });
           }
         }
@@ -344,7 +355,7 @@ const noUntranslatedString = createRule({
         // and Lumino widget titles such as this.title.label = STRING
         if (
           checkAssignments.has(left.property.name) &&
-          isRawStringNode(node.right)
+          isReportableString(node.right)
         ) {
           report(node.right, 'untranslatedPropertyAssign', {
             prop: left.property.name
@@ -363,7 +374,7 @@ const noUntranslatedString = createRule({
         if (!keyName || !checkProperties.has(keyName)) {
           return;
         }
-        if (reportedNodes.has(node.value) || !isRawStringNode(node.value)) {
+        if (reportedNodes.has(node.value) || !isReportableString(node.value)) {
           return;
         }
         report(node.value, 'untranslatedProperty', { prop: keyName });
@@ -381,10 +392,7 @@ const noUntranslatedString = createRule({
 
       // Raw text between JSX tags: <span>Untranslated text</span>
       JSXText(node) {
-        if (
-          node.value.trim().length > 0 &&
-          (enforcePunctuation || hasLetters(node.value))
-        ) {
+        if (isReportableText(node.value)) {
           report(node, 'untranslatedJsxText');
         }
       },
@@ -402,14 +410,8 @@ const noUntranslatedString = createRule({
           checkJsxAttributeValue(attrName, node.expression);
           return;
         }
-        if (isRawStringNode(node.expression)) {
-          const value = getRawStringValue(node.expression);
-          if (
-            value !== null &&
-            (enforcePunctuation ? value.trim().length > 0 : hasLetters(value))
-          ) {
-            report(node.expression, 'untranslatedJsxText');
-          }
+        if (isReportableString(node.expression)) {
+          report(node.expression, 'untranslatedJsxText');
         }
       }
     };

--- a/src/rules/no-untranslated-string.ts
+++ b/src/rules/no-untranslated-string.ts
@@ -6,26 +6,57 @@
 import { TSESTree } from '@typescript-eslint/types';
 import { isAddCommandCall } from '../utils/commands';
 import { getObjectProperties } from '../utils/plugin-utils';
+import { unwrapExpression } from '../utils/translation';
 import { createRule } from '../utils/create-rule';
 
-function hasLetters(str: string): boolean {
-  return /\p{L}/u.test(str);
+/**
+ * Returns true if the text carries content a translator would work on, as
+ * opposed to punctuation and symbols alone. Digits also count.
+ */
+function hasTranslatableContent(str: string): boolean {
+  return /[\p{L}\p{N}]/u.test(str);
 }
 
-function getRawStringValue(node: TSESTree.Node): string | null {
-  if (node.type === 'Literal' && typeof node.value === 'string') {
-    return node.value;
+/**
+ * A raw string literal found behind a value expression, paired with the node
+ * that should be reported (the literal itself, never its wrapper).
+ */
+interface RawString {
+  node: TSESTree.Node;
+  value: string;
+}
+
+/**
+ * Returns the raw string behind a value expression
+ * or null when the value is not a static string.
+ */
+function getRawString(node: TSESTree.Node): RawString | null {
+  const inner = unwrapExpression(node);
+  if (inner.type === 'Literal' && typeof inner.value === 'string') {
+    return { node: inner, value: inner.value };
   }
-  if (node.type === 'TemplateLiteral' && node.expressions.length === 0) {
-    return node.quasis.map(q => q.value.cooked ?? '').join('');
+  if (inner.type === 'TemplateLiteral' && inner.expressions.length === 0) {
+    return {
+      node: inner,
+      value: inner.quasis.map(q => q.value.cooked ?? '').join('')
+    };
   }
   if (
-    node.type === 'ArrowFunctionExpression' &&
-    node.body.type !== 'BlockStatement'
+    inner.type === 'ArrowFunctionExpression' &&
+    inner.body.type !== 'BlockStatement'
   ) {
-    return getRawStringValue(node.body);
+    return getRawString(inner.body);
   }
   return null;
+}
+
+/**
+ * Folds the hyphenated and camelCase spellings of a name together so that a
+ * single configured entry covers both, e.g. the `aria-label` attribute and the
+ * `ariaLabel` DOM property.
+ */
+function normalizeName(name: string): string {
+  return name.replace(/-/g, '').toLowerCase();
 }
 
 function isSetAttributeCall(node: TSESTree.CallExpression): boolean {
@@ -61,33 +92,31 @@ function isDialogButtonCall(node: TSESTree.CallExpression): boolean {
   );
 }
 
+// Properties checked only on the call they belong to, because the name alone
+// does not imply user-facing text anywhere else.
 const MONITORED_COMMAND_PROPS = ['label', 'caption', 'usage'];
-const MONITORED_A11Y_ATTRS = ['aria-label', 'aria-description', 'title'];
-const MONITORED_SET_ATTRIBUTE_ATTRS = MONITORED_A11Y_ATTRS;
 const MONITORED_DIALOG_PROPS = ['title', 'body'];
 
-/** Object property names checked in any object literal. */
-const DEFAULT_CHECK_PROPERTIES = ['label', 'category'];
-/** JSX attribute names checked on any element. */
-const DEFAULT_CHECK_JSX_ATTRIBUTES = [...MONITORED_A11Y_ATTRS, 'label'];
 /**
- * Property names checked on the left-hand side of an assignment. `label` and
- * `caption` also cover Lumino widget titles (`this.title.label = '...'`).
+ * Names checked in every generic position: object literal properties, JSX
+ * attributes, `setAttribute()` attribute names and assignment targets.
  */
-const DEFAULT_CHECK_ASSIGNMENTS = [
-  'title',
-  'ariaLabel',
+const DEFAULT_CHECK_PROPERTIES = [
   'alt',
-  'textContent',
+  'aria-description',
+  'aria-label',
+  'caption',
+  'category',
   'label',
-  'caption'
+  'placeholder',
+  'title',
+  'textContent',
+  'innerText'
 ];
 
 interface Options {
   enforcePunctuation?: boolean;
   checkProperties?: string[];
-  checkJsxAttributes?: string[];
-  checkAssignments?: string[];
 }
 
 type MessageId =
@@ -116,12 +145,6 @@ function getPropertyKeyName(node: TSESTree.Property): string | null {
   }
   return null;
 }
-
-const NAME_LIST_SCHEMA = {
-  type: 'array' as const,
-  items: { type: 'string' as const },
-  uniqueItems: true
-};
 
 const noUntranslatedString = createRule({
   name: 'no-untranslated-string',
@@ -155,9 +178,11 @@ const noUntranslatedString = createRule({
         type: 'object',
         properties: {
           enforcePunctuation: { type: 'boolean' },
-          checkProperties: NAME_LIST_SCHEMA,
-          checkJsxAttributes: NAME_LIST_SCHEMA,
-          checkAssignments: NAME_LIST_SCHEMA
+          checkProperties: {
+            type: 'array',
+            items: { type: 'string' },
+            uniqueItems: true
+          }
         },
         additionalProperties: false
       }
@@ -166,9 +191,7 @@ const noUntranslatedString = createRule({
   defaultOptions: [
     {
       enforcePunctuation: false,
-      checkProperties: DEFAULT_CHECK_PROPERTIES,
-      checkJsxAttributes: DEFAULT_CHECK_JSX_ATTRIBUTES,
-      checkAssignments: DEFAULT_CHECK_ASSIGNMENTS
+      checkProperties: DEFAULT_CHECK_PROPERTIES
     }
   ],
 
@@ -176,39 +199,29 @@ const noUntranslatedString = createRule({
     const options = context.options[0] as Options | undefined;
     const enforcePunctuation = options?.enforcePunctuation ?? false;
     const checkProperties = new Set(
-      options?.checkProperties ?? DEFAULT_CHECK_PROPERTIES
+      (options?.checkProperties ?? DEFAULT_CHECK_PROPERTIES).map(normalizeName)
     );
-    const checkJsxAttributes = new Set(
-      options?.checkJsxAttributes ?? DEFAULT_CHECK_JSX_ATTRIBUTES
-    );
-    const checkAssignments = new Set(
-      options?.checkAssignments ?? DEFAULT_CHECK_ASSIGNMENTS
-    );
+
+    function isMonitoredName(name: string): boolean {
+      return checkProperties.has(normalizeName(name));
+    }
 
     /**
      * Returns true if the text should be wrapped in a translation call. Blank
-     * strings are never reported. Strings with no letters, such as '/' and '¶',
-     * are only reported when `enforcePunctuation` is on.
+     * strings are never reported. Strings made only of punctuation and symbols
+     * are reported only when `enforcePunctuation` is on.
      */
     function isReportableText(value: string): boolean {
       return (
-        value.trim().length > 0 && (enforcePunctuation || hasLetters(value))
+        value.trim().length > 0 &&
+        (enforcePunctuation || hasTranslatableContent(value))
       );
     }
 
-    /**
-     * Returns true if the node is a raw string literal (or a concise arrow
-     * returning one) whose text should be wrapped in a translation call.
-     */
-    function isReportableString(node: TSESTree.Node): boolean {
-      const value = getRawStringValue(node);
-      return value !== null && isReportableText(value);
-    }
-
-    // Nodes already reported by a more specific branch (e.g. addCommand or a
-    // Dialog button builder), so the generic `checkProperties` check does not
-    // duplicate them. Enclosing calls are visited before the properties they
-    // contain, so the specific branch always runs first.
+    // Literals already reported by a more specific branch (e.g. addCommand or
+    // a Dialog button builder), so the generic checks do not duplicate them.
+    // Enclosing calls are visited before the properties they contain, so the
+    // specific branch always runs first.
     const reportedNodes = new Set<TSESTree.Node>();
 
     function report(
@@ -221,18 +234,32 @@ const noUntranslatedString = createRule({
     }
 
     /**
+     * Reports the string literal behind `value`, if there is one and it has
+     * not been reported already.
+     */
+    function reportRawString(
+      value: TSESTree.Node,
+      messageId: MessageId,
+      data?: Record<string, string>
+    ): void {
+      const raw = getRawString(value);
+      if (!raw || reportedNodes.has(raw.node) || !isReportableText(raw.value)) {
+        return;
+      }
+      report(raw.node, messageId, data);
+    }
+
+    /**
      * Reports a monitored JSX attribute whose value is a raw string.
      */
     function checkJsxAttributeValue(
       attrName: string | null,
       value: TSESTree.Node
     ): void {
-      if (!attrName || !checkJsxAttributes.has(attrName)) {
+      if (!attrName || !isMonitoredName(attrName)) {
         return;
       }
-      if (isReportableString(value)) {
-        report(value, 'untranslatedJsxAttribute', { prop: attrName });
-      }
+      reportRawString(value, 'untranslatedJsxAttribute', { prop: attrName });
     }
 
     return {
@@ -249,14 +276,16 @@ const noUntranslatedString = createRule({
           const properties = getObjectProperties(optionsArg);
           for (const propName of MONITORED_COMMAND_PROPS) {
             const prop = properties.get(propName);
-            if (prop && isReportableString(prop.value)) {
-              report(prop.value, 'untranslatedCommandProp', { prop: propName });
+            if (prop) {
+              reportRawString(prop.value, 'untranslatedCommandProp', {
+                prop: propName
+              });
             }
           }
           return;
         }
 
-        // Branch B: element.setAttribute('aria-label'/'aria-description'/'title', string)
+        // Branch B: element.setAttribute('aria-label', string)
         if (isSetAttributeCall(node)) {
           if (node.arguments.length < 2) {
             return;
@@ -265,16 +294,13 @@ const noUntranslatedString = createRule({
           if (
             attrNameArg.type !== 'Literal' ||
             typeof attrNameArg.value !== 'string' ||
-            !MONITORED_SET_ATTRIBUTE_ATTRS.includes(attrNameArg.value)
+            !isMonitoredName(attrNameArg.value)
           ) {
             return;
           }
-          const attrValueArg = node.arguments[1];
-          if (isReportableString(attrValueArg)) {
-            report(attrValueArg, 'untranslatedSetAttribute', {
-              attr: attrNameArg.value
-            });
-          }
+          reportRawString(node.arguments[1], 'untranslatedSetAttribute', {
+            attr: attrNameArg.value
+          });
           return;
         }
 
@@ -290,8 +316,8 @@ const noUntranslatedString = createRule({
           const properties = getObjectProperties(optionsArg);
           for (const propName of MONITORED_DIALOG_PROPS) {
             const prop = properties.get(propName);
-            if (prop && isReportableString(prop.value)) {
-              report(prop.value, 'untranslatedDialogOption', {
+            if (prop) {
+              reportRawString(prop.value, 'untranslatedDialogOption', {
                 prop: propName
               });
             }
@@ -310,8 +336,8 @@ const noUntranslatedString = createRule({
           }
           const properties = getObjectProperties(optionsArg);
           const labelProp = properties.get('label');
-          if (labelProp && isReportableString(labelProp.value)) {
-            report(labelProp.value, 'untranslatedDialogButtonLabel');
+          if (labelProp) {
+            reportRawString(labelProp.value, 'untranslatedDialogButtonLabel');
           }
         }
       },
@@ -331,12 +357,17 @@ const noUntranslatedString = createRule({
         const properties = getObjectProperties(optionsArg);
         for (const propName of MONITORED_DIALOG_PROPS) {
           const prop = properties.get(propName);
-          if (prop && isReportableString(prop.value)) {
-            report(prop.value, 'untranslatedDialogOption', { prop: propName });
+          if (prop) {
+            reportRawString(prop.value, 'untranslatedDialogOption', {
+              prop: propName
+            });
           }
         }
       },
 
+      // Any monitored assignment target: element.title = STRING,
+      // widget.label = STRING, this.label = STRING, node.textContent = STRING,
+      // and Lumino widget titles such as this.title.label = STRING
       AssignmentExpression(node) {
         if (node.operator !== '=') {
           return;
@@ -345,39 +376,28 @@ const noUntranslatedString = createRule({
         if (
           left.type !== 'MemberExpression' ||
           left.computed ||
-          left.property.type !== 'Identifier'
+          left.property.type !== 'Identifier' ||
+          !isMonitoredName(left.property.name)
         ) {
           return;
         }
-
-        // Any monitored assignment target: element.title = STRING,
-        // widget.label = STRING, this.label = STRING, node.textContent = STRING,
-        // and Lumino widget titles such as this.title.label = STRING
-        if (
-          checkAssignments.has(left.property.name) &&
-          isReportableString(node.right)
-        ) {
-          report(node.right, 'untranslatedPropertyAssign', {
-            prop: left.property.name
-          });
-        }
+        reportRawString(node.right, 'untranslatedPropertyAssign', {
+          prop: left.property.name
+        });
       },
 
       // Any monitored object property: { label: 'raw string' }.
-      // Runs after the call-specific branches above, which mark the nodes they
-      // already reported so a property is never reported twice.
+      // Runs after the call-specific branches above, which mark the literals
+      // they already reported so a property is never reported twice.
       Property(node) {
         if (node.shorthand) {
           return;
         }
         const keyName = getPropertyKeyName(node);
-        if (!keyName || !checkProperties.has(keyName)) {
+        if (!keyName || !isMonitoredName(keyName)) {
           return;
         }
-        if (reportedNodes.has(node.value) || !isReportableString(node.value)) {
-          return;
-        }
-        report(node.value, 'untranslatedProperty', { prop: keyName });
+        reportRawString(node.value, 'untranslatedProperty', { prop: keyName });
       },
 
       // Monitored attribute with a plain string: <span aria-label="text" />
@@ -410,9 +430,7 @@ const noUntranslatedString = createRule({
           checkJsxAttributeValue(attrName, node.expression);
           return;
         }
-        if (isReportableString(node.expression)) {
-          report(node.expression, 'untranslatedJsxText');
-        }
+        reportRawString(node.expression, 'untranslatedJsxText');
       }
     };
   }

--- a/tests/jupyter-no-untranslated-string.test.ts
+++ b/tests/jupyter-no-untranslated-string.test.ts
@@ -196,12 +196,23 @@ ruleTester.run('no-untranslated-string', noUntranslatedString, {
     // --- title.label: raw string ---
     {
       code: `this.title.label = 'Source';`,
-      errors: [{ messageId: 'untranslatedTitleProp', data: { prop: 'label' } }]
+      errors: [
+        { messageId: 'untranslatedPropertyAssign', data: { prop: 'label' } }
+      ]
     },
     // --- title.label: arbitrary receiver ---
     {
       code: `widget.title.label = 'My Panel';`,
-      errors: [{ messageId: 'untranslatedTitleProp', data: { prop: 'label' } }]
+      errors: [
+        { messageId: 'untranslatedPropertyAssign', data: { prop: 'label' } }
+      ]
+    },
+    // --- title.caption: raw string ---
+    {
+      code: `this.title.caption = 'Source file';`,
+      errors: [
+        { messageId: 'untranslatedPropertyAssign', data: { prop: 'caption' } }
+      ]
     },
     // --- showDialog: raw string title ---
     {
@@ -233,40 +244,33 @@ ruleTester.run('no-untranslated-string', noUntranslatedString, {
   ]
 });
 
-// checkAllLabels option tests
+// checkProperties tests
 ruleTester.run(
-  'no-untranslated-string (checkAllLabels)',
+  'no-untranslated-string (checkProperties)',
   noUntranslatedString,
   {
     valid: [
-      // Arbitrary `label` is not flagged unless the option is enabled
-      {
-        code: `const field = new MyField({ label: 'My field' });`
-      },
-      // Translated label
-      {
-        code: `const field = new MyField({ label: trans.__('My field') });`,
-        options: [{ checkAllLabels: true }]
-      },
-      // Non-literal label
-      {
-        code: `const field = new MyField({ label: someVar });`,
-        options: [{ checkAllLabels: true }]
-      },
-      // Empty label
-      {
-        code: `const field = new MyField({ label: '' });`,
-        options: [{ checkAllLabels: true }]
-      },
+      // Translated
+      { code: `const field = new MyField({ label: trans.__('My field') });` },
+      // Non-literal
+      { code: `const field = new MyField({ label: someVar });` },
+      // Empty
+      { code: `const field = new MyField({ label: '' });` },
       // Shorthand is a reference, not a literal
-      {
-        code: `const opts = { label };`,
-        options: [{ checkAllLabels: true }]
-      },
+      { code: `const opts = { label };` },
       // Computed keys are not tracked
+      { code: `const opts = { [label]: 'My field' };` },
+      // Property names outside the list are ignored
+      { code: `const opts = { id: 'my-id', className: 'my-class' };` },
+      // An empty list disables the check
       {
-        code: `const opts = { [label]: 'My field' };`,
-        options: [{ checkAllLabels: true }]
+        code: `const opts = { label: 'My field' };`,
+        options: [{ checkProperties: [] }]
+      },
+      // A custom list replaces the default one
+      {
+        code: `const opts = { label: 'My field' };`,
+        options: [{ checkProperties: ['caption'] }]
       }
     ],
     invalid: [
@@ -279,39 +283,48 @@ ruleTester.run(
             translator: translator
           });
         `,
-        options: [{ checkAllLabels: true }],
-        errors: [{ messageId: 'untranslatedLabelProp' }]
+        errors: [{ messageId: 'untranslatedProperty', data: { prop: 'label' } }]
       },
       // Plain object literal
       {
         code: `const opts = { label: 'My field' };`,
-        options: [{ checkAllLabels: true }],
-        errors: [{ messageId: 'untranslatedLabelProp' }]
+        errors: [{ messageId: 'untranslatedProperty', data: { prop: 'label' } }]
+      },
+      // `category` is checked by default too
+      {
+        code: `launcher.add({ command, category: 'Notebook' });`,
+        errors: [
+          { messageId: 'untranslatedProperty', data: { prop: 'category' } }
+        ]
       },
       // Quoted key
       {
         code: `const opts = { 'label': 'My field' };`,
-        options: [{ checkAllLabels: true }],
-        errors: [{ messageId: 'untranslatedLabelProp' }]
+        errors: [{ messageId: 'untranslatedProperty', data: { prop: 'label' } }]
       },
       // Template literal and concise arrow function
       {
         code: `const opts = { label: \`My field\` };`,
-        options: [{ checkAllLabels: true }],
-        errors: [{ messageId: 'untranslatedLabelProp' }]
+        errors: [{ messageId: 'untranslatedProperty', data: { prop: 'label' } }]
       },
       {
         code: `const opts = { label: () => 'My field' };`,
-        options: [{ checkAllLabels: true }],
-        errors: [{ messageId: 'untranslatedLabelProp' }]
+        errors: [{ messageId: 'untranslatedProperty', data: { prop: 'label' } }]
       },
-      // Nested labels are all reported
+      // Nested properties are all reported
       {
         code: `const opts = { label: 'Outer', child: { label: 'Inner' } };`,
-        options: [{ checkAllLabels: true }],
         errors: [
-          { messageId: 'untranslatedLabelProp' },
-          { messageId: 'untranslatedLabelProp' }
+          { messageId: 'untranslatedProperty', data: { prop: 'label' } },
+          { messageId: 'untranslatedProperty', data: { prop: 'label' } }
+        ]
+      },
+      // A custom list replaces the default one
+      {
+        code: `const opts = { label: 'My field', caption: 'My caption' };`,
+        options: [{ checkProperties: ['caption'] }],
+        errors: [
+          { messageId: 'untranslatedProperty', data: { prop: 'caption' } }
         ]
       },
       // More specific branches still win, without duplicate reports
@@ -322,15 +335,97 @@ ruleTester.run(
             execute: () => {}
           });
         `,
-        options: [{ checkAllLabels: true }],
         errors: [
           { messageId: 'untranslatedCommandProp', data: { prop: 'label' } }
         ]
       },
       {
         code: `Dialog.okButton({ label: 'Build' });`,
-        options: [{ checkAllLabels: true }],
         errors: [{ messageId: 'untranslatedDialogButtonLabel' }]
+      }
+    ]
+  }
+);
+
+// checkAssignments tests
+ruleTester.run(
+  'no-untranslated-string (checkAssignments)',
+  noUntranslatedString,
+  {
+    valid: [
+      { code: `widget.label = trans.__('Save');` },
+      { code: `this.label = trans.__('Save');` },
+      { code: `node.textContent = trans.__('Save');` },
+      { code: `img.alt = trans.__('A diagram');` },
+      // Not in the default list
+      { code: `el.className = 'my-class';` },
+      { code: `el.id = 'my-id';` },
+      // An empty list disables the check
+      { code: `widget.label = 'Save';`, options: [{ checkAssignments: [] }] },
+      // Dropping `label` also drops the Lumino widget title check
+      {
+        code: `widget.title.label = 'Source';`,
+        options: [{ checkAssignments: ['title'] }]
+      },
+      // A custom list replaces the default one
+      {
+        code: `widget.label = 'Save';`,
+        options: [{ checkAssignments: ['textContent'] }]
+      },
+      // Compound assignment is not a plain assignment
+      { code: `el.textContent += 'Save';` }
+    ],
+    invalid: [
+      {
+        code: `widget.label = 'Save';`,
+        errors: [
+          { messageId: 'untranslatedPropertyAssign', data: { prop: 'label' } }
+        ]
+      },
+      {
+        code: `this.label = 'Save';`,
+        errors: [
+          { messageId: 'untranslatedPropertyAssign', data: { prop: 'label' } }
+        ]
+      },
+      {
+        code: `node.textContent = 'Save';`,
+        errors: [
+          {
+            messageId: 'untranslatedPropertyAssign',
+            data: { prop: 'textContent' }
+          }
+        ]
+      },
+      {
+        code: `img.alt = 'A diagram';`,
+        errors: [
+          { messageId: 'untranslatedPropertyAssign', data: { prop: 'alt' } }
+        ]
+      },
+      // A custom list replaces the default one
+      {
+        code: `el.placeholder = 'Search';`,
+        options: [{ checkAssignments: ['placeholder'] }],
+        errors: [
+          {
+            messageId: 'untranslatedPropertyAssign',
+            data: { prop: 'placeholder' }
+          }
+        ]
+      },
+      // Lumino widget titles fall out of `label` / `caption` being listed
+      {
+        code: `widget.title.label = 'Source';`,
+        errors: [
+          { messageId: 'untranslatedPropertyAssign', data: { prop: 'label' } }
+        ]
+      },
+      {
+        code: `widget.title.caption = 'Source file';`,
+        errors: [
+          { messageId: 'untranslatedPropertyAssign', data: { prop: 'caption' } }
+        ]
       }
     ]
   }
@@ -377,45 +472,78 @@ jsxRuleTester.run('no-untranslated-string (JSX)', noUntranslatedString, {
     // --- JSX accessibility attributes must be translated ---
     {
       code: `<button aria-label={'Close dialog'} />`,
-      errors: [{ messageId: 'untranslatedJsxText' }]
+      errors: [
+        { messageId: 'untranslatedJsxAttribute', data: { prop: 'aria-label' } }
+      ]
     },
     {
       code: `<div title={'My tooltip'} />`,
-      errors: [{ messageId: 'untranslatedJsxText' }]
+      errors: [
+        { messageId: 'untranslatedJsxAttribute', data: { prop: 'title' } }
+      ]
     },
     {
       code: `<span aria-description={'Describes something'} />`,
-      errors: [{ messageId: 'untranslatedJsxText' }]
+      errors: [
+        {
+          messageId: 'untranslatedJsxAttribute',
+          data: { prop: 'aria-description' }
+        }
+      ]
     },
     {
       code: `<span aria-description="Describes something" />`,
-      errors: [{ messageId: 'untranslatedJsxText' }]
+      errors: [
+        {
+          messageId: 'untranslatedJsxAttribute',
+          data: { prop: 'aria-description' }
+        }
+      ]
     }
   ]
 });
 
+// checkJsxAttributes tests
 jsxRuleTester.run(
-  'no-untranslated-string (JSX, checkAllLabels)',
+  'no-untranslated-string (JSX, checkJsxAttributes)',
   noUntranslatedString,
   {
     valid: [
-      // Not flagged unless the option is enabled
-      { code: `<MyCheckbox label="Enable feature" />` },
+      { code: `<MyCheckbox label={trans.__('Enable feature')} />` },
+      // An empty list disables the check
       {
-        code: `<MyCheckbox label={trans.__('Enable feature')} />`,
-        options: [{ checkAllLabels: true }]
+        code: `<MyCheckbox label="Enable feature" />`,
+        options: [{ checkJsxAttributes: [] }]
+      },
+      // A custom list replaces the default one
+      {
+        code: `<MyCheckbox label="Enable feature" />`,
+        options: [{ checkJsxAttributes: ['placeholder'] }]
       }
     ],
     invalid: [
       {
         code: `<MyCheckbox label="Enable feature" />`,
-        options: [{ checkAllLabels: true }],
-        errors: [{ messageId: 'untranslatedLabelProp' }]
+        errors: [
+          { messageId: 'untranslatedJsxAttribute', data: { prop: 'label' } }
+        ]
       },
       {
         code: `<MyCheckbox label={'Enable feature'} />`,
-        options: [{ checkAllLabels: true }],
-        errors: [{ messageId: 'untranslatedLabelProp' }]
+        errors: [
+          { messageId: 'untranslatedJsxAttribute', data: { prop: 'label' } }
+        ]
+      },
+      // A custom list replaces the default one
+      {
+        code: `<MyInput placeholder="Search" label="Enable feature" />`,
+        options: [{ checkJsxAttributes: ['placeholder'] }],
+        errors: [
+          {
+            messageId: 'untranslatedJsxAttribute',
+            data: { prop: 'placeholder' }
+          }
+        ]
       }
     ]
   }

--- a/tests/jupyter-no-untranslated-string.test.ts
+++ b/tests/jupyter-no-untranslated-string.test.ts
@@ -233,6 +233,109 @@ ruleTester.run('no-untranslated-string', noUntranslatedString, {
   ]
 });
 
+// checkAllLabels option tests
+ruleTester.run(
+  'no-untranslated-string (checkAllLabels)',
+  noUntranslatedString,
+  {
+    valid: [
+      // Arbitrary `label` is not flagged unless the option is enabled
+      {
+        code: `const field = new MyField({ label: 'My field' });`
+      },
+      // Translated label
+      {
+        code: `const field = new MyField({ label: trans.__('My field') });`,
+        options: [{ checkAllLabels: true }]
+      },
+      // Non-literal label
+      {
+        code: `const field = new MyField({ label: someVar });`,
+        options: [{ checkAllLabels: true }]
+      },
+      // Empty label
+      {
+        code: `const field = new MyField({ label: '' });`,
+        options: [{ checkAllLabels: true }]
+      },
+      // Shorthand is a reference, not a literal
+      {
+        code: `const opts = { label };`,
+        options: [{ checkAllLabels: true }]
+      },
+      // Computed keys are not tracked
+      {
+        code: `const opts = { [label]: 'My field' };`,
+        options: [{ checkAllLabels: true }]
+      }
+    ],
+    invalid: [
+      // A `label` on an arbitrary constructor
+      {
+        code: `
+          const field = new MyField({
+            factory,
+            label: 'My field',
+            translator: translator
+          });
+        `,
+        options: [{ checkAllLabels: true }],
+        errors: [{ messageId: 'untranslatedLabelProp' }]
+      },
+      // Plain object literal
+      {
+        code: `const opts = { label: 'My field' };`,
+        options: [{ checkAllLabels: true }],
+        errors: [{ messageId: 'untranslatedLabelProp' }]
+      },
+      // Quoted key
+      {
+        code: `const opts = { 'label': 'My field' };`,
+        options: [{ checkAllLabels: true }],
+        errors: [{ messageId: 'untranslatedLabelProp' }]
+      },
+      // Template literal and concise arrow function
+      {
+        code: `const opts = { label: \`My field\` };`,
+        options: [{ checkAllLabels: true }],
+        errors: [{ messageId: 'untranslatedLabelProp' }]
+      },
+      {
+        code: `const opts = { label: () => 'My field' };`,
+        options: [{ checkAllLabels: true }],
+        errors: [{ messageId: 'untranslatedLabelProp' }]
+      },
+      // Nested labels are all reported
+      {
+        code: `const opts = { label: 'Outer', child: { label: 'Inner' } };`,
+        options: [{ checkAllLabels: true }],
+        errors: [
+          { messageId: 'untranslatedLabelProp' },
+          { messageId: 'untranslatedLabelProp' }
+        ]
+      },
+      // More specific branches still win, without duplicate reports
+      {
+        code: `
+          commands.addCommand('file-download', {
+            label: 'Download',
+            execute: () => {}
+          });
+        `,
+        options: [{ checkAllLabels: true }],
+        errors: [
+          { messageId: 'untranslatedCommandProp', data: { prop: 'label' } }
+        ]
+      },
+      {
+        code: `Dialog.okButton({ label: 'Build' });`,
+        options: [{ checkAllLabels: true }],
+        errors: [{ messageId: 'untranslatedDialogButtonLabel' }]
+      }
+    ]
+  }
+);
+
 // JSX tests require a separate tester with JSX parsing enabled
 const jsxRuleTester = new RuleTester({
   languageOptions: {
@@ -290,6 +393,33 @@ jsxRuleTester.run('no-untranslated-string (JSX)', noUntranslatedString, {
     }
   ]
 });
+
+jsxRuleTester.run(
+  'no-untranslated-string (JSX, checkAllLabels)',
+  noUntranslatedString,
+  {
+    valid: [
+      // Not flagged unless the option is enabled
+      { code: `<MyCheckbox label="Enable feature" />` },
+      {
+        code: `<MyCheckbox label={trans.__('Enable feature')} />`,
+        options: [{ checkAllLabels: true }]
+      }
+    ],
+    invalid: [
+      {
+        code: `<MyCheckbox label="Enable feature" />`,
+        options: [{ checkAllLabels: true }],
+        errors: [{ messageId: 'untranslatedLabelProp' }]
+      },
+      {
+        code: `<MyCheckbox label={'Enable feature'} />`,
+        options: [{ checkAllLabels: true }],
+        errors: [{ messageId: 'untranslatedLabelProp' }]
+      }
+    ]
+  }
+);
 
 // enforcePunctuation option tests
 jsxRuleTester.run(

--- a/tests/jupyter-no-untranslated-string.test.ts
+++ b/tests/jupyter-no-untranslated-string.test.ts
@@ -262,6 +262,7 @@ ruleTester.run(
       { code: `const opts = { [label]: 'My field' };` },
       // Property names outside the list are ignored
       { code: `const opts = { id: 'my-id', className: 'my-class' };` },
+      { code: `const opts = { label: '-' };` },
       // An empty list disables the check
       {
         code: `const opts = { label: 'My field' };`,
@@ -360,6 +361,10 @@ ruleTester.run(
       // Not in the default list
       { code: `el.className = 'my-class';` },
       { code: `el.id = 'my-id';` },
+      { code: `item.textContent = '/';` },
+      { code: `title.textContent = '-';` },
+      { code: `anchor.textContent = '¶';` },
+      { code: `widget.label = ' … ';` },
       // An empty list disables the check
       { code: `widget.label = 'Save';`, options: [{ checkAssignments: [] }] },
       // Dropping `label` also drops the Lumino widget title check
@@ -425,6 +430,49 @@ ruleTester.run(
         code: `widget.title.caption = 'Source file';`,
         errors: [
           { messageId: 'untranslatedPropertyAssign', data: { prop: 'caption' } }
+        ]
+      }
+    ]
+  }
+);
+
+// enforcePunctuation applies to every position, not just JSX
+ruleTester.run(
+  'no-untranslated-string (enforcePunctuation)',
+  noUntranslatedString,
+  {
+    valid: [
+      // Blank strings stay ignored even with enforcePunctuation on
+      {
+        code: `item.textContent = '';`,
+        options: [{ enforcePunctuation: true }]
+      },
+      {
+        code: `const opts = { label: '   ' };`,
+        options: [{ enforcePunctuation: true }]
+      }
+    ],
+    invalid: [
+      {
+        code: `item.textContent = '/';`,
+        options: [{ enforcePunctuation: true }],
+        errors: [
+          {
+            messageId: 'untranslatedPropertyAssign',
+            data: { prop: 'textContent' }
+          }
+        ]
+      },
+      {
+        code: `const opts = { label: '-' };`,
+        options: [{ enforcePunctuation: true }],
+        errors: [{ messageId: 'untranslatedProperty', data: { prop: 'label' } }]
+      },
+      {
+        code: `commands.addCommand('sep', { label: '-', execute: () => {} });`,
+        options: [{ enforcePunctuation: true }],
+        errors: [
+          { messageId: 'untranslatedCommandProp', data: { prop: 'label' } }
         ]
       }
     ]

--- a/tests/jupyter-no-untranslated-string.test.ts
+++ b/tests/jupyter-no-untranslated-string.test.ts
@@ -348,93 +348,89 @@ ruleTester.run(
   }
 );
 
-// checkAssignments tests
-ruleTester.run(
-  'no-untranslated-string (checkAssignments)',
-  noUntranslatedString,
-  {
-    valid: [
-      { code: `widget.label = trans.__('Save');` },
-      { code: `this.label = trans.__('Save');` },
-      { code: `node.textContent = trans.__('Save');` },
-      { code: `img.alt = trans.__('A diagram');` },
-      // Not in the default list
-      { code: `el.className = 'my-class';` },
-      { code: `el.id = 'my-id';` },
-      { code: `item.textContent = '/';` },
-      { code: `title.textContent = '-';` },
-      { code: `anchor.textContent = '¶';` },
-      { code: `widget.label = ' … ';` },
-      // An empty list disables the check
-      { code: `widget.label = 'Save';`, options: [{ checkAssignments: [] }] },
-      // Dropping `label` also drops the Lumino widget title check
-      {
-        code: `widget.title.label = 'Source';`,
-        options: [{ checkAssignments: ['title'] }]
-      },
-      // A custom list replaces the default one
-      {
-        code: `widget.label = 'Save';`,
-        options: [{ checkAssignments: ['textContent'] }]
-      },
-      // Compound assignment is not a plain assignment
-      { code: `el.textContent += 'Save';` }
-    ],
-    invalid: [
-      {
-        code: `widget.label = 'Save';`,
-        errors: [
-          { messageId: 'untranslatedPropertyAssign', data: { prop: 'label' } }
-        ]
-      },
-      {
-        code: `this.label = 'Save';`,
-        errors: [
-          { messageId: 'untranslatedPropertyAssign', data: { prop: 'label' } }
-        ]
-      },
-      {
-        code: `node.textContent = 'Save';`,
-        errors: [
-          {
-            messageId: 'untranslatedPropertyAssign',
-            data: { prop: 'textContent' }
-          }
-        ]
-      },
-      {
-        code: `img.alt = 'A diagram';`,
-        errors: [
-          { messageId: 'untranslatedPropertyAssign', data: { prop: 'alt' } }
-        ]
-      },
-      // A custom list replaces the default one
-      {
-        code: `el.placeholder = 'Search';`,
-        options: [{ checkAssignments: ['placeholder'] }],
-        errors: [
-          {
-            messageId: 'untranslatedPropertyAssign',
-            data: { prop: 'placeholder' }
-          }
-        ]
-      },
-      // Lumino widget titles fall out of `label` / `caption` being listed
-      {
-        code: `widget.title.label = 'Source';`,
-        errors: [
-          { messageId: 'untranslatedPropertyAssign', data: { prop: 'label' } }
-        ]
-      },
-      {
-        code: `widget.title.caption = 'Source file';`,
-        errors: [
-          { messageId: 'untranslatedPropertyAssign', data: { prop: 'caption' } }
-        ]
-      }
-    ]
-  }
-);
+// checkProperties applied to assignment targets
+ruleTester.run('no-untranslated-string (assignments)', noUntranslatedString, {
+  valid: [
+    { code: `widget.label = trans.__('Save');` },
+    { code: `this.label = trans.__('Save');` },
+    { code: `node.textContent = trans.__('Save');` },
+    { code: `img.alt = trans.__('A diagram');` },
+    // Not in the default list
+    { code: `el.className = 'my-class';` },
+    { code: `el.id = 'my-id';` },
+    { code: `item.textContent = '/';` },
+    { code: `title.textContent = '-';` },
+    { code: `anchor.textContent = '¶';` },
+    { code: `widget.label = ' … ';` },
+    // An empty list disables the check
+    { code: `widget.label = 'Save';`, options: [{ checkProperties: [] }] },
+    // Dropping `label` also drops the Lumino widget title check
+    {
+      code: `widget.title.label = 'Source';`,
+      options: [{ checkProperties: ['title'] }]
+    },
+    // A custom list replaces the default one
+    {
+      code: `widget.label = 'Save';`,
+      options: [{ checkProperties: ['textContent'] }]
+    },
+    // Compound assignment is not a plain assignment
+    { code: `el.textContent += 'Save';` }
+  ],
+  invalid: [
+    {
+      code: `widget.label = 'Save';`,
+      errors: [
+        { messageId: 'untranslatedPropertyAssign', data: { prop: 'label' } }
+      ]
+    },
+    {
+      code: `this.label = 'Save';`,
+      errors: [
+        { messageId: 'untranslatedPropertyAssign', data: { prop: 'label' } }
+      ]
+    },
+    {
+      code: `node.textContent = 'Save';`,
+      errors: [
+        {
+          messageId: 'untranslatedPropertyAssign',
+          data: { prop: 'textContent' }
+        }
+      ]
+    },
+    {
+      code: `img.alt = 'A diagram';`,
+      errors: [
+        { messageId: 'untranslatedPropertyAssign', data: { prop: 'alt' } }
+      ]
+    },
+    // A custom list replaces the default one
+    {
+      code: `el.placeholder = 'Search';`,
+      options: [{ checkProperties: ['placeholder'] }],
+      errors: [
+        {
+          messageId: 'untranslatedPropertyAssign',
+          data: { prop: 'placeholder' }
+        }
+      ]
+    },
+    // Lumino widget titles fall out of `label` / `caption` being listed
+    {
+      code: `widget.title.label = 'Source';`,
+      errors: [
+        { messageId: 'untranslatedPropertyAssign', data: { prop: 'label' } }
+      ]
+    },
+    {
+      code: `widget.title.caption = 'Source file';`,
+      errors: [
+        { messageId: 'untranslatedPropertyAssign', data: { prop: 'caption' } }
+      ]
+    }
+  ]
+});
 
 // enforcePunctuation applies to every position, not just JSX
 ruleTester.run(
@@ -551,9 +547,9 @@ jsxRuleTester.run('no-untranslated-string (JSX)', noUntranslatedString, {
   ]
 });
 
-// checkJsxAttributes tests
+// checkProperties applied to JSX attributes
 jsxRuleTester.run(
-  'no-untranslated-string (JSX, checkJsxAttributes)',
+  'no-untranslated-string (JSX attributes)',
   noUntranslatedString,
   {
     valid: [
@@ -561,12 +557,12 @@ jsxRuleTester.run(
       // An empty list disables the check
       {
         code: `<MyCheckbox label="Enable feature" />`,
-        options: [{ checkJsxAttributes: [] }]
+        options: [{ checkProperties: [] }]
       },
       // A custom list replaces the default one
       {
         code: `<MyCheckbox label="Enable feature" />`,
-        options: [{ checkJsxAttributes: ['placeholder'] }]
+        options: [{ checkProperties: ['placeholder'] }]
       }
     ],
     invalid: [
@@ -585,7 +581,7 @@ jsxRuleTester.run(
       // A custom list replaces the default one
       {
         code: `<MyInput placeholder="Search" label="Enable feature" />`,
-        options: [{ checkJsxAttributes: ['placeholder'] }],
+        options: [{ checkProperties: ['placeholder'] }],
         errors: [
           {
             messageId: 'untranslatedJsxAttribute',
@@ -622,6 +618,222 @@ jsxRuleTester.run(
         code: `<span>{'.'}</span>`,
         options: [{ enforcePunctuation: true }],
         errors: [{ messageId: 'untranslatedJsxText' }]
+      }
+    ]
+  }
+);
+
+// One list drives every generic position, so a name never applies in one
+// place but not another
+ruleTester.run(
+  'no-untranslated-string (one list, every position)',
+  noUntranslatedString,
+  {
+    valid: [
+      { code: `el.setAttribute('alt', trans.__('A diagram'));` },
+      // Removing a name removes it from every position at once
+      {
+        code: `
+          img.alt = 'A diagram';
+          el.setAttribute('alt', 'A diagram');
+          const opts = { alt: 'A diagram' };
+        `,
+        options: [{ checkProperties: [] }]
+      }
+    ],
+    invalid: [
+      // `alt` used to report on assignment only
+      {
+        code: `el.setAttribute('alt', 'A diagram');`,
+        errors: [
+          { messageId: 'untranslatedSetAttribute', data: { attr: 'alt' } }
+        ]
+      },
+      {
+        code: `const opts = { alt: 'A diagram' };`,
+        errors: [{ messageId: 'untranslatedProperty', data: { prop: 'alt' } }]
+      },
+      // `placeholder` is checked by default
+      {
+        code: `input.placeholder = 'Search files';`,
+        errors: [
+          {
+            messageId: 'untranslatedPropertyAssign',
+            data: { prop: 'placeholder' }
+          }
+        ]
+      },
+      {
+        code: `InputDialog.getText({ placeholder: 'Enter WMS URL' });`,
+        errors: [
+          { messageId: 'untranslatedProperty', data: { prop: 'placeholder' } }
+        ]
+      },
+      // `innerText` is handled like `textContent`
+      {
+        code: `node.innerText = 'Save';`,
+        errors: [
+          {
+            messageId: 'untranslatedPropertyAssign',
+            data: { prop: 'innerText' }
+          }
+        ]
+      },
+      // `title` is checked in plain object literals too
+      {
+        code: `const format = { id: 'csv', title: 'Comma separated values' };`,
+        errors: [{ messageId: 'untranslatedProperty', data: { prop: 'title' } }]
+      }
+    ]
+  }
+);
+
+// Hyphenated and camelCase spellings of a name are the same entry
+ruleTester.run('no-untranslated-string (name spelling)', noUntranslatedString, {
+  valid: [
+    // Listing only `label` leaves the aria names alone in every spelling
+    {
+      code: `
+        el.ariaLabel = 'Search results';
+        el.setAttribute('aria-label', 'Search results');
+      `,
+      options: [{ checkProperties: ['label'] }]
+    }
+  ],
+  invalid: [
+    // The default list spells it `aria-label`; the DOM property matches too
+    {
+      code: `el.ariaLabel = 'Search results';`,
+      errors: [
+        { messageId: 'untranslatedPropertyAssign', data: { prop: 'ariaLabel' } }
+      ]
+    },
+    // ... and a camelCase entry matches the hyphenated attribute
+    {
+      code: `el.setAttribute('aria-label', 'Search results');`,
+      options: [{ checkProperties: ['ariaLabel'] }],
+      errors: [
+        { messageId: 'untranslatedSetAttribute', data: { attr: 'aria-label' } }
+      ]
+    }
+  ]
+});
+
+// TypeScript wrappers around a literal do not hide it
+ruleTester.run(
+  'no-untranslated-string (TypeScript wrappers)',
+  noUntranslatedString,
+  {
+    valid: [{ code: `const o = { label: trans.__('Save') as string };` }],
+    invalid: [
+      {
+        code: `const o = { label: 'Save' as const };`,
+        errors: [{ messageId: 'untranslatedProperty', data: { prop: 'label' } }]
+      },
+      {
+        code: `widget.label = 'Save' as string;`,
+        errors: [
+          { messageId: 'untranslatedPropertyAssign', data: { prop: 'label' } }
+        ]
+      },
+      {
+        code: `el.setAttribute('title', <string>'Close Tab');`,
+        errors: [
+          { messageId: 'untranslatedSetAttribute', data: { attr: 'title' } }
+        ]
+      }
+    ]
+  }
+);
+
+// The literal is reported, not the wrapper that holds it
+ruleTester.run(
+  'no-untranslated-string (report location)',
+  noUntranslatedString,
+  {
+    valid: [],
+    invalid: [
+      {
+        code: `const opts = { label: () => 'My field' };`,
+        errors: [
+          {
+            messageId: 'untranslatedProperty',
+            data: { prop: 'label' },
+            type: 'Literal',
+            column: 29,
+            endColumn: 39
+          }
+        ]
+      },
+      {
+        code: `const opts = { label: 'My field' as const };`,
+        errors: [
+          {
+            messageId: 'untranslatedProperty',
+            data: { prop: 'label' },
+            type: 'Literal',
+            column: 23,
+            endColumn: 33
+          }
+        ]
+      }
+    ]
+  }
+);
+
+// Digits are content, not punctuation: enforcePunctuation does not gate them
+ruleTester.run('no-untranslated-string (digits)', noUntranslatedString, {
+  valid: [{ code: `const opts = { label: '-' };` }],
+  invalid: [
+    {
+      code: `const opts = { label: '1970' };`,
+      errors: [{ messageId: 'untranslatedProperty', data: { prop: 'label' } }]
+    },
+    {
+      code: `node.textContent = '100%';`,
+      errors: [
+        {
+          messageId: 'untranslatedPropertyAssign',
+          data: { prop: 'textContent' }
+        }
+      ]
+    }
+  ]
+});
+
+// JSX shares the same list
+jsxRuleTester.run(
+  'no-untranslated-string (JSX, one list)',
+  noUntranslatedString,
+  {
+    valid: [{ code: `<img alt={trans.__('A diagram')} />` }],
+    invalid: [
+      // `alt` used to report on assignment only
+      {
+        code: `<img alt="A diagram" />`,
+        errors: [
+          { messageId: 'untranslatedJsxAttribute', data: { prop: 'alt' } }
+        ]
+      },
+      {
+        code: `<input placeholder="Search files" />`,
+        errors: [
+          {
+            messageId: 'untranslatedJsxAttribute',
+            data: { prop: 'placeholder' }
+          }
+        ]
+      },
+      // A camelCase entry matches the hyphenated JSX attribute
+      {
+        code: `<span aria-label="Close" />`,
+        options: [{ checkProperties: ['ariaLabel'] }],
+        errors: [
+          {
+            messageId: 'untranslatedJsxAttribute',
+            data: { prop: 'aria-label' }
+          }
+        ]
       }
     ]
   }

--- a/website/docs/rules/no-untranslated-string.md
+++ b/website/docs/rules/no-untranslated-string.md
@@ -4,7 +4,9 @@ Require user-facing string literals to be wrapped in a translation call such as 
 
 ## Rule details
 
-The rule reports raw string literals (and template literals without expressions) in the following positions:
+The rule reports raw string literals (and template literals without expressions) in the following positions.
+
+In every position, blank strings are never flagged. Strings with no letters — such as `'/'` and `'-'` — can be translatable, but this rule only flags them when [`enforcePunctuation`](#enforcepunctuation) is on.
 
 ### 1. `commands.addCommand()` properties
 
@@ -139,6 +141,13 @@ Each `check*` option is a list of names that **replaces** the default list rathe
 ### `enforcePunctuation`
 
 Set to `true` to enforce translation of punctuation characters such as `,`, `-`, `+`, and other symbols.
+
+```ts
+// Not flagged by default; flagged when enforcePunctuation is true
+item.textContent = '/';
+anchor.textContent = '+';
+const el = <span>,</span>;
+```
 
 ### `checkProperties`
 

--- a/website/docs/rules/no-untranslated-string.md
+++ b/website/docs/rules/no-untranslated-string.md
@@ -31,31 +31,27 @@ node.setAttribute('aria-label', 'main sidebar');
 node.setAttribute('aria-label', trans.__('main sidebar'));
 ```
 
-### 3. Direct assignment to `title` and `ariaLabel`
+### 3. Direct property assignment
+
+Applies to the names in [`checkAssignments`](#checkassignments), on any receiver. Because the receiver is not inspected, this also covers widget title properties such as `this.title.label`.
 
 ```ts
 // Incorrect
 element.title = 'Close Tab';
 element.ariaLabel = 'Search results';
+element.textContent = 'Save';
+widget.label = 'Save';
+this.title.label = 'Source';
 
 // Correct
 element.title = trans.__('Close Tab');
 element.ariaLabel = trans.__('Search results');
-```
-
-### 4. Lumino widget title properties
-
-Applies to `*.title.label` and `*.title.caption` assignments.
-
-```ts
-// Incorrect
-this.title.label = 'Source';
-
-// Correct
+element.textContent = trans.__('Save');
+widget.label = trans.__('Save');
 this.title.label = trans.__('Source');
 ```
 
-### 5. `showDialog()` and `new Dialog()` options
+### 4. `showDialog()` and `new Dialog()` options
 
 The `title` and `body` options must not be raw strings.
 
@@ -67,7 +63,7 @@ showDialog({ title: 'Confirm', body: 'Are you sure?' });
 showDialog({ title: trans.__('Confirm'), body: trans.__('Are you sure?') });
 ```
 
-### 6. Dialog button builder labels
+### 5. Dialog button builder labels
 
 Applies to `Dialog.okButton`, `Dialog.cancelButton`, `Dialog.warnButton`, and `Dialog.errorButton`.
 
@@ -79,7 +75,7 @@ Dialog.okButton({ label: 'Build' });
 Dialog.okButton({ label: trans.__('Build') });
 ```
 
-### 7. JSX text content
+### 6. JSX text content
 
 Raw text between JSX tags and string literals inside `{...}` expressions are flagged.
 
@@ -92,18 +88,32 @@ const el = <span>{'raw string'}</span>;
 const el = <span>{trans.__('Error message:')}</span>;
 ```
 
-### 8. Any `label` property (opt-in)
+### 7. JSX attributes
 
-With the [`checkAllLabels`](#checkalllabels) option enabled, every `label: 'raw string'` object property and every raw `label` JSX attribute is flagged, no matter which call or component it belongs to.
+Applies to the names in [`checkJsxAttributes`](#checkjsxattributes), on any element.
 
 ```tsx
 // Incorrect
-new MyField({ ...options, label: 'My field' });
+const el = <span aria-label="Close" />;
 const el = <MyCheckbox label="Enable feature" />;
 
 // Correct
-new MyField({ ...options, label: trans.__('My field') });
+const el = <span aria-label={trans.__('Close')} />;
 const el = <MyCheckbox label={trans.__('Enable feature')} />;
+```
+
+### 8. Object properties
+
+Applies to the names in [`checkProperties`](#checkproperties), in any object literal — this catches labels handed to widgets and components the rule knows nothing about.
+
+```ts
+// Incorrect
+new MyField({ ...options, label: 'My field' });
+launcher.add({ command, category: 'Notebook' });
+
+// Correct
+new MyField({ ...options, label: trans.__('My field') });
+launcher.add({ command, category: trans.__('Notebook') });
 ```
 
 ## Options
@@ -111,14 +121,33 @@ const el = <MyCheckbox label={trans.__('Enable feature')} />;
 ```ts
 {
   "enforcePunctuation": false,
-  "checkAllLabels": false
+  "checkProperties": ["label", "category"],
+  "checkJsxAttributes": ["aria-label", "aria-description", "title", "label"],
+  "checkAssignments": [
+    "title",
+    "ariaLabel",
+    "alt",
+    "textContent",
+    "label",
+    "caption"
+  ]
 }
 ```
+
+Each `check*` option is a list of names that **replaces** the default list rather than adding to it. Pass `[]` to turn that check off entirely.
 
 ### `enforcePunctuation`
 
 Set to `true` to enforce translation of punctuation characters such as `,`, `-`, `+`, and other symbols.
 
-### `checkAllLabels`
+### `checkProperties`
 
-Set to `true` to flag every `label` property whose value is a raw string literal, rather than only the `label` positions the rule knows about.
+Object property names flagged when their value is a raw string literal, in any object literal.
+
+### `checkJsxAttributes`
+
+JSX attribute names flagged when their value is a raw string literal, whether written as `label="text"` or `label={'text'}`.
+
+### `checkAssignments`
+
+Property names flagged when a raw string literal is assigned to them, on any receiver — `widget.label = 'Save'`, `this.label = 'Save'`, `node.textContent = 'Save'`. Only plain `=` assignments are checked.

--- a/website/docs/rules/no-untranslated-string.md
+++ b/website/docs/rules/no-untranslated-string.md
@@ -92,12 +92,33 @@ const el = <span>{'raw string'}</span>;
 const el = <span>{trans.__('Error message:')}</span>;
 ```
 
+### 8. Any `label` property (opt-in)
+
+With the [`checkAllLabels`](#checkalllabels) option enabled, every `label: 'raw string'` object property and every raw `label` JSX attribute is flagged, no matter which call or component it belongs to.
+
+```tsx
+// Incorrect
+new MyField({ ...options, label: 'My field' });
+const el = <MyCheckbox label="Enable feature" />;
+
+// Correct
+new MyField({ ...options, label: trans.__('My field') });
+const el = <MyCheckbox label={trans.__('Enable feature')} />;
+```
+
 ## Options
 
 ```ts
 {
-  "enforcePunctuation": false
+  "enforcePunctuation": false,
+  "checkAllLabels": false
 }
 ```
 
-Set `enforcePunctuation` option to `true` to enforce translation of punctuation characters such as `,`, `-`, `+`, and other symbols.
+### `enforcePunctuation`
+
+Set to `true` to enforce translation of punctuation characters such as `,`, `-`, `+`, and other symbols.
+
+### `checkAllLabels`
+
+Set to `true` to flag every `label` property whose value is a raw string literal, rather than only the `label` positions the rule knows about.

--- a/website/docs/rules/no-untranslated-string.md
+++ b/website/docs/rules/no-untranslated-string.md
@@ -6,7 +6,7 @@ Require user-facing string literals to be wrapped in a translation call such as 
 
 The rule reports raw string literals (and template literals without expressions) in the following positions.
 
-In every position, blank strings are never flagged. Strings with no letters — such as `'/'` and `'-'` — can be translatable, but this rule only flags them when [`enforcePunctuation`](#enforcepunctuation) is on.
+In every position, blank strings are never flagged. Strings of pure punctuation — such as `'/'` and `'-'` — can be translatable, but this rule only flags them when [`enforcePunctuation`](#enforcepunctuation) is on.
 
 ### 1. `commands.addCommand()` properties
 
@@ -21,9 +21,9 @@ commands.addCommand('file-download', { label: trans.__('Download') });
 commands.addCommand('file-download', { label: () => trans.__('Download') });
 ```
 
-### 2. `element.setAttribute()` with accessibility attributes
+### 2. `element.setAttribute()`
 
-Applies to `aria-label`, `aria-description`, and `title`.
+Applies to the names in [`checkProperties`](#checkproperties).
 
 ```ts
 // Incorrect
@@ -35,7 +35,7 @@ node.setAttribute('aria-label', trans.__('main sidebar'));
 
 ### 3. Direct property assignment
 
-Applies to the names in [`checkAssignments`](#checkassignments), on any receiver. Because the receiver is not inspected, this also covers widget title properties such as `this.title.label`.
+Applies to the names in [`checkProperties`](#checkproperties), on any receiver. Because the receiver is not inspected, this also covers widget title properties such as `this.title.label`.
 
 ```ts
 // Incorrect
@@ -92,7 +92,7 @@ const el = <span>{trans.__('Error message:')}</span>;
 
 ### 7. JSX attributes
 
-Applies to the names in [`checkJsxAttributes`](#checkjsxattributes), on any element.
+Applies to the names in [`checkProperties`](#checkproperties), on any element.
 
 ```tsx
 // Incorrect
@@ -123,24 +123,24 @@ launcher.add({ command, category: trans.__('Notebook') });
 ```ts
 {
   "enforcePunctuation": false,
-  "checkProperties": ["label", "category"],
-  "checkJsxAttributes": ["aria-label", "aria-description", "title", "label"],
-  "checkAssignments": [
-    "title",
-    "ariaLabel",
+  "checkProperties": [
     "alt",
-    "textContent",
+    "aria-description",
+    "aria-label",
+    "caption",
+    "category",
     "label",
-    "caption"
+    "placeholder",
+    "title",
+    "textContent",
+    "innerText"
   ]
 }
 ```
 
-Each `check*` option is a list of names that **replaces** the default list rather than adding to it. Pass `[]` to turn that check off entirely.
-
 ### `enforcePunctuation`
 
-Set to `true` to enforce translation of punctuation characters such as `,`, `-`, `+`, and other symbols.
+Set to `true` to enforce translation of punctuation characters such as `,`, `-`, `+`, and other symbols. Digits are not punctuation: `label: '1970'` is flagged either way.
 
 ```ts
 // Not flagged by default; flagged when enforcePunctuation is true
@@ -151,12 +151,8 @@ const el = <span>,</span>;
 
 ### `checkProperties`
 
-Object property names flagged when their value is a raw string literal, in any object literal.
+The names checked in sections 2, 3, 7 and 8 above — object literal properties, `setAttribute()` attributes, assignment targets and JSX attributes all share this one list, so a name can never apply in one of those positions but not another.
 
-### `checkJsxAttributes`
+The list **replaces** the default rather than adding to it. Pass `[]` to turn those four checks off; the `addCommand`, dialog, dialog button and JSX text checks (sections 1, 4, 5 and 6) are not configurable and stay on.
 
-JSX attribute names flagged when their value is a raw string literal, whether written as `label="text"` or `label={'text'}`.
-
-### `checkAssignments`
-
-Property names flagged when a raw string literal is assigned to them, on any receiver — `widget.label = 'Save'`, `this.label = 'Save'`, `node.textContent = 'Save'`. Only plain `=` assignments are checked.
+Hyphenated and camelCase spellings are the same entry, so listing either `aria-label` or `ariaLabel` covers both the `aria-label` attribute and the `ariaLabel` DOM property.


### PR DESCRIPTION
## Fixes #100 

### Description

Untranslated `label` props were slipping through since the rule only looked at `addCommand()` and dialog button labels. Instead of a one-off `label` heuristic, the monitored names are now one configurable list, shared by every generic position the rule checks.

```js
{
  "checkProperties": [
    "alt", "aria-description", "aria-label", "caption", "category",
    "label", "placeholder", "title", "textContent", "innerText"
  ]
}
```

One list covers object literal properties, `setAttribute()` attributes, assignment targets and JSX attributes — so `label:` in any object literal, raw `label=` on any element, and `widget.label = 'Save'` / `this.label = 'Save'` are all caught. Also hyphenated and camelCase spellings are the same entry, so `aria-label` and `ariaLabel` are one name.

Also `enforcePunctuation` no longer gates digits, only punctuation, `label: '1970'` is flagged either way.