### PR TITLE
Add kernel session types to `longLivedTypes`

### DIFF
--- a/src/utils/signal-lifetime.ts
+++ b/src/utils/signal-lifetime.ts
@@ -53,6 +53,8 @@ export const DEFAULT_LONG_LIVED_TYPES: readonly string[] = [
   'ILabShell',
   'ILanguageServerManager',
   'IRenderMimeRegistry',
+  'ISessionConnection',
+  'ISessionContext',
   'ISettingRegistry',
   'IShell',
   'IStateDB',
@@ -451,11 +453,11 @@ export interface LifetimeContext {
   longLivedTypes: ReadonlySet<string>;
 }
 
-/** Resolves the symbol name of an expression's static type, if available. */
-function typeNameOf(
+/** Resolves the symbol of an expression's static type, if available. */
+function typeSymbolOf(
   node: TSESTree.Node,
   context: LifetimeContext
-): string | null {
+): ts.Symbol | null {
   const { checker, services } = context;
   if (!checker || !services || !services.esTreeNodeToTSNodeMap) {
     return null;
@@ -486,10 +488,74 @@ function typeNameOf(
         // Keep the un-aliased symbol.
       }
     }
-    return symbol.getName();
+    return symbol;
   } catch {
     return null;
   }
+}
+
+/** Resolves the symbol name of an expression's static type, if available. */
+function typeNameOf(
+  node: TSESTree.Node,
+  context: LifetimeContext
+): string | null {
+  const symbol = typeSymbolOf(node, context);
+  return symbol ? symbol.getName() : null;
+}
+
+/**
+ * The namespace path of an expression's static type, outermost first:
+ * `ISessionConnection` declared in `namespace Session` comes back as
+ * `['Session', 'ISessionConnection']`.
+ */
+function typeNamePathOf(
+  node: TSESTree.Node,
+  context: LifetimeContext
+): string[] {
+  const symbol = typeSymbolOf(node, context);
+  if (!symbol || !context.checker) {
+    return [];
+  }
+  let qualified: string;
+  try {
+    qualified = context.checker.getFullyQualifiedName(symbol);
+  } catch {
+    return [symbol.getName()];
+  }
+  // A module-scoped symbol is qualified by its quoted specifier, which may
+  // itself contain dots (`"@jupyterlab/services"`, `"./foo.bar"`).
+  const withoutModule = qualified.replace(/^(["'])(?:(?!\1).)*\1\.?/, '');
+  const segments = (withoutModule || qualified).split('.').filter(Boolean);
+  return segments.length > 0 ? segments : [symbol.getName()];
+}
+
+/**
+ * The `longLivedTypes` entry matching this expression's static type, or null.
+ *
+ * An entry matches when it is a suffix of the type's namespace path, so
+ * `Session.ISessionConnection` and a bare `ISessionConnection` both match
+ * `Session.ISessionConnection` while `Session.ISessionConnection` does not
+ * match some unrelated top-level `ISessionConnection`.
+ */
+function matchLongLivedType(
+  node: TSESTree.Node,
+  context: LifetimeContext
+): string | null {
+  const path = typeNamePathOf(node, context);
+  if (path.length === 0) {
+    return null;
+  }
+  for (const entry of context.longLivedTypes) {
+    const wanted = entry.split('.').filter(Boolean);
+    if (wanted.length === 0 || wanted.length > path.length) {
+      continue;
+    }
+    const offset = path.length - wanted.length;
+    if (wanted.every((segment, i) => segment === path[offset + i])) {
+      return entry;
+    }
+  }
+  return null;
 }
 
 function isWidgetTyped(node: TSESTree.Node, context: LifetimeContext): boolean {
@@ -764,8 +830,8 @@ function isLongLivedService(
   // configured entry) is not matched against itself.
   const start = chain.root?.type === 'ThisExpression' ? 1 : 0;
   for (let i = start; i < chain.prefixes.length; i++) {
-    const name = typeNameOf(chain.prefixes[i], context);
-    if (!name || !context.longLivedTypes.has(name)) {
+    const name = matchLongLivedType(chain.prefixes[i], context);
+    if (!name) {
       continue;
     }
     let blocked = false;

--- a/src/utils/signal-lifetime.ts
+++ b/src/utils/signal-lifetime.ts
@@ -535,7 +535,10 @@ function typeNamePathOf(
  * An entry matches when it is a suffix of the type's namespace path, so
  * `Session.ISessionConnection` and a bare `ISessionConnection` both match
  * `Session.ISessionConnection` while `Session.ISessionConnection` does not
- * match some unrelated top-level `ISessionConnection`.
+ * match some unrelated top-level `ISessionConnection`. When several entries
+ * match, the longest wins: a list carrying both `IContext` and
+ * `DocumentRegistry.IContext` reports the qualified one regardless of the order
+ * they were configured in.
  */
 function matchLongLivedType(
   node: TSESTree.Node,
@@ -545,17 +548,20 @@ function matchLongLivedType(
   if (path.length === 0) {
     return null;
   }
+  let best: string | null = null;
+  let bestLength = 0;
   for (const entry of context.longLivedTypes) {
     const wanted = entry.split('.').filter(Boolean);
-    if (wanted.length === 0 || wanted.length > path.length) {
+    if (wanted.length <= bestLength || wanted.length > path.length) {
       continue;
     }
     const offset = path.length - wanted.length;
     if (wanted.every((segment, i) => segment === path[offset + i])) {
-      return entry;
+      best = entry;
+      bestLength = wanted.length;
     }
   }
-  return null;
+  return best;
 }
 
 function isWidgetTyped(node: TSESTree.Node, context: LifetimeContext): boolean {

--- a/tests/jupyter-prefer-signal-this-arg.test.ts
+++ b/tests/jupyter-prefer-signal-this-arg.test.ts
@@ -55,6 +55,16 @@ const PRELUDE = `
           readonly ready: ISignal<IEditor, void>;
           dispose(): void;
         }
+        namespace Session {
+          export interface ISessionConnection {
+            readonly kernelChanged: ISignal<ISessionConnection, void>;
+            readonly statusChanged: ISignal<ISessionConnection, string>;
+          }
+        }
+        interface ISessionContext {
+          readonly statusChanged: ISignal<ISessionContext, string>;
+          readonly session: Session.ISessionConnection | null;
+        }
         declare const Signal: {
           clearData(obj: unknown): void;
         };
@@ -456,6 +466,37 @@ ruleTester.run('prefer-signal-this-arg', preferSignalThisArg, {
           private _onChanged(): void {
             console.log('changed');
           }
+        }
+      `,
+      errors: [{ messageId: 'preferThisArg', suggestions: 1 }]
+    },
+    {
+      // A kernel session context outlives the widgets built on the document it
+      // belongs to.
+      filename: 'tests/type-aware-fixture.ts',
+      code: `${PRELUDE}
+        class Indicator {
+          wire(context: ISessionContext): void {
+            context.statusChanged.connect(() => this._onStatus());
+          }
+          dispose(): void {
+            Signal.clearData(this);
+          }
+          private _onStatus(): void {}
+        }
+      `,
+      errors: [{ messageId: 'preferThisArg', suggestions: 1 }]
+    },
+    {
+      // Same for the kernel connection itself, matched by the qualified
+      // `Session.ISessionConnection` entry in the default list.
+      filename: 'tests/type-aware-fixture.ts',
+      code: `${PRELUDE}
+        class Handler extends Widget {
+          wire(connection: Session.ISessionConnection): void {
+            connection.kernelChanged.connect(() => this._onKernel());
+          }
+          private _onKernel(): void {}
         }
       `,
       errors: [{ messageId: 'preferThisArg', suggestions: 1 }]

--- a/tests/jupyter-prefer-signal-this-arg.test.ts
+++ b/tests/jupyter-prefer-signal-this-arg.test.ts
@@ -488,8 +488,8 @@ ruleTester.run('prefer-signal-this-arg', preferSignalThisArg, {
       errors: [{ messageId: 'preferThisArg', suggestions: 1 }]
     },
     {
-      // Same for the kernel connection itself, matched by the qualified
-      // `Session.ISessionConnection` entry in the default list.
+      // Same for the kernel connection itself, matched by the bare
+      // `ISessionConnection` entry in the default list (which matches any namespace).
       filename: 'tests/type-aware-fixture.ts',
       code: `${PRELUDE}
         class Handler extends Widget {

--- a/tests/jupyter-require-signal-cleanup.test.ts
+++ b/tests/jupyter-require-signal-cleanup.test.ts
@@ -54,6 +54,21 @@ const PRELUDE = `
         interface INotebookModel {
           readonly contentChanged: ISignal<INotebookModel, void>;
         }
+        namespace Session {
+          export interface ISessionConnection {
+            readonly kernelChanged: ISignal<ISessionConnection, void>;
+            readonly statusChanged: ISignal<ISessionConnection, string>;
+          }
+        }
+        interface ISessionContext {
+          readonly statusChanged: ISignal<ISessionContext, string>;
+          readonly session: Session.ISessionConnection | null;
+        }
+        declare class SessionContext implements ISessionContext {
+          readonly statusChanged: ISignal<ISessionContext, string>;
+          readonly session: Session.ISessionConnection | null;
+          dispose(): void;
+        }
         declare const Signal: {
           clearData(obj: unknown): void;
         };
@@ -353,6 +368,43 @@ ruleTester.run('require-signal-cleanup', requireSignalCleanup, {
       options: [{ longLivedTypes: ['ServiceManager'] }]
     },
     {
+      // A namespace-qualified entry does not match an unrelated top-level type
+      // that happens to share only the last segment.
+      filename: 'tests/type-aware-fixture.ts',
+      code: `${PRELUDE}
+        interface IOtherConnection {
+          readonly statusChanged: ISignal<IOtherConnection, string>;
+        }
+        class Handler implements IDisposable {
+          constructor(connection: IOtherConnection) {
+            connection.statusChanged.connect(this._onStatus, this);
+          }
+          readonly isDisposed = false;
+          dispose(): void {}
+          private _onStatus(): void {}
+        }
+      `,
+      options: [{ longLivedTypes: ['Session.IOtherConnection'] }]
+    },
+    {
+      // A session context the class constructs and disposes itself dies with
+      // the receiver, allowlisted type or not.
+      filename: 'tests/type-aware-fixture.ts',
+      code: `${PRELUDE}
+        class Runner implements IDisposable {
+          constructor() {
+            this._sessionContext.statusChanged.connect(this._onStatus, this);
+          }
+          readonly isDisposed = false;
+          dispose(): void {
+            this._sessionContext.dispose();
+          }
+          private _onStatus(): void {}
+          private _sessionContext = new SessionContext();
+        }
+      `
+    },
+    {
       // Cleanup reached through a namespace import of `@lumino/signaling`.
       filename: 'tests/type-aware-fixture.ts',
       code: `${PRELUDE}
@@ -440,6 +492,74 @@ ruleTester.run('require-signal-cleanup', requireSignalCleanup, {
         }
       `,
       errors: [{ messageId: 'serviceOutlivesReceiver' }]
+    },
+    {
+      // A kernel session context is owned by the document, not by the objects
+      // built on it: it stays alive for as long as the document is open.
+      filename: 'tests/type-aware-fixture.ts',
+      code: `${PRELUDE}
+        class Indicator implements IDisposable {
+          constructor(context: ISessionContext) {
+            context.statusChanged.connect(this._onStatus, this);
+          }
+          readonly isDisposed = false;
+          dispose(): void {}
+          private _onStatus(): void {}
+        }
+      `,
+      errors: [
+        {
+          messageId: 'serviceOutlivesReceiver',
+          data: { sender: 'context', typeName: 'ISessionContext' }
+        }
+      ]
+    },
+    {
+      // The kernel connection itself. The default list names it bare, which
+      // matches whatever namespace it is declared in.
+      filename: 'tests/type-aware-fixture.ts',
+      code: `${PRELUDE}
+        class Handler implements IDisposable {
+          constructor(connection: Session.ISessionConnection) {
+            connection.kernelChanged.connect(this._onKernel, this);
+          }
+          readonly isDisposed = false;
+          dispose(): void {}
+          private _onKernel(): void {}
+        }
+      `,
+      errors: [
+        {
+          messageId: 'serviceOutlivesReceiver',
+          data: { sender: 'connection', typeName: 'ISessionConnection' }
+        }
+      ]
+    },
+    {
+      // A qualified entry also matches a hop partway along the sender chain:
+      // here only the session connection is allowlisted, not the context it
+      // hangs off.
+      filename: 'tests/type-aware-fixture.ts',
+      code: `${PRELUDE}
+        class Handler implements IDisposable {
+          constructor(context: ISessionContext) {
+            context.session!.kernelChanged.connect(this._onKernel, this);
+          }
+          readonly isDisposed = false;
+          dispose(): void {}
+          private _onKernel(): void {}
+        }
+      `,
+      options: [{ longLivedTypes: ['Session.ISessionConnection'] }],
+      errors: [
+        {
+          messageId: 'serviceOutlivesReceiver',
+          data: {
+            sender: 'context.session',
+            typeName: 'Session.ISessionConnection'
+          }
+        }
+      ]
     },
     {
       // A custom longLivedTypes entry is honoured.

--- a/website/docs/rules/prefer-signal-this-arg.md
+++ b/website/docs/rules/prefer-signal-this-arg.md
@@ -32,6 +32,7 @@ The rule reports a one-argument `signal.connect(callback)` call only when **all*
 5. There is no matching one-argument `.disconnect(callback)` anywhere in the file — Lumino matches connections by the exact `(signal, slot, thisArg)` triple, so adding `, this` would silently break a teardown that currently works.
 6. **The fix is viable**: the class already relies on receiver-based cleanup, shown either by a `Signal.clearData(this)` / `Signal.disconnectReceiver(this)` / `Signal.disconnectAll(this)` / `Signal.disconnectBetween(sender, this)` call or a two-argument `.disconnect(callback, this)` in the class body, or by the class extending a Lumino `Widget` (whose `dispose()` calls `Signal.clearData(this)`). Without one, adding a `thisArg` would change disconnect matching and buy nothing.
 7. **The sender is proven long-lived**, by one of two arguments:
+
    - **an application-lifetime service** — the sender's type resolves to an entry in the allowlist (see [Options](#options)), with no Lumino `Widget` hop between that entry and the signal (`shell.currentWidget.title.changed` is a widget reached _through_ a service, not a long-lived sender);
    - **a model behind a view** — the receiver extends a Lumino `Widget` and some segment of the sender path is model-like by name (`model`, `sharedModel`, `context`) or by type (a name ending in `Model` or `Context`). JupyterLab routinely recycles views over a stable model: notebook windowing, "New View for Notebook", output-area reuse.
 
@@ -155,7 +156,7 @@ The rule is tuned for precision over recall — it reports only what it can prov
 
 - `longLivedTypes` (`string[]`): type names treated as application-lifetime services. **Replaces** the built-in list when provided. The default is:
 
-  `CommandRegistry`, `IDebugger`, `IDocumentManager`, `ILSPConnection`, `ILabShell`, `ILanguageServerManager`, `IRenderMimeRegistry`, `ISettingRegistry`, `IShell`, `IStateDB`, `IThemeManager`, `ServiceManager`
+  `CommandRegistry`, `IDebugger`, `IDocumentManager`, `ILSPConnection`, `ILabShell`, `ILanguageServerManager`, `IRenderMimeRegistry`, `ISessionConnection`, `ISessionContext`, `ISettingRegistry`, `IShell`, `IStateDB`, `IThemeManager`, `ServiceManager`
 
 ```json
 {

--- a/website/docs/rules/require-signal-cleanup.md
+++ b/website/docs/rules/require-signal-cleanup.md
@@ -142,7 +142,7 @@ The rule deliberately trades recall for precision — it is designed to report o
 
 - `longLivedTypes` (`string[]`): type names treated as application-lifetime services. **Replaces** the built-in list when provided. The default is:
 
-  `CommandRegistry`, `IDebugger`, `IDocumentManager`, `ILSPConnection`, `ILabShell`, `ILanguageServerManager`, `IRenderMimeRegistry`, `ISettingRegistry`, `IShell`, `IStateDB`, `IThemeManager`, `ServiceManager`
+  `CommandRegistry`, `IDebugger`, `IDocumentManager`, `ILSPConnection`, `ILabShell`, `ILanguageServerManager`, `IRenderMimeRegistry`, `ISessionConnection`, `ISessionContext`, `ISettingRegistry`, `IShell`, `IStateDB`, `IThemeManager`, `ServiceManager`
 
 - `additionalCleanupMethods` (`string[]`, default `[]`): additional method names (besides `disconnect`) that count as cleanup evidence when called anywhere in the class. Use this to whitelist project-specific teardown idioms.
 


### PR DESCRIPTION
## Fixes #99 

### Description

Add `ISessionContext` and `ISessionConnection` to the default `longLivedTypes`.

Also make allowlist matching namespace-aware. Entries were compared against the bare symbol name, so a qualified entry like `Session.ISessionConnection` could never match. Entries are now matched as a suffix of the type's declared namespace path: `DocumentRegistry.IContext` matches only that `IContext`, while a bare name still matches any namespace.
