### PR TITLE
Add `galata-prefer-context-menu-helper` rule

### DIFF
--- a/eslint.downstream.config.mjs
+++ b/eslint.downstream.config.mjs
@@ -145,6 +145,7 @@ function makeTestConfig(projectName) {
         playwright: playwrightStub
       },
       rules: {
+        'jupyter/galata-prefer-context-menu-helper': 'warn',
         'jupyter/galata-prefer-filebrowser-helper': 'warn',
         'jupyter/galata-prefer-menu-helper': 'warn',
         'jupyter/galata-prefer-notebook-cell-helper': 'warn',

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import noPageconfigBaseUrl from './rules/no-pageconfig-base-url';
 import requireSignalCleanup from './rules/require-signal-cleanup';
 import requireSignalThisArg from './rules/require-signal-this-arg';
 import preferSignalThisArg from './rules/prefer-signal-this-arg';
+import galataPreferContextMenuHelper from './rules/galata-prefer-context-menu-helper';
 import galataPreferFilebrowserHelper from './rules/galata-prefer-filebrowser-helper';
 import galataPreferMenuHelper from './rules/galata-prefer-menu-helper';
 import galataPreferNotebookCellHelper from './rules/galata-prefer-notebook-cell-helper';
@@ -42,6 +43,7 @@ const plugin = {
     'require-signal-cleanup': requireSignalCleanup,
     'require-signal-this-arg': requireSignalThisArg,
     'prefer-signal-this-arg': preferSignalThisArg,
+    'galata-prefer-context-menu-helper': galataPreferContextMenuHelper,
     'galata-prefer-filebrowser-helper': galataPreferFilebrowserHelper,
     'galata-prefer-menu-helper': galataPreferMenuHelper,
     'galata-prefer-notebook-cell-helper': galataPreferNotebookCellHelper,
@@ -84,6 +86,7 @@ const plugin = {
         files: ['**/*.spec.ts', '**/*.spec.js', '**/*.test.ts', '**/*.test.js'],
         rules: {
           'jupyter/require-soft-assertions-before-snapshots': 'warn',
+          'jupyter/galata-prefer-context-menu-helper': 'warn',
           'jupyter/galata-prefer-filebrowser-helper': 'warn',
           'jupyter/galata-prefer-menu-helper': 'warn',
           'jupyter/galata-prefer-notebook-cell-helper': 'warn',
@@ -122,6 +125,7 @@ const plugin = {
           ],
           rules: {
             'jupyter/require-soft-assertions-before-snapshots': 'warn',
+            'jupyter/galata-prefer-context-menu-helper': 'warn',
             'jupyter/galata-prefer-filebrowser-helper': 'warn',
             'jupyter/galata-prefer-menu-helper': 'warn',
             'jupyter/galata-prefer-notebook-cell-helper': 'warn',

--- a/src/rules/galata-prefer-context-menu-helper.ts
+++ b/src/rules/galata-prefer-context-menu-helper.ts
@@ -381,8 +381,15 @@ function findOpenWithFlows(
         openWithOpen = false;
         break;
       case 'contextMenuOpen':
+        // The selection outlives the menu, so `multiSelectSeen` is not reset
+        // here. A right-click on an item that is already part of a multi-file
+        // selection keeps the whole selection, and only a plain click narrows
+        // it back to one. Which of the two a right-click is cannot be read off
+        // the selector: `Shift+ArrowDown` extends the selection to a neighbour
+        // the test never names, so the item right-clicked next may well be
+        // that neighbour. Staying with the wider selection is the answer that
+        // does not invent a report.
         contextMenu = { multiSelect: multiSelectSeen };
-        multiSelectSeen = false;
         openWithOpen = false;
         break;
       case 'menuClose':

--- a/src/rules/galata-prefer-context-menu-helper.ts
+++ b/src/rules/galata-prefer-context-menu-helper.ts
@@ -137,14 +137,24 @@ function isPageKeyboard(node: TSESTree.Node): boolean {
   );
 }
 
+/**
+ * Whether a call's receiver is Galata's menu helper, `….menu`.
+ */
+function isMenuHelperReceiver(node: TSESTree.Node): boolean {
+  return (
+    node.type === 'MemberExpression' &&
+    !node.computed &&
+    node.property.type === 'Identifier' &&
+    node.property.name === 'menu'
+  );
+}
+
 /** `page.menu.closeAll()`, which dismisses whatever menu is open. */
 function isMenuCloseAll(callee: TSESTree.MemberExpression): boolean {
   return (
     callee.property.type === 'Identifier' &&
     callee.property.name === 'closeAll' &&
-    callee.object.type === 'MemberExpression' &&
-    callee.object.property.type === 'Identifier' &&
-    callee.object.property.name === 'menu'
+    isMenuHelperReceiver(callee.object)
   );
 }
 
@@ -198,7 +208,10 @@ function classifyGesture(
     // right-click the target themselves, so they open the context menu exactly
     // as a raw right-click does. A test that uses them and then walks
     // `Open With` by hand is still the sequence this rule replaces.
-    if (callee.property.name.startsWith('openContextMenu')) {
+    if (
+      callee.property.name.startsWith('openContextMenu') &&
+      isMenuHelperReceiver(callee.object)
+    ) {
       return gesture('contextMenuOpen');
     }
     if (isMenuCloseAll(callee)) {

--- a/src/rules/galata-prefer-context-menu-helper.ts
+++ b/src/rules/galata-prefer-context-menu-helper.ts
@@ -279,7 +279,11 @@ function classifyGesture(
     if (POPUP_MENU_PATTERN.test(selectorText)) {
       return gesture('menuItemClick', label);
     }
-    if (label !== null && BARE_TEXT_QUERY_PATTERN.test(selectorText)) {
+    // A null label here means the whole name was interpolated,
+    // `` page.click(`text=${factory}`) ``. The click is still the one that
+    // activates an item, so the flow is complete and the message falls back to
+    // naming the helpers without an argument.
+    if (BARE_TEXT_QUERY_PATTERN.test(selectorText)) {
       return gesture('menuItemClick', label);
     }
     // A plain click on a listing item leaves that one file selected, so a

--- a/src/rules/galata-prefer-context-menu-helper.ts
+++ b/src/rules/galata-prefer-context-menu-helper.ts
@@ -1,0 +1,504 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import { TSESLint, TSESTree } from '@typescript-eslint/utils';
+import { createRule } from '../utils/create-rule';
+import {
+  combineStaticSelectorText,
+  enclosingTestScope,
+  extractStaticSelectorText,
+  forEachChildNode,
+  isRightClick,
+  isTestScopeBoundary,
+  matchSelectorInteraction,
+  resolveLocatorBinding
+} from '../utils/playwright-selectors';
+
+type MessageIds =
+  | 'preferNotebookOpenNoKernel'
+  | 'preferFilebrowserOpenFactory'
+  | 'preferFilebrowserOpen';
+type Options = [];
+
+// The label of the file browser context menu submenu that lists the document
+// factories a file can be opened with.
+const OPEN_WITH_LABEL_PATTERN = /^open with$/i;
+
+// The factory `notebook-extension` adds to `Open With` for a notebook opened
+// without starting a kernel.
+const NO_KERNEL_FACTORY_PATTERN = /^notebook \(no kernel\)$/i;
+
+// Markup proving a selector is scoped inside an open Lumino popup menu — the
+// submenu, once `Open With` has been opened.
+const POPUP_MENU_PATTERN =
+  /\blm-Menu\b|role\s*=\s*["']menuitem(?:checkbox)?["']|role\s*=\s*["']menu["']/;
+
+// The whole selector is a text query, `text=Markdown Preview`. Once the
+// `Open With` submenu is open a bare label click lands in it, which is how
+// every corpus site spells the factory click.
+const BARE_TEXT_QUERY_PATTERN = /^text=/;
+
+// A file browser listing item.
+const FILE_BROWSER_ITEM_PATTERN = /\bjp-DirListing-item\b/;
+
+// A label carried by a `text=` engine query, which `combineStaticSelectorText`
+// also normalizes `getByText(…)` and `getByRole(role, { name })` into.
+const TEXT_QUERY_LABEL_PATTERN = /(?:^|\s|>>\s*)text=\s*(.+)$/;
+
+// The same label written with one of Playwright's text pseudo-classes:
+// `:has-text("Editor")`, `:text("Editor")`, `:text-is("Editor")`. The quoted
+// form is tried first so that a label containing a `)` survives.
+const QUOTED_PSEUDO_LABEL_PATTERN =
+  /:(?:has-)?text(?:-is)?\(\s*["'](.+?)["']\s*\)/;
+const BARE_PSEUDO_LABEL_PATTERN =
+  /:(?:has-)?text(?:-is)?\(\s*([^"')][^)]*?)\s*\)/;
+
+// Keys that extend a file browser selection rather than moving it. A context
+// menu opened over several selected files acts on all of them, and no helper
+// opens more than one document, so the rule stays quiet there.
+//
+// Only these spellings count. `Shift+Enter` and `Control+Enter` are notebook
+// run shortcuts and select nothing, so a blanket "any modified key" test would
+// silence genuine findings.
+const SELECTION_KEY_PATTERN =
+  /^(?:Shift|Control|Meta|ControlOrMeta)\+(?:Arrow(?:Up|Down|Left|Right)|Home|End|[aA])$/;
+
+// Modifiers that turn a click into a selection change: shift extends the
+// range, control/meta toggles one item.
+const SELECTION_MODIFIERS: ReadonlySet<string> = new Set([
+  'Shift',
+  'Control',
+  'Meta',
+  'ControlOrMeta'
+]);
+
+// Interactions that only observe. A wait between the right-click and the
+// factory click does not change what is on screen, so it must not break the
+// sequence.
+const OBSERVING_METHODS: ReadonlySet<string> = new Set(['waitForSelector']);
+
+/**
+ * What a call does to the context menu flow the rule is looking for.
+ *
+ * `otherGesture` is any interaction the rule cannot place. It is tracked rather
+ * than ignored, because a gesture in the middle of the flow means the pointer
+ * left the submenu and the click after it is no longer the factory click.
+ */
+type GestureKind =
+  | 'contextMenuOpen'
+  | 'menuClose'
+  | 'multiSelect'
+  | 'singleSelect'
+  | 'openWith'
+  | 'menuItemClick'
+  | 'otherGesture';
+
+interface Gesture {
+  kind: GestureKind;
+  /** Source offset, so gestures can be put back in source order. */
+  start: number;
+  node: TSESTree.CallExpression;
+  /** The item label a `menuItemClick` targets, when it is static. */
+  label: string | null;
+}
+
+/**
+ * The item label a selector looks for, or null when it carries none.
+ *
+ * A label is required to have a word character in it, so that the leftover
+ * static text of a fully interpolated name — `` `text=${factory}` `` reduces to
+ * `text=` — does not read as a label.
+ */
+function extractItemLabel(selectorText: string): string | null {
+  const match =
+    TEXT_QUERY_LABEL_PATTERN.exec(selectorText) ??
+    QUOTED_PSEUDO_LABEL_PATTERN.exec(selectorText) ??
+    BARE_PSEUDO_LABEL_PATTERN.exec(selectorText);
+  if (!match) {
+    return null;
+  }
+  const label = match[1]
+    .trim()
+    .replace(/^["']|["']$/g, '')
+    .trim();
+  return /\w/.test(label) ? label : null;
+}
+
+function isPageKeyboard(node: TSESTree.Node): boolean {
+  return (
+    node.type === 'MemberExpression' &&
+    !node.computed &&
+    node.object.type === 'Identifier' &&
+    node.object.name === 'page' &&
+    node.property.type === 'Identifier' &&
+    node.property.name === 'keyboard'
+  );
+}
+
+/** `page.menu.closeAll()`, which dismisses whatever menu is open. */
+function isMenuCloseAll(callee: TSESTree.MemberExpression): boolean {
+  return (
+    callee.property.type === 'Identifier' &&
+    callee.property.name === 'closeAll' &&
+    callee.object.type === 'MemberExpression' &&
+    callee.object.property.type === 'Identifier' &&
+    callee.object.property.name === 'menu'
+  );
+}
+
+/** `page.click(sel, { modifiers: ['Shift'] })` and friends. */
+function hasSelectionModifier(node: TSESTree.CallExpression): boolean {
+  return node.arguments.some(
+    arg =>
+      arg.type === 'ObjectExpression' &&
+      arg.properties.some(
+        prop =>
+          prop.type === 'Property' &&
+          !prop.computed &&
+          ((prop.key.type === 'Identifier' && prop.key.name === 'modifiers') ||
+            (prop.key.type === 'Literal' && prop.key.value === 'modifiers')) &&
+          prop.value.type === 'ArrayExpression' &&
+          prop.value.elements.some(
+            element =>
+              element?.type === 'Literal' &&
+              typeof element.value === 'string' &&
+              SELECTION_MODIFIERS.has(element.value)
+          )
+      )
+  );
+}
+
+/**
+ * Reads one call as a step of the context menu flow, or null when the call
+ * changes nothing the rule tracks.
+ */
+function classifyGesture(
+  node: TSESTree.CallExpression,
+  resolveBinding: (identifier: TSESTree.Identifier) => TSESTree.Node | null
+): Gesture | null {
+  const gesture = (
+    kind: GestureKind,
+    label: string | null = null
+  ): Gesture => ({
+    kind,
+    start: node.range[0],
+    node,
+    label
+  });
+
+  const callee = node.callee;
+  if (
+    callee.type === 'MemberExpression' &&
+    !callee.computed &&
+    callee.property.type === 'Identifier'
+  ) {
+    // `page.menu.openContextMenu(selector)` / `openContextMenuLocator(selector)`
+    // right-click the target themselves, so they open the context menu exactly
+    // as a raw right-click does. A test that uses them and then walks
+    // `Open With` by hand is still the sequence this rule replaces.
+    if (callee.property.name.startsWith('openContextMenu')) {
+      return gesture('contextMenuOpen');
+    }
+    if (isMenuCloseAll(callee)) {
+      return gesture('menuClose');
+    }
+    if (callee.property.name === 'press' && isPageKeyboard(callee.object)) {
+      const keyArg = node.arguments[0];
+      const key =
+        keyArg && keyArg.type !== 'SpreadElement'
+          ? extractStaticSelectorText(keyArg, { allowPartialTemplate: false })
+          : null;
+      if (key === 'Escape') {
+        return gesture('menuClose');
+      }
+      if (key !== null && SELECTION_KEY_PATTERN.test(key)) {
+        return gesture('multiSelect');
+      }
+      return gesture('otherGesture');
+    }
+    // A right-click is the one gesture that opens the context menu, whatever it
+    // targets, so the receiver does not have to resolve to `page` first:
+    // `const item = page.locator(a); await item.click({ button: 'right' });`
+    // opens it just as `page.click(a, { button: 'right' })` does.
+    if (callee.property.name === 'click') {
+      if (isRightClick(node)) {
+        return gesture('contextMenuOpen');
+      }
+      if (hasSelectionModifier(node)) {
+        return gesture('multiSelect');
+      }
+    }
+  }
+
+  const match = matchSelectorInteraction(node, resolveBinding);
+  if (!match) {
+    return null;
+  }
+  if (OBSERVING_METHODS.has(match.interactionMethod)) {
+    return null;
+  }
+
+  const selectorText = combineStaticSelectorText(match);
+  if (selectorText === null) {
+    // An interaction on a selector the rule cannot read still happened, and it
+    // may have dismissed the menu, so it counts as a gesture.
+    return gesture('otherGesture');
+  }
+  const label = extractItemLabel(selectorText);
+
+  // The submenu opens on hover and on click alike: Lumino opens a submenu when
+  // the pointer rests on its parent item, and clicking the item opens it too.
+  // Both spellings appear in the corpus.
+  if (
+    label !== null &&
+    OPEN_WITH_LABEL_PATTERN.test(label) &&
+    (match.interactionMethod === 'hover' || match.interactionMethod === 'click')
+  ) {
+    return gesture('openWith');
+  }
+
+  // A menu item is activated with a single click. A hover on a factory item is
+  // deliberately not one: it opens nothing, and the tests that hover a factory
+  // are screenshotting the submenu, which no helper can do.
+  if (match.interactionMethod === 'click') {
+    if (POPUP_MENU_PATTERN.test(selectorText)) {
+      return gesture('menuItemClick', label);
+    }
+    if (label !== null && BARE_TEXT_QUERY_PATTERN.test(selectorText)) {
+      return gesture('menuItemClick', label);
+    }
+    // A plain click on a listing item leaves that one file selected, so a
+    // right-click after it acts on a single document again even if an earlier
+    // statement had extended the selection.
+    if (FILE_BROWSER_ITEM_PATTERN.test(selectorText)) {
+      return gesture('singleSelect');
+    }
+  }
+
+  return gesture('otherGesture');
+}
+
+/**
+ * Every gesture inside `scope`, in source order.
+ *
+ * Nested test callbacks and named helpers are not entered: their statements do
+ * not run where they are written, so one test's menu state must not reach the
+ * next. Gestures inside an `if` or a loop *are*
+ * collected, because the flow the rule looks for is a fixed three-step sequence
+ * that no corpus site splits across branches.
+ */
+function collectGestures(
+  scope: TSESTree.Node,
+  resolveBinding: (identifier: TSESTree.Identifier) => TSESTree.Node | null
+): Gesture[] {
+  const gestures: Gesture[] = [];
+  const visit = (node: TSESTree.Node): void => {
+    if (node !== scope && isTestScopeBoundary(node)) {
+      return;
+    }
+    if (node.type === 'CallExpression') {
+      const gesture = classifyGesture(node, resolveBinding);
+      if (gesture) {
+        gestures.push(gesture);
+      }
+    }
+    // A gesture can sit inside another call's arguments — `Promise.all([…,
+    // page.click(…)])` — so children are visited whether or not this node was
+    // itself a gesture.
+    forEachChildNode(node, visit);
+  };
+  visit(scope);
+  return gestures.sort((left, right) => left.start - right.start);
+}
+
+/**
+ * Whether the call is the whole of its statement, `await page.click(…);`.
+ */
+function isOwnStatement(node: TSESTree.CallExpression): boolean {
+  let current: TSESTree.Node = node;
+  let parent = current.parent;
+  while (
+    parent &&
+    (parent.type === 'AwaitExpression' ||
+      parent.type === 'TSNonNullExpression' ||
+      parent.type === 'TSAsExpression')
+  ) {
+    current = parent;
+    parent = current.parent;
+  }
+  return parent?.type === 'ExpressionStatement';
+}
+
+interface Finding {
+  messageId: MessageIds;
+  factory: string | null;
+}
+
+/**
+ * Replays the gestures of one test and returns the factory clicks that complete
+ * a raw `Open With` sequence, keyed by the call to report.
+ *
+ * The flow is three steps: something opens the context menu, `Open With` opens
+ * the factory submenu, and a click on a factory opens the document. The factory
+ * click has to be the first item click after `Open With` — an item clicked
+ * later is in some other menu, because activating an item closes the one it was
+ * in.
+ */
+function findOpenWithFlows(
+  scope: TSESTree.Node,
+  resolveBinding: (identifier: TSESTree.Identifier) => TSESTree.Node | null
+): Map<TSESTree.CallExpression, Finding> {
+  const findings = new Map<TSESTree.CallExpression, Finding>();
+  // The open context menu, and whether more than one file was selected when it
+  // was opened.
+  let contextMenu: { multiSelect: boolean } | null = null;
+  let multiSelectSeen = false;
+  let openWithOpen = false;
+
+  for (const gesture of collectGestures(scope, resolveBinding)) {
+    switch (gesture.kind) {
+      case 'multiSelect':
+        multiSelectSeen = true;
+        break;
+      case 'singleSelect':
+        multiSelectSeen = false;
+        // Clicking in the file browser also dismisses whatever menu was open.
+        contextMenu = null;
+        openWithOpen = false;
+        break;
+      case 'contextMenuOpen':
+        contextMenu = { multiSelect: multiSelectSeen };
+        multiSelectSeen = false;
+        openWithOpen = false;
+        break;
+      case 'menuClose':
+        contextMenu = null;
+        openWithOpen = false;
+        break;
+      case 'openWith':
+        // `Open With` only exists in the file browser context menu, so with
+        // nothing having opened one the hover is on something else, or on a
+        // context menu opened outside this test — either way the rule has no
+        // sequence to replace.
+        openWithOpen = contextMenu !== null;
+        break;
+      case 'menuItemClick': {
+        if (openWithOpen && contextMenu) {
+          const finding = describeFlow(gesture, contextMenu.multiSelect);
+          if (finding) {
+            findings.set(gesture.node, finding);
+          }
+        }
+        // Activating an item closes the menu it was in.
+        contextMenu = null;
+        openWithOpen = false;
+        break;
+      }
+      case 'otherGesture':
+        // A gesture the rule cannot place may have dismissed the menu, so what
+        // is on screen is no longer known.
+        contextMenu = null;
+        openWithOpen = false;
+        break;
+    }
+  }
+
+  return findings;
+}
+
+function describeFlow(gesture: Gesture, multiSelect: boolean): Finding | null {
+  // Every helper opens exactly one document. A context menu opened over a
+  // multi-file selection opens one per file, which is what the test is there
+  // to check, so there is nothing to recommend.
+  if (multiSelect) {
+    return null;
+  }
+  if (!isOwnStatement(gesture.node)) {
+    return null;
+  }
+  const { label } = gesture;
+  if (label !== null && NO_KERNEL_FACTORY_PATTERN.test(label)) {
+    return { messageId: 'preferNotebookOpenNoKernel', factory: label };
+  }
+  return label === null
+    ? { messageId: 'preferFilebrowserOpen', factory: null }
+    : { messageId: 'preferFilebrowserOpenFactory', factory: label };
+}
+
+const galataPreferContextMenuHelper = createRule<Options, MessageIds>({
+  name: 'galata-prefer-context-menu-helper',
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Prefer the Galata filebrowser and notebook open helpers over a raw right-click `Open With` context menu sequence'
+    },
+    messages: {
+      preferNotebookOpenNoKernel:
+        'Prefer `page.notebook.open(name, { noKernel: true })` over a raw right-click, `Open With`, `Notebook (no kernel)` sequence.',
+      preferFilebrowserOpenFactory:
+        "Prefer `page.filebrowser.open(path, '{{factory}}')` over a raw right-click, `Open With`, factory sequence.",
+      preferFilebrowserOpen:
+        'Prefer `page.filebrowser.open(path, factory)` (or `page.notebook.open(name, { noKernel: true })`) over a raw right-click, `Open With`, factory sequence.'
+    },
+    schema: []
+  },
+  defaultOptions: [],
+  create(context) {
+    // One replay per test, keyed by its scope node, so a file that opens
+    // several documents this way does not re-read the same statements once per
+    // click.
+    const scopeCache = new WeakMap<
+      TSESTree.Node,
+      Map<TSESTree.CallExpression, Finding>
+    >();
+
+    const resolveBinding = (
+      identifier: TSESTree.Identifier
+    ): TSESTree.Node | null => {
+      const scope: TSESLint.Scope.Scope =
+        context.sourceCode.getScope(identifier);
+      return resolveLocatorBinding(identifier, scope);
+    };
+
+    return {
+      CallExpression(node) {
+        // The reported call is always a click on a factory item, so everything
+        // else can be skipped before any scope is walked.
+        const callee = node.callee;
+        if (
+          callee.type !== 'MemberExpression' ||
+          callee.computed ||
+          callee.property.type !== 'Identifier' ||
+          callee.property.name !== 'click'
+        ) {
+          return;
+        }
+
+        const scope = enclosingTestScope(node);
+        let findings = scopeCache.get(scope);
+        if (!findings) {
+          findings = findOpenWithFlows(scope, resolveBinding);
+          scopeCache.set(scope, findings);
+        }
+
+        const finding = findings.get(node);
+        if (!finding) {
+          return;
+        }
+
+        context.report({
+          node,
+          messageId: finding.messageId,
+          ...(finding.factory !== null
+            ? { data: { factory: finding.factory } }
+            : {})
+        });
+      }
+    };
+  }
+});
+
+export = galataPreferContextMenuHelper;

--- a/src/rules/galata-prefer-context-menu-helper.ts
+++ b/src/rules/galata-prefer-context-menu-helper.ts
@@ -4,12 +4,12 @@
  */
 
 import { TSESLint, TSESTree } from '@typescript-eslint/utils';
+import { walkFrom } from '../utils/ast';
 import { createRule } from '../utils/create-rule';
 import {
   combineStaticSelectorText,
   enclosingTestScope,
   extractStaticSelectorText,
-  forEachChildNode,
   isRightClick,
   isTestScopeBoundary,
   matchSelectorInteraction,
@@ -307,9 +307,9 @@ function collectGestures(
   resolveBinding: (identifier: TSESTree.Identifier) => TSESTree.Node | null
 ): Gesture[] {
   const gestures: Gesture[] = [];
-  const visit = (node: TSESTree.Node): void => {
+  walkFrom(scope, node => {
     if (node !== scope && isTestScopeBoundary(node)) {
-      return;
+      return 'skip-children';
     }
     if (node.type === 'CallExpression') {
       const gesture = classifyGesture(node, resolveBinding);
@@ -320,9 +320,8 @@ function collectGestures(
     // A gesture can sit inside another call's arguments — `Promise.all([…,
     // page.click(…)])` — so children are visited whether or not this node was
     // itself a gesture.
-    forEachChildNode(node, visit);
-  };
-  visit(scope);
+    return undefined;
+  });
   return gestures.sort((left, right) => left.start - right.start);
 }
 

--- a/src/rules/galata-prefer-menu-helper.ts
+++ b/src/rules/galata-prefer-menu-helper.ts
@@ -4,11 +4,11 @@
  */
 
 import { TSESLint, TSESTree } from '@typescript-eslint/utils';
+import { walkFrom } from '../utils/ast';
 import { createRule } from '../utils/create-rule';
 import {
   combineStaticSelectorText,
   enclosingTestScope,
-  forEachChildNode,
   isRightClick,
   isTestScopeBoundary,
   matchSelectorInteraction,
@@ -194,19 +194,21 @@ function menuOriginOf(node: TSESTree.CallExpression): MenuOrigin | null {
 }
 
 function collectMenuOrigins(
-  node: TSESTree.Node,
+  root: TSESTree.Node,
   found: { origin: MenuOrigin; start: number }[]
 ): void {
-  if (isTestScopeBoundary(node)) {
-    return;
-  }
-  if (node.type === 'CallExpression') {
-    const origin = menuOriginOf(node);
-    if (origin) {
-      found.push({ origin, start: node.range[0] });
+  walkFrom(root, node => {
+    if (isTestScopeBoundary(node)) {
+      return 'skip-children';
     }
-  }
-  forEachChildNode(node, child => collectMenuOrigins(child, found));
+    if (node.type === 'CallExpression') {
+      const origin = menuOriginOf(node);
+      if (origin) {
+        found.push({ origin, start: node.range[0] });
+      }
+    }
+    return undefined;
+  });
 }
 
 /**
@@ -339,10 +341,7 @@ function testMentionsMenuMarkup(node: TSESTree.Node): boolean {
     }
   }
   let found = false;
-  const visit = (current: TSESTree.Node): void => {
-    if (found) {
-      return;
-    }
+  walkFrom(scope, current => {
     if (
       (current.type === 'Literal' && typeof current.value === 'string'
         ? ANY_MENU_MARKUP_PATTERN.test(current.value)
@@ -351,11 +350,10 @@ function testMentionsMenuMarkup(node: TSESTree.Node): boolean {
         ANY_MENU_MARKUP_PATTERN.test(current.value.cooked ?? ''))
     ) {
       found = true;
-      return;
+      return 'stop';
     }
-    forEachChildNode(current, visit);
-  };
-  visit(scope);
+    return undefined;
+  });
   return found;
 }
 

--- a/src/rules/galata-prefer-menu-helper.ts
+++ b/src/rules/galata-prefer-menu-helper.ts
@@ -7,7 +7,10 @@ import { TSESLint, TSESTree } from '@typescript-eslint/utils';
 import { createRule } from '../utils/create-rule';
 import {
   combineStaticSelectorText,
+  enclosingTestScope,
+  forEachChildNode,
   isRightClick,
+  isTestScopeBoundary,
   matchSelectorInteraction,
   resolveLocatorBinding
 } from '../utils/playwright-selectors';
@@ -190,72 +193,11 @@ function menuOriginOf(node: TSESTree.CallExpression): MenuOrigin | null {
     : null;
 }
 
-function isNode(value: unknown): value is TSESTree.Node {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    typeof (value as { type?: unknown }).type === 'string'
-  );
-}
-
-// Calls whose callback is stored and run later. Statements next to such a call
-// say nothing about the state its body starts in.
-const DEFERRED_CALLBACK_CALLEES: ReadonlySet<string> = new Set([
-  'test',
-  'it',
-  'describe',
-  'suite',
-  'beforeAll',
-  'beforeEach',
-  'afterAll',
-  'afterEach'
-]);
-
-function rootCalleeName(node: TSESTree.Expression): string | null {
-  let current: TSESTree.Node = node;
-  while (current.type === 'MemberExpression') {
-    current = current.object;
-  }
-  return current.type === 'Identifier' ? current.name : null;
-}
-
-/**
- * Whether the lookback must stop before leaving `node`, and whether the scan of
- * preceding statements must stop before entering it.
- *
- * A callback written inline runs where it stands, so the statements above it
- * did run first and the walk continues through it: `perf.measure(async () => {
- * … })` keeps the menu its caller opened. A named helper and a test callback do
- * not. `async function openMenu(page) { … }` can be called from anywhere, and
- * `test('b', …)` does not run after the body of `test('a', …)`, so a
- * right-click in one test must not silence the next one.
- */
-function isLookbackBoundary(node: TSESTree.Node): boolean {
-  if (node.type === 'FunctionDeclaration') {
-    return true;
-  }
-  if (
-    node.type !== 'FunctionExpression' &&
-    node.type !== 'ArrowFunctionExpression'
-  ) {
-    return false;
-  }
-  const parent = node.parent;
-  if (parent?.type === 'VariableDeclarator' || parent?.type === 'Property') {
-    return true;
-  }
-  return (
-    parent?.type === 'CallExpression' &&
-    parent.arguments.includes(node) &&
-    DEFERRED_CALLBACK_CALLEES.has(rootCalleeName(parent.callee) ?? '')
-  );
-}
-
 function collectMenuOrigins(
   node: TSESTree.Node,
   found: { origin: MenuOrigin; start: number }[]
 ): void {
-  if (isLookbackBoundary(node)) {
+  if (isTestScopeBoundary(node)) {
     return;
   }
   if (node.type === 'CallExpression') {
@@ -264,23 +206,7 @@ function collectMenuOrigins(
       found.push({ origin, start: node.range[0] });
     }
   }
-  for (const [key, value] of Object.entries(
-    node as unknown as Record<string, unknown>
-  )) {
-    // `parent` is a back-reference; following it would not terminate.
-    if (key === 'parent') {
-      continue;
-    }
-    if (Array.isArray(value)) {
-      for (const item of value) {
-        if (isNode(item)) {
-          collectMenuOrigins(item, found);
-        }
-      }
-    } else if (isNode(value)) {
-      collectMenuOrigins(value, found);
-    }
-  }
+  forEachChildNode(node, child => collectMenuOrigins(child, found));
 }
 
 /**
@@ -339,7 +265,7 @@ function originBeforeStatement(
  * preceding statements all come after an outer block's, so the innermost block
  * with an answer holds the latest one and the walk can stop there. The walk
  * also stops at the enclosing test callback or named helper, so one test's menu
- * state never reaches the next (see `isLookbackBoundary`).
+ * state never reaches the next (see `isTestScopeBoundary`).
  */
 function findMenuOrigin(
   node: TSESTree.Node,
@@ -364,7 +290,7 @@ function findMenuOrigin(
       }
     }
 
-    if (isLookbackBoundary(parent)) {
+    if (isTestScopeBoundary(parent)) {
       return null;
     }
     current = parent;
@@ -397,10 +323,7 @@ const MENU_WORD_PATTERN = /menus?\b/i;
  * or a file name says nothing.
  */
 function testMentionsMenuMarkup(node: TSESTree.Node): boolean {
-  let scope: TSESTree.Node = node;
-  while (scope.parent && !isLookbackBoundary(scope)) {
-    scope = scope.parent;
-  }
+  const scope = enclosingTestScope(node);
   // The title of a `test(…)` sits next to its callback rather than inside it.
   // It is a sentence a person wrote about what the test does, so the bare word
   // is enough there, where in a selector it would not be.
@@ -430,22 +353,7 @@ function testMentionsMenuMarkup(node: TSESTree.Node): boolean {
       found = true;
       return;
     }
-    for (const [key, value] of Object.entries(
-      current as unknown as Record<string, unknown>
-    )) {
-      if (key === 'parent') {
-        continue;
-      }
-      if (Array.isArray(value)) {
-        for (const item of value) {
-          if (isNode(item)) {
-            visit(item);
-          }
-        }
-      } else if (isNode(value)) {
-        visit(value);
-      }
-    }
+    forEachChildNode(current, visit);
   };
   visit(scope);
   return found;

--- a/src/utils/ast.ts
+++ b/src/utils/ast.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import { TSESTree } from '@typescript-eslint/types';
+import { visitorKeys, getKeys } from '@typescript-eslint/visitor-keys';
+
+export type WalkAction = 'skip-children' | 'stop' | undefined;
+
+export function isNode(value: unknown): value is TSESTree.Node {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as { type?: unknown }).type === 'string'
+  );
+}
+
+/**
+ * Iterative AST walk from `root`, visiting every node. The visitor may return
+ * 'skip-children' to avoid descending into a node, or 'stop' to abort the
+ * whole walk.
+ *
+ * Children come from the parser's visitor keys, so `parent` is never followed
+ * and a node's `loc` and `range` are never read as children.
+ */
+export function walkFrom(
+  root: TSESTree.Node,
+  visit: (node: TSESTree.Node) => WalkAction
+): void {
+  const stack: TSESTree.Node[] = [root];
+  while (stack.length > 0) {
+    const node = stack.pop()!;
+    const action = visit(node);
+    if (action === 'stop') {
+      return;
+    }
+    if (action === 'skip-children') {
+      continue;
+    }
+    const keys = visitorKeys[node.type] ?? getKeys(node);
+    for (const key of keys) {
+      const child = (node as unknown as Record<string, unknown>)[key];
+      if (Array.isArray(child)) {
+        for (const item of child) {
+          if (isNode(item)) {
+            stack.push(item);
+          }
+        }
+      } else if (isNode(child)) {
+        stack.push(child);
+      }
+    }
+  }
+}

--- a/src/utils/playwright-selectors.ts
+++ b/src/utils/playwright-selectors.ts
@@ -396,3 +396,104 @@ export function combineStaticSelectorText(
   }
   return parts.length > 0 ? parts.join(' ') : null;
 }
+
+function isNode(value: unknown): value is TSESTree.Node {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as { type?: unknown }).type === 'string'
+  );
+}
+
+/**
+ * Calls `visit` for every child node of `node`, in no particular order.
+ *
+ * `parent` is skipped: it is a back-reference, and following it would not
+ * terminate. A caller that needs source order has to sort the result itself.
+ */
+export function forEachChildNode(
+  node: TSESTree.Node,
+  visit: (child: TSESTree.Node) => void
+): void {
+  for (const [key, value] of Object.entries(
+    node as unknown as Record<string, unknown>
+  )) {
+    if (key === 'parent') {
+      continue;
+    }
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        if (isNode(item)) {
+          visit(item);
+        }
+      }
+    } else if (isNode(value)) {
+      visit(value);
+    }
+  }
+}
+
+/**
+ * Calls whose callback is stored and run later. Statements next to such a call
+ * say nothing about the state its body starts in.
+ */
+const DEFERRED_CALLBACK_CALLEES: ReadonlySet<string> = new Set([
+  'test',
+  'it',
+  'describe',
+  'suite',
+  'beforeAll',
+  'beforeEach',
+  'afterAll',
+  'afterEach'
+]);
+
+function rootCalleeName(node: TSESTree.Expression): string | null {
+  let current: TSESTree.Node = node;
+  while (current.type === 'MemberExpression') {
+    current = current.object;
+  }
+  return current.type === 'Identifier' ? current.name : null;
+}
+
+/**
+ * Whether `node` bounds the statements a rule may read as "what ran before".
+ *
+ * A rule that reasons about UI state — which menu is open, what was selected —
+ * reads the statements preceding a gesture. That reading has to stop somewhere,
+ * and the boundary is the unit that runs as one: a test callback or a named
+ * function.
+ */
+export function isTestScopeBoundary(node: TSESTree.Node): boolean {
+  if (node.type === 'FunctionDeclaration') {
+    return true;
+  }
+  if (
+    node.type !== 'FunctionExpression' &&
+    node.type !== 'ArrowFunctionExpression'
+  ) {
+    return false;
+  }
+  const parent = node.parent;
+  if (parent?.type === 'VariableDeclarator' || parent?.type === 'Property') {
+    return true;
+  }
+  return (
+    parent?.type === 'CallExpression' &&
+    parent.arguments.includes(node) &&
+    DEFERRED_CALLBACK_CALLEES.has(rootCalleeName(parent.callee) ?? '')
+  );
+}
+
+/**
+ * The innermost test callback or named function containing `node`, which is
+ * where a lookback over preceding statements has to stop. Falls back to the
+ * `Program` for a gesture written at the top level of a file.
+ */
+export function enclosingTestScope(node: TSESTree.Node): TSESTree.Node {
+  let scope: TSESTree.Node = node;
+  while (scope.parent && !isTestScopeBoundary(scope)) {
+    scope = scope.parent;
+  }
+  return scope;
+}

--- a/src/utils/playwright-selectors.ts
+++ b/src/utils/playwright-selectors.ts
@@ -412,10 +412,32 @@ const DEFERRED_CALLBACK_CALLEES: ReadonlySet<string> = new Set([
   'afterEach'
 ]);
 
+/**
+ * The expression a callee is written on, or null once the name itself is
+ * reached. A parameterized test is called twice, `test.each(cases)('name',
+ * cb)`, and the table form tags a template first, `` test.each`a | b`('name',
+ * cb) ``. Stopping at the inner call would read no name and leave `cb` outside
+ * any test scope, so one test's state would reach the next.
+ */
+function calleeReceiver(node: TSESTree.Node): TSESTree.Node | null {
+  switch (node.type) {
+    case 'MemberExpression':
+      return node.object;
+    case 'CallExpression':
+      return node.callee;
+    case 'TaggedTemplateExpression':
+      return node.tag;
+    default:
+      return null;
+  }
+}
+
 function rootCalleeName(node: TSESTree.Expression): string | null {
   let current: TSESTree.Node = node;
-  while (current.type === 'MemberExpression') {
-    current = current.object;
+  let receiver = calleeReceiver(current);
+  while (receiver) {
+    current = receiver;
+    receiver = calleeReceiver(current);
   }
   return current.type === 'Identifier' ? current.name : null;
 }

--- a/src/utils/playwright-selectors.ts
+++ b/src/utils/playwright-selectors.ts
@@ -397,42 +397,6 @@ export function combineStaticSelectorText(
   return parts.length > 0 ? parts.join(' ') : null;
 }
 
-function isNode(value: unknown): value is TSESTree.Node {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    typeof (value as { type?: unknown }).type === 'string'
-  );
-}
-
-/**
- * Calls `visit` for every child node of `node`, in no particular order.
- *
- * `parent` is skipped: it is a back-reference, and following it would not
- * terminate. A caller that needs source order has to sort the result itself.
- */
-export function forEachChildNode(
-  node: TSESTree.Node,
-  visit: (child: TSESTree.Node) => void
-): void {
-  for (const [key, value] of Object.entries(
-    node as unknown as Record<string, unknown>
-  )) {
-    if (key === 'parent') {
-      continue;
-    }
-    if (Array.isArray(value)) {
-      for (const item of value) {
-        if (isNode(item)) {
-          visit(item);
-        }
-      }
-    } else if (isNode(value)) {
-      visit(value);
-    }
-  }
-}
-
 /**
  * Calls whose callback is stored and run later. Statements next to such a call
  * say nothing about the state its body starts in.

--- a/src/utils/signals.ts
+++ b/src/utils/signals.ts
@@ -5,8 +5,11 @@
 
 import { TSESTree } from '@typescript-eslint/types';
 import { ParserServices } from '@typescript-eslint/utils';
-import { visitorKeys, getKeys } from '@typescript-eslint/visitor-keys';
+import { walkFrom } from './ast';
 import * as ts from 'typescript';
+
+export { walkFrom } from './ast';
+export type { WalkAction } from './ast';
 
 export type ClassLike = TSESTree.ClassDeclaration | TSESTree.ClassExpression;
 
@@ -15,51 +18,6 @@ export type SignalClassification = 'signal' | 'not-signal' | 'unknown';
 type ConnectCallExpression = TSESTree.CallExpression & {
   callee: TSESTree.MemberExpression;
 };
-
-export type WalkAction = 'skip-children' | 'stop' | undefined;
-
-/**
- * Iterative AST walk from `root`, visiting every node. The visitor may return
- * 'skip-children' to avoid descending into a node, or 'stop' to abort the
- * whole walk.
- */
-export function walkFrom(
-  root: TSESTree.Node,
-  visit: (node: TSESTree.Node) => WalkAction
-): void {
-  const stack: TSESTree.Node[] = [root];
-  while (stack.length > 0) {
-    const node = stack.pop()!;
-    const action = visit(node);
-    if (action === 'stop') {
-      return;
-    }
-    if (action === 'skip-children') {
-      continue;
-    }
-    const keys = visitorKeys[node.type] ?? getKeys(node);
-    for (const key of keys) {
-      const child = (node as unknown as Record<string, unknown>)[key];
-      if (Array.isArray(child)) {
-        for (const item of child) {
-          if (isNode(item)) {
-            stack.push(item);
-          }
-        }
-      } else if (isNode(child)) {
-        stack.push(child);
-      }
-    }
-  }
-}
-
-function isNode(value: unknown): value is TSESTree.Node {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    typeof (value as { type?: unknown }).type === 'string'
-  );
-}
 
 /**
  * Checks if a call expression is a non-computed `<expr>.<name>(...)` call.

--- a/tests/jupyter-galata-prefer-context-menu-helper.test.ts
+++ b/tests/jupyter-galata-prefer-context-menu-helper.test.ts
@@ -182,6 +182,33 @@ ruleTester.run(
           await page.keyboard.press('Enter');
         `
       },
+      // Two parameterized tests are two scopes, the same as two plain ones
+      {
+        code: `
+          test.each(cases)('opens the menu', async ({ page }) => {
+            await page.click('.jp-DirListing-item', { button: 'right' });
+            await page.hover('text=Open With');
+          });
+          test.each(cases)('clicks elsewhere', async ({ page }) => {
+            await page.click('text=Editor');
+          });
+        `
+      },
+      // The table form of the same API
+      {
+        code: `
+          test.each\`
+            factory
+            \${'Editor'}
+          \`('opens the menu', async ({ page }) => {
+            await page.click('.jp-DirListing-item', { button: 'right' });
+            await page.hover('text=Open With');
+          });
+          test('clicks elsewhere', async ({ page }) => {
+            await page.click('text=Editor');
+          });
+        `
+      },
       // The right-click and the submenu traversal live in different test
       // scopes, so the rule cannot see one flow
       {
@@ -295,6 +322,15 @@ ruleTester.run(
           await page.click('.jp-DirListing-item', { button: 'right' });
           await page.click('text=Open With');
           await page.click(\`.lm-Menu-itemLabel >> text=\${factory}\`);
+        `,
+        errors: [{ messageId: 'preferFilebrowserOpen' }]
+      },
+      // The same label written without any markup around it
+      {
+        code: `
+          await page.click('.jp-DirListing-item', { button: 'right' });
+          await page.click('text=Open With');
+          await page.click(\`text=\${factory}\`);
         `,
         errors: [{ messageId: 'preferFilebrowserOpen' }]
       },

--- a/tests/jupyter-galata-prefer-context-menu-helper.test.ts
+++ b/tests/jupyter-galata-prefer-context-menu-helper.test.ts
@@ -126,6 +126,32 @@ ruleTester.run(
           await page.click('text=Editor');
         `
       },
+      // Dismissing the menu does not deselect, so the menu opened after it
+      // still acts on both files
+      {
+        code: `
+          await page.click('.jp-DirListing-item >> text=a.ipynb');
+          await page.keyboard.press('Shift+ArrowDown');
+          await page.click('.jp-DirListing-item >> text=b.ipynb', { button: 'right' });
+          await page.keyboard.press('Escape');
+          await page.click('.jp-DirListing-item >> text=b.ipynb', { button: 'right' });
+          await page.hover('text=Open With');
+          await page.click('text=Notebook (no kernel)');
+        `
+      },
+      // A second flow in the same test inherits the selection of the first
+      {
+        code: `
+          await page.click('.jp-DirListing-item >> text=a.ipynb');
+          await page.keyboard.press('Shift+ArrowDown');
+          await page.click('.jp-DirListing-item >> text=b.ipynb', { button: 'right' });
+          await page.hover('text=Open With');
+          await page.click('text=Notebook (no kernel)');
+          await page.click('.jp-DirListing-item >> text=b.ipynb', { button: 'right' });
+          await page.hover('text=Open With');
+          await page.click('text=Editor');
+        `
+      },
       // The factory click is raced against `waitForEvent('popup')`, so the test
       // needs the new `Page` the click returns — something the helpers, which
       // resolve to the current page, cannot hand back

--- a/tests/jupyter-galata-prefer-context-menu-helper.test.ts
+++ b/tests/jupyter-galata-prefer-context-menu-helper.test.ts
@@ -77,6 +77,25 @@ ruleTester.run(
           await page.click('text=Editor');
         `
       },
+      // A `menu.closeAll()` on any receiver dismisses the menu: `this.menu`
+      // is how `JupyterLabPage` calls the helper internally
+      {
+        code: `
+          await page.click('.jp-DirListing-item', { button: 'right' });
+          await page.hover('text=Open With');
+          await this.menu.closeAll();
+          await page.click('text=Editor');
+        `
+      },
+      // An `openContextMenu…` method that is not Galata's menu helper proves
+      // nothing about which menu, if any, is open
+      {
+        code: `
+          await helpers.openContextMenuForTab('notebook.ipynb');
+          await page.hover('text=Open With');
+          await page.click('text=Editor');
+        `
+      },
       // An unrelated click between `Open With` and the factory closes the
       // submenu, so the two are not one flow
       {

--- a/tests/jupyter-galata-prefer-context-menu-helper.test.ts
+++ b/tests/jupyter-galata-prefer-context-menu-helper.test.ts
@@ -1,0 +1,286 @@
+/*
+ * Copyright (c) Jupyter Development Team.
+ * Distributed under the terms of the Modified BSD License.
+ */
+
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import galataPreferContextMenuHelper from '../src/rules/galata-prefer-context-menu-helper';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parser: require('@typescript-eslint/parser'),
+    parserOptions: {
+      ecmaVersion: 2020,
+      sourceType: 'module'
+    }
+  }
+});
+
+ruleTester.run(
+  'galata-prefer-context-menu-helper',
+  galataPreferContextMenuHelper,
+  {
+    valid: [
+      // The helpers the rule recommends
+      {
+        code: `await page.notebook.open('notebook.ipynb', { noKernel: true });`
+      },
+      {
+        code: `await page.filebrowser.open('README.md', 'Markdown Preview');`
+      },
+      // No context menu opener precedes the flow, so there is no menu open and
+      // nothing to rewrite
+      {
+        code: `
+          await page.hover('text=Open With');
+          await page.click('text=Editor');
+        `
+      },
+      // Hovering the factory only opens its tooltip/highlight
+      {
+        code: `
+          await page.click('.jp-DirListing-item', { button: 'right' });
+          await page.hover('text=Open With');
+          await page.hover('text=Notebook (no kernel)');
+        `
+      },
+      // A context menu item that is not reached through `Open With` is a
+      // command, not a factory; `openContextMenu` is itself a right-click, so
+      // reporting here would only trade one raw gesture for another
+      {
+        code: `
+          await page.click('.jp-DirListing-item', { button: 'right' });
+          await page.click('.lm-Menu li[role="menuitem"]:has-text("Rename")');
+        `
+      },
+      {
+        code: `
+          await page.click('.jp-DirListing-item', { button: 'right' });
+          await page.click('text=Open in Terminal');
+        `
+      },
+      // The menu is dismissed before the factory click, so the click lands
+      // somewhere else entirely
+      {
+        code: `
+          await page.click('.jp-DirListing-item', { button: 'right' });
+          await page.hover('text=Open With');
+          await page.keyboard.press('Escape');
+          await page.click('text=Editor');
+        `
+      },
+      {
+        code: `
+          await page.click('.jp-DirListing-item', { button: 'right' });
+          await page.hover('text=Open With');
+          await page.menu.closeAll();
+          await page.click('text=Editor');
+        `
+      },
+      // An unrelated click between `Open With` and the factory closes the
+      // submenu, so the two are not one flow
+      {
+        code: `
+          await page.click('.jp-DirListing-item', { button: 'right' });
+          await page.hover('text=Open With');
+          await page.click('#jp-main-dock-panel .lm-TabBar-tab');
+          await page.click('text=Editor');
+        `
+      },
+      // A multi-file selection opens several documents at once, which neither
+      // `filebrowser.open` nor `notebook.open` can do
+      {
+        code: `
+          await page.click('.jp-DirListing-item >> text=a.ipynb');
+          await page.keyboard.press('Shift+ArrowDown');
+          await page.click('.jp-DirListing-item >> text=b.ipynb', { button: 'right' });
+          await page.hover('text=Open With');
+          await page.click('text=Notebook (no kernel)');
+        `
+      },
+      {
+        code: `
+          await page.click('.jp-DirListing-item >> text=a.ipynb');
+          await page.click('.jp-DirListing-item >> text=b.ipynb', { modifiers: ['Shift'] });
+          await page.click('.jp-DirListing-item >> text=b.ipynb', { button: 'right' });
+          await page.hover('text=Open With');
+          await page.click('text=Editor');
+        `
+      },
+      // The factory click is raced against `waitForEvent('popup')`, so the test
+      // needs the new `Page` the click returns — something the helpers, which
+      // resolve to the current page, cannot hand back
+      {
+        code: `
+          await page.click('.jp-DirListing-item', { button: 'right' });
+          await page.click('text=Open With');
+          const [popup] = await Promise.all([
+            page.waitForEvent('popup'),
+            page.click('text=Editor')
+          ]);
+        `
+      },
+      // Non-\`page\` receivers are out of scope
+      {
+        code: `
+          await this.page.click('.jp-DirListing-item', { button: 'right' });
+          await this.page.hover('text=Open With');
+          await this.page.click('text=Notebook (no kernel)');
+        `
+      },
+      // Keyboard traversal of the submenu is not the sequence the rule
+      // describes, and the item it lands on is unknown
+      {
+        code: `
+          await page.click('.jp-DirListing-item', { button: 'right' });
+          await page.keyboard.press('ArrowDown');
+          await page.keyboard.press('Enter');
+        `
+      },
+      // The right-click and the submenu traversal live in different test
+      // scopes, so the rule cannot see one flow
+      {
+        code: `
+          test.beforeEach(async ({ page }) => {
+            await page.click('.jp-DirListing-item', { button: 'right' });
+            await page.hover('text=Open With');
+          });
+          test('opens', async ({ page }) => {
+            await page.click('text=Editor');
+          });
+        `
+      },
+      // Fully dynamic selectors cannot be analyzed
+      {
+        code: `
+          await page.click(itemSelector, { button: 'right' });
+          await page.hover(openWith);
+          await page.click(factorySelector);
+        `
+      }
+    ],
+    invalid: [
+      {
+        code: `
+          await page.click(\`.jp-DirListing-item span:has-text("\${NOTEBOOK_NAME}")\`, { button: 'right' });
+          await page.hover('text=Open With');
+          await page.click('text=Notebook (no kernel)');
+          await page.waitForSelector('.jp-NotebookPanel');
+        `,
+        errors: [{ messageId: 'preferNotebookOpenNoKernel' }]
+      },
+      // A document factory names `filebrowser.open`'s second argument
+      {
+        code: `
+          await page.click('.jp-DirListing-item >> text=README.md', { button: 'right' });
+          await page.click('text=Open With');
+          await page.click('.lm-Menu-itemLabel:text("Markdown Preview")');
+        `,
+        errors: [
+          {
+            messageId: 'preferFilebrowserOpenFactory',
+            data: { factory: 'Markdown Preview' }
+          }
+        ]
+      },
+      // `notebook-trust.test.ts` opens a notebook in the plain text editor
+      {
+        code: `
+          await page.click('.jp-DirListing-item >> text=notebook.ipynb', { button: 'right' });
+          await page.hover('text=Open With');
+          await page.click('text=Editor');
+        `,
+        errors: [
+          {
+            messageId: 'preferFilebrowserOpenFactory',
+            data: { factory: 'Editor' }
+          }
+        ]
+      },
+      // Locator chains and the `getBy*` spellings are the same gestures
+      {
+        code: `
+          const item = page.locator('.jp-DirListing-item').first();
+          await item.click({ button: 'right' });
+          await page.getByText('Open With').hover();
+          await page.getByRole('menuitem', { name: 'Notebook (no kernel)' }).click();
+        `,
+        errors: [{ messageId: 'preferNotebookOpenNoKernel' }]
+      },
+      // `page.menu.openContextMenu` opens the same menu a right-click does, so
+      // the submenu traversal after it is still boilerplate
+      {
+        code: `
+          await page.menu.openContextMenu('.jp-DirListing-item >> text=data.csv');
+          await page.hover('text=Open With');
+          await page.click('text=CSV Viewer');
+        `,
+        errors: [
+          {
+            messageId: 'preferFilebrowserOpenFactory',
+            data: { factory: 'CSV Viewer' }
+          }
+        ]
+      },
+      // Waits interleaved through the flow are exactly the fragile boilerplate
+      // the helpers remove; they do not break the sequence
+      {
+        code: `
+          await page.click('.jp-DirListing-item', { button: 'right' });
+          await page.waitForSelector('.lm-Menu');
+          await page.hover('text=Open With');
+          await page.waitForSelector('.lm-Menu .lm-Menu');
+          await page.click('text=Editor');
+        `,
+        errors: [{ messageId: 'preferFilebrowserOpenFactory' }]
+      },
+      // An unraced click in a new-tab test is a plain factory click
+      {
+        code: `
+          await page.click('.jp-DirListing-item >> text=notebook.ipynb', { button: 'right' });
+          await page.click('text=Open With');
+          await page.click('text=Editor');
+        `,
+        errors: [{ messageId: 'preferFilebrowserOpenFactory' }]
+      },
+      // A dynamic factory label still identifies the flow, but not the
+      // argument to suggest
+      {
+        code: `
+          await page.click('.jp-DirListing-item', { button: 'right' });
+          await page.click('text=Open With');
+          await page.click(\`.lm-Menu-itemLabel >> text=\${factory}\`);
+        `,
+        errors: [{ messageId: 'preferFilebrowserOpen' }]
+      },
+      // Two flows in one test are two reports
+      {
+        code: `
+          await page.click('text=a.md', { button: 'right' });
+          await page.hover('text=Open With');
+          await page.click('text=Markdown Preview');
+          await page.click('text=b.ipynb', { button: 'right' });
+          await page.hover('text=Open With');
+          await page.click('text=Notebook (no kernel)');
+        `,
+        errors: [
+          { messageId: 'preferFilebrowserOpenFactory' },
+          { messageId: 'preferNotebookOpenNoKernel' }
+        ]
+      },
+      // A selection collapsed back to a single file before the right-click is
+      // a single-document flow again
+      {
+        code: `
+          await page.click('.jp-DirListing-item >> text=a.ipynb');
+          await page.keyboard.press('Shift+ArrowDown');
+          await page.click('.jp-DirListing-item >> text=b.ipynb');
+          await page.click('.jp-DirListing-item >> text=b.ipynb', { button: 'right' });
+          await page.hover('text=Open With');
+          await page.click('text=Notebook (no kernel)');
+        `,
+        errors: [{ messageId: 'preferNotebookOpenNoKernel' }]
+      }
+    ]
+  }
+);

--- a/website/docs/rules/galata-prefer-context-menu-helper.md
+++ b/website/docs/rules/galata-prefer-context-menu-helper.md
@@ -1,0 +1,68 @@
+# `galata-prefer-context-menu-helper`
+
+Prefer Galata's `page.filebrowser.open` / `page.notebook.open` helpers over a raw right-click, `Open With`, factory sequence.
+
+## Why
+
+Opening a document with a specific factory is a four-step gesture when it is written by hand: right-click the file in the browser, hover `Open With` to open its submenu, click the factory, then wait for the widget to appear.
+
+```ts
+await page.click(`.jp-DirListing-item span:has-text("${NOTEBOOK_NAME}")`, {
+  button: 'right'
+});
+await page.hover('text=Open With');
+await page.click('text=Notebook (no kernel)');
+await page.waitForSelector('.jp-NotebookPanel');
+```
+
+Every step is fragile. The listing item has to be found by name inside markup that changes; the submenu opens on a hover, so the click after it races the animation; the `waitForSelector` at the end is hand-written and only approximates "the document is ready".
+
+`FileBrowserHelper.open(path, factory)` and `NotebookHelper.open(name, { noKernel: true })` do the same thing in one call, and they wait for the document to be revealed rather than for a selector to exist:
+
+```ts
+await page.notebook.open(NOTEBOOK_NAME, { noKernel: true });
+await page.filebrowser.open('README.md', 'Markdown Preview');
+```
+
+## Rule details
+
+The rule reports the factory click at the end of a complete `Open With` flow inside one test:
+
+1. something opened the file browser context menu — a click with `{ button: 'right' }` (on `page` or on a locator), or `page.menu.openContextMenu` / `openContextMenuLocator`;
+2. `Open With` was hovered or clicked, opening the factory submenu;
+3. a menu item was clicked while that submenu was open.
+
+The message names the helper to use. A click on `Notebook (no kernel)` is reported as `preferNotebookOpenNoKernel`; any other factory is `preferFilebrowserOpenFactory`, which quotes the label as the second argument to `page.filebrowser.open`. When the label is interpolated and cannot be read, the generic `preferFilebrowserOpen` is reported instead.
+
+`waitForSelector` calls are ignored, so the waits a test interleaves through the flow do not break the sequence.
+
+## Incorrect
+
+```ts
+await page.click('.jp-DirListing-item >> text=notebook.ipynb', {
+  button: 'right'
+});
+await page.hover('text=Open With');
+await page.click('text=Notebook (no kernel)');
+await page.waitForSelector('.jp-NotebookPanel');
+
+await page.click('.jp-DirListing-item >> text=README.md', { button: 'right' });
+await page.click('text=Open With');
+await page.click('.lm-Menu-itemLabel:text("Markdown Preview")');
+
+await page.menu.openContextMenu('.jp-DirListing-item >> text=data.csv');
+await page.getByText('Open With').hover();
+await page.getByRole('menuitem', { name: 'CSV Viewer' }).click();
+```
+
+## Correct
+
+```ts
+await page.notebook.open('notebook.ipynb', { noKernel: true });
+await page.filebrowser.open('README.md', 'Markdown Preview');
+await page.filebrowser.open('data.csv', 'CSV Viewer');
+```
+
+## Options
+
+This rule has no options.

--- a/website/docs/rules/index.md
+++ b/website/docs/rules/index.md
@@ -5,6 +5,7 @@ This section documents all rules currently provided by `eslint-plugin-jupyter`.
 ## Available rules
 
 - [command-described-by](./command-described-by)
+- [galata-prefer-context-menu-helper](./galata-prefer-context-menu-helper)
 - [galata-prefer-filebrowser-helper](./galata-prefer-filebrowser-helper)
 - [galata-prefer-menu-helper](./galata-prefer-menu-helper)
 - [galata-prefer-notebook-cell-helper](./galata-prefer-notebook-cell-helper)
@@ -47,6 +48,7 @@ The plugin ships with a recommended configuration that enables all current rules
 | [jupyter/require-signal-cleanup](./require-signal-cleanup)                                     | `warn`   |
 | [jupyter/require-signal-this-arg](./require-signal-this-arg)                                   | `error`  |
 | [jupyter/prefer-signal-this-arg](./prefer-signal-this-arg)                                     | `warn`   |
+| [jupyter/galata-prefer-context-menu-helper](./galata-prefer-context-menu-helper)               | `warn` ¹ |
 | [jupyter/galata-prefer-filebrowser-helper](./galata-prefer-filebrowser-helper)                 | `warn` ¹ |
 | [jupyter/galata-prefer-menu-helper](./galata-prefer-menu-helper)                               | `warn` ¹ |
 | [jupyter/galata-prefer-notebook-cell-helper](./galata-prefer-notebook-cell-helper)             | `warn` ¹ |

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -20,6 +20,7 @@ const sidebars: SidebarsConfig = {
       items: [
         'rules/index',
         'rules/command-described-by',
+        'rules/galata-prefer-context-menu-helper',
         'rules/galata-prefer-filebrowser-helper',
         'rules/galata-prefer-menu-helper',
         'rules/galata-prefer-notebook-cell-helper',


### PR DESCRIPTION
## References #71 

### Description

Flags the raw right-click → `Open With` → factory sequence in Galata tests and recommends `page.filebrowser.open(path, factory)` / `page.notebook.open(name, { noKernel: true })`.

Reports the factory click that completes the three-step flow within one test scope.

Also extracts `enclosingTestScope`, `isTestScopeBoundary` and `forEachChildNode` from `galata-prefer-menu-helper` into `playwright-selectors.ts`.