### PR TITLE
Align with JupyterLab config for `galata-prefer-filebrowser-helper` rule

### DIFF
--- a/eslint.downstream.config.mjs
+++ b/eslint.downstream.config.mjs
@@ -140,7 +140,7 @@ function makeTestConfig(projectName) {
         playwright: playwrightStub
       },
       rules: {
-        'jupyter/galata-prefer-filebrowser-helper': 'error'
+        'jupyter/galata-prefer-filebrowser-helper': 'warn'
       },
       languageOptions: {
         parser: resolvedParser,


### PR DESCRIPTION
Fixes CI - we did not enable this rule at error level for now.