### PR TITLE
Add type autofix for schema `oneOf` choices

### DIFF
--- a/src/rules/no-schema-enum.ts
+++ b/src/rules/no-schema-enum.ts
@@ -10,14 +10,91 @@ type JSONKey =
   | { type: 'JSONLiteral'; value: unknown }
   | { type: 'JSONIdentifier'; name: string };
 
-interface JSONPropertyNode {
-  key: JSONKey;
-  value: { type: string };
+interface JSONNode {
+  type: string;
+  range: [number, number];
   loc: TSESTree.SourceLocation;
+  value?: unknown;
+}
+
+interface JSONPropertyNode {
+  type: 'JSONProperty';
+  key: JSONKey;
+  value: JSONNode;
+  parent?: JSONNode;
+  range: [number, number];
+  loc: TSESTree.SourceLocation;
+}
+
+interface JSONObjectExpressionNode extends JSONNode {
+  type: 'JSONObjectExpression';
+  properties: JSONPropertyNode[];
+}
+
+interface JSONArrayExpressionNode extends JSONNode {
+  type: 'JSONArrayExpression';
+  elements: JSONNode[];
 }
 
 function isSchemaJsonFile(filename: string): boolean {
   return /[/\\]schema[/\\][^/\\]*\.json$/.test(filename);
+}
+
+function getProperty(
+  node: JSONObjectExpressionNode,
+  name: string
+): JSONPropertyNode | undefined {
+  return node.properties.find(property => {
+    if (property.key.type === 'JSONLiteral') {
+      return property.key.value === name;
+    }
+
+    return property.key.name === name;
+  });
+}
+
+function hasOnlyStringConstChoices(node: JSONArrayExpressionNode): boolean {
+  return (
+    node.elements.length > 0 &&
+    node.elements.every(element => {
+      if (element.type !== 'JSONObjectExpression') {
+        return false;
+      }
+
+      const constProperty = getProperty(
+        element as JSONObjectExpressionNode,
+        'const'
+      );
+
+      return (
+        constProperty !== undefined &&
+        constProperty.value.type === 'JSONLiteral' &&
+        typeof constProperty.value.value === 'string'
+      );
+    })
+  );
+}
+
+function getStringTypeInsertion(
+  sourceCode: { text: string },
+  node: JSONPropertyNode
+): string {
+  const beforeNode = sourceCode.text.slice(0, node.range[0]);
+  const lastNewline = beforeNode.lastIndexOf('\n');
+
+  if (lastNewline === -1) {
+    return '"type":"string",';
+  }
+
+  const indentation = beforeNode.slice(lastNewline + 1);
+
+  if (!/^[ \t]*$/.test(indentation)) {
+    return '"type":"string",';
+  }
+
+  const lineBreak = sourceCode.text.includes('\r\n') ? '\r\n' : '\n';
+
+  return `"type": "string",${lineBreak}${indentation}`;
 }
 
 const noSchemaEnum = createRule({
@@ -26,12 +103,15 @@ const noSchemaEnum = createRule({
     type: 'suggestion',
     docs: {
       description:
-        'Disallow `enum` in settings JSON schema files; use `oneOf` with `const` and `title` instead'
+        'Disallow `enum` in settings JSON schema files; use `oneOf` with `const`, `title`, and `type` instead'
     },
     messages: {
       forbidEnum:
-        'Avoid `enum` in settings schema. Use `oneOf` with `const` and `title` per entry to support user-facing labels and translations.'
+        'Avoid `enum` in settings schema. Use `oneOf` with `const` and `title` per entry to support user-facing labels and translations.',
+      requireStringType:
+        'Add `type: "string"` next to `oneOf`; React JSON Schema Form may not render string choices without it.'
     },
+    fixable: 'code',
     schema: []
   },
   defaultOptions: [],
@@ -49,6 +129,33 @@ const noSchemaEnum = createRule({
         if (keyValue === 'enum' && node.value.type === 'JSONArrayExpression') {
           context.report({ loc: node.loc, messageId: 'forbidEnum' });
         }
+
+        if (keyValue !== 'oneOf' || node.value.type !== 'JSONArrayExpression') {
+          return;
+        }
+
+        const schemaNode =
+          node.parent?.type === 'JSONObjectExpression'
+            ? (node.parent as JSONObjectExpressionNode)
+            : undefined;
+
+        if (
+          !schemaNode ||
+          getProperty(schemaNode, 'type') ||
+          !hasOnlyStringConstChoices(node.value as JSONArrayExpressionNode)
+        ) {
+          return;
+        }
+
+        context.report({
+          loc: node.loc,
+          messageId: 'requireStringType',
+          fix: fixer =>
+            fixer.insertTextBeforeRange(
+              [node.range[0], node.range[0]],
+              getStringTypeInsertion(context.sourceCode, node)
+            )
+        });
       }
     };
   }

--- a/src/rules/no-schema-enum.ts
+++ b/src/rules/no-schema-enum.ts
@@ -81,20 +81,20 @@ function getStringTypeInsertion(
 ): string {
   const beforeNode = sourceCode.text.slice(0, node.range[0]);
   const lastNewline = beforeNode.lastIndexOf('\n');
+  const lineStart = beforeNode.slice(lastNewline + 1);
 
-  if (lastNewline === -1) {
-    return '"type":"string",';
+  if (lastNewline !== -1 && /^[ \t]*$/.test(lineStart)) {
+    const lineBreak = sourceCode.text.includes('\r\n') ? '\r\n' : '\n';
+
+    return `"type": "string",${lineBreak}${lineStart}`;
   }
 
-  const indentation = beforeNode.slice(lastNewline + 1);
+  // The property shares its line with an earlier token, so the new property has
+  // to go on that line too. Repeat the spacing that already separates the
+  // properties, which keeps a Prettier-formatted single-line object formatted.
+  const spacing = /[ \t]*$/.exec(beforeNode)?.[0] ?? '';
 
-  if (!/^[ \t]*$/.test(indentation)) {
-    return '"type":"string",';
-  }
-
-  const lineBreak = sourceCode.text.includes('\r\n') ? '\r\n' : '\n';
-
-  return `"type": "string",${lineBreak}${indentation}`;
+  return spacing ? `"type": "string",${spacing}` : '"type":"string",';
 }
 
 const noSchemaEnum = createRule({

--- a/tests/jupyter-no-schema-enum.test.ts
+++ b/tests/jupyter-no-schema-enum.test.ts
@@ -20,16 +20,77 @@ const ruleTester = new RuleTester({
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ruleTester.run('no-schema-enum', noSchemaEnum as any, {
   valid: [
-    // oneOf is used instead of enum — correct pattern
+    // oneOf is used instead of enum with an explicit type — correct pattern
     {
       filename: SCHEMA_FILENAME,
       code: JSON.stringify({
         properties: {
           defaultZoom: {
+            type: 'string',
             oneOf: [
               { const: 'fit-to-width', title: 'Fit to width' },
               { const: 'fit-to-height', title: 'Fit to height' },
               { const: '100%', title: '100%' }
+            ]
+          }
+        }
+      })
+    },
+    // nullable oneOf schemas need a more specific type declaration than this
+    // rule can safely infer.
+    {
+      filename: SCHEMA_FILENAME,
+      code: JSON.stringify({
+        properties: {
+          mode: {
+            oneOf: [
+              { const: 'default', title: 'Default' },
+              { const: null, title: 'None' }
+            ]
+          }
+        }
+      })
+    },
+    // string remains valid when included in a JSON Schema type array
+    {
+      filename: SCHEMA_FILENAME,
+      code: JSON.stringify({
+        properties: {
+          mode: {
+            type: ['string', 'null'],
+            oneOf: [
+              { const: 'default', title: 'Default' },
+              { const: 'single', title: 'Single' }
+            ]
+          }
+        }
+      })
+    },
+    // Existing type declarations are left alone to avoid producing duplicate
+    // JSON keys.
+    {
+      filename: SCHEMA_FILENAME,
+      code: JSON.stringify({
+        properties: {
+          mode: {
+            type: 'number',
+            oneOf: [
+              { const: 'default', title: 'Default' },
+              { const: 'single', title: 'Single' }
+            ]
+          }
+        }
+      })
+    },
+    // oneOf without type in a non-schema directory is allowed
+    {
+      filename: NON_SCHEMA_FILENAME,
+      code: JSON.stringify({
+        properties: {
+          mode: {
+            oneOf: [
+              { const: 'default', title: 'Default' },
+              { const: 'single', title: 'Single' }
             ]
           }
         }
@@ -85,6 +146,62 @@ ruleTester.run('no-schema-enum', noSchemaEnum as any, {
         }
       }),
       errors: [{ messageId: 'forbidEnum' }, { messageId: 'forbidEnum' }]
+    },
+    // oneOf string choices without type fail to render in RJSF
+    {
+      filename: SCHEMA_FILENAME,
+      code: JSON.stringify({
+        properties: {
+          defaultZoom: {
+            oneOf: [
+              { const: 'fit-to-width', title: 'Fit to width' },
+              { const: 'fit-to-height', title: 'Fit to height' },
+              { const: '100%', title: '100%' }
+            ]
+          }
+        }
+      }),
+      output: JSON.stringify({
+        properties: {
+          defaultZoom: {
+            type: 'string',
+            oneOf: [
+              { const: 'fit-to-width', title: 'Fit to width' },
+              { const: 'fit-to-height', title: 'Fit to height' },
+              { const: '100%', title: '100%' }
+            ]
+          }
+        }
+      }),
+      errors: [{ messageId: 'requireStringType' }]
+    },
+    // The autofix preserves multiline JSON indentation
+    {
+      filename: SCHEMA_FILENAME,
+      code: `{
+  "properties": {
+    "mode": {
+      "title": "Mode",
+      "oneOf": [
+        { "const": "default", "title": "Default" },
+        { "const": "single", "title": "Single" }
+      ]
+    }
+  }
+}`,
+      output: `{
+  "properties": {
+    "mode": {
+      "title": "Mode",
+      "type": "string",
+      "oneOf": [
+        { "const": "default", "title": "Default" },
+        { "const": "single", "title": "Single" }
+      ]
+    }
+  }
+}`,
+      errors: [{ messageId: 'requireStringType' }]
     }
   ]
 });

--- a/tests/jupyter-no-schema-enum.test.ts
+++ b/tests/jupyter-no-schema-enum.test.ts
@@ -202,6 +202,29 @@ ruleTester.run('no-schema-enum', noSchemaEnum as any, {
   }
 }`,
       errors: [{ messageId: 'requireStringType' }]
+    },
+    // The autofix keeps the spacing of an object held on a single line, which is
+    // what Prettier emits when the object fits within the print width.
+    {
+      filename: SCHEMA_FILENAME,
+      code: `{
+  "properties": {
+    "mode": { "title": "M", "oneOf": [{ "const": "a" }] }
+  }
+}`,
+      output: `{
+  "properties": {
+    "mode": { "title": "M", "type": "string", "oneOf": [{ "const": "a" }] }
+  }
+}`,
+      errors: [{ messageId: 'requireStringType' }]
+    },
+    // A whole file on one line with no spacing keeps that style too
+    {
+      filename: SCHEMA_FILENAME,
+      code: '{"mode":{"title":"M","oneOf":[{"const":"a"}]}}',
+      output: '{"mode":{"title":"M","type":"string","oneOf":[{"const":"a"}]}}',
+      errors: [{ messageId: 'requireStringType' }]
     }
   ]
 });

--- a/website/docs/rules/no-schema-enum.md
+++ b/website/docs/rules/no-schema-enum.md
@@ -1,14 +1,16 @@
 # `no-schema-enum`
 
-Disallow `enum` in settings JSON schema files; use `oneOf` with `const` and `title` instead.
+Disallow `enum` in settings JSON schema files; use `oneOf` with `const`, `title`, and an explicit `type` instead.
 
 ## Why
 
 In JupyterLab/Notebook v7+, using `enum` in a settings JSON schema prevents associating user-facing labels with values and makes the options untranslatable. The `oneOf` pattern with `const` and `title` per entry solves both problems: the `title` is what the user sees, and the `const` is the value stored — and `title` can be passed through the translation system.
 
+String-valued `oneOf` choices also need `"type": "string"` on the containing schema object. Without the explicit type, React JSON Schema Form may fail to render the setting editor control.
+
 ## Rule details
 
-The rule inspects JSON files located inside a `schema/` directory and reports any property named `"enum"` whose value is an array. It does not flag `enum` used with a non-array value, and it ignores JSON files outside of `schema/` directories.
+The rule inspects JSON files located inside a `schema/` directory and reports any property named `"enum"` whose value is an array. It also reports string-valued `oneOf` choices that are missing a sibling `"type": "string"` declaration and can automatically add it. It does not flag `enum` used with a non-array value, and it ignores JSON files outside of `schema/` directories.
 
 Requires [`jsonc-eslint-parser`](https://github.com/ota-meshi/jsonc-eslint-parser) (v2) to be configured as the parser for JSON files.
 
@@ -20,6 +22,20 @@ Requires [`jsonc-eslint-parser`](https://github.com/ota-meshi/jsonc-eslint-parse
     "defaultZoom": {
       "type": "string",
       "enum": ["fit-to-width", "fit-to-height", "100%"]
+    }
+  }
+}
+```
+
+```json
+{
+  "properties": {
+    "defaultZoom": {
+      "oneOf": [
+        { "const": "fit-to-width", "title": "Fit to width" },
+        { "const": "fit-to-height", "title": "Fit to height" },
+        { "const": "100%", "title": "100%" }
+      ]
     }
   }
 }


### PR DESCRIPTION
Closes #69 


This updates `jupyter/no-schema-enum` to also detect string-valued `oneOf` settings schemas that are missing an explicit `"type": "string"`, which can prevent React JSON Schema Form from rendering the setting control. The rule now reports that case and autofixes it by inserting the missing type before `oneOf`, with tests covering the regression, autofix output, and non-string/typed cases.